### PR TITLE
feat(retrieval): add weighted retrieval and bundle assembly

### DIFF
--- a/evals/__init__.py
+++ b/evals/__init__.py
@@ -1,0 +1,1 @@
+"""Version-controlled eval assets for Cellin."""

--- a/evals/benchmarks/__init__.py
+++ b/evals/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Benchmark assets for Cellin."""

--- a/evals/benchmarks/retrieval/__init__.py
+++ b/evals/benchmarks/retrieval/__init__.py
@@ -1,0 +1,1 @@
+"""Retrieval benchmark assets for Cellin."""

--- a/evals/benchmarks/retrieval/cases.py
+++ b/evals/benchmarks/retrieval/cases.py
@@ -1,0 +1,5 @@
+"""Deterministic benchmark cases for retrieval quality."""
+
+from cellin.evals.retrieval_benchmarks import RetrievalBenchmarkCase, seeded_benchmark_cases
+
+__all__ = ["RetrievalBenchmarkCase", "seeded_benchmark_cases"]

--- a/src/cellin/evals/retrieval_benchmarks.py
+++ b/src/cellin/evals/retrieval_benchmarks.py
@@ -1,0 +1,37 @@
+"""Installed benchmark definitions for retrieval quality."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class RetrievalBenchmarkCase:
+    """A retrieval benchmark expectation over a seeded corpus."""
+
+    name: str
+    query: str
+    profile_name: str
+    expected_memory_ids: tuple[str, ...]
+    top_k: int
+
+
+def seeded_benchmark_cases() -> tuple[RetrievalBenchmarkCase, ...]:
+    """Return deterministic benchmark cases for the current retrieval MVP."""
+
+    return (
+        RetrievalBenchmarkCase(
+            name="concept-aware-atlas",
+            query="How does Atlas architecture support memory graphs?",
+            profile_name="concept_sensitive",
+            expected_memory_ids=("atlas-arch", "atlas-vision"),
+            top_k=2,
+        ),
+        RetrievalBenchmarkCase(
+            name="recent-deployment",
+            query="What happened yesterday with the deployment?",
+            profile_name="recency_sensitive",
+            expected_memory_ids=("deploy-yesterday",),
+            top_k=1,
+        ),
+    )

--- a/src/cellin/ranking/__init__.py
+++ b/src/cellin/ranking/__init__.py
@@ -1,0 +1,6 @@
+"""Ranking primitives for Cellin retrieval."""
+
+from cellin.ranking.profiles import WeightProfile, get_weight_profile
+from cellin.ranking.weighted import WeightedRanker
+
+__all__ = ["WeightProfile", "WeightedRanker", "get_weight_profile"]

--- a/src/cellin/ranking/profiles.py
+++ b/src/cellin/ranking/profiles.py
@@ -1,0 +1,67 @@
+"""Built-in weighting profiles for deterministic retrieval."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class WeightProfile:
+    """A named set of factor weights for retrieval ranking."""
+
+    name: str
+    semantic_similarity: float
+    graph_proximity: float
+    recency: float
+    salience: float
+    trust: float
+    reinforcement: float
+    modality_match: float
+    token_budget: int = 120
+    candidate_limit: int = 8
+    recency_half_life_days: float = 14.0
+
+
+PROFILES: dict[str, WeightProfile] = {
+    "balanced": WeightProfile(
+        name="balanced",
+        semantic_similarity=0.28,
+        graph_proximity=0.18,
+        recency=0.12,
+        salience=0.18,
+        trust=0.08,
+        reinforcement=0.08,
+        modality_match=0.08,
+    ),
+    "recency_sensitive": WeightProfile(
+        name="recency_sensitive",
+        semantic_similarity=0.22,
+        graph_proximity=0.10,
+        recency=0.30,
+        salience=0.14,
+        trust=0.08,
+        reinforcement=0.08,
+        modality_match=0.08,
+        recency_half_life_days=5.0,
+    ),
+    "concept_sensitive": WeightProfile(
+        name="concept_sensitive",
+        semantic_similarity=0.30,
+        graph_proximity=0.24,
+        recency=0.06,
+        salience=0.16,
+        trust=0.08,
+        reinforcement=0.08,
+        modality_match=0.08,
+        recency_half_life_days=21.0,
+    ),
+}
+
+
+def get_weight_profile(name: str) -> WeightProfile:
+    """Return a built-in profile by name."""
+
+    try:
+        return PROFILES[name]
+    except KeyError as exc:
+        raise ValueError(f"Unknown retrieval weight profile: {name}") from exc

--- a/src/cellin/ranking/weighted.py
+++ b/src/cellin/ranking/weighted.py
@@ -1,0 +1,121 @@
+"""Deterministic weighted ranking for Cellin retrieval."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from math import log1p
+
+from cellin.core import FactorScore, MemoryAtom, Modality, ScoredMemory
+from cellin.ranking.profiles import WeightProfile
+
+TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _tokenize(text: str) -> set[str]:
+    return set(TOKEN_RE.findall(text.lower()))
+
+
+def _semantic_similarity(query: str, memory: MemoryAtom) -> float:
+    query_tokens = _tokenize(query)
+    memory_tokens = _tokenize(memory.text)
+    if not query_tokens or not memory_tokens:
+        return 0.0
+
+    overlap = query_tokens & memory_tokens
+    union = query_tokens | memory_tokens
+    jaccard = len(overlap) / len(union)
+    substring_bonus = 0.15 if query.lower() in memory.text.lower() else 0.0
+    return min(1.0, jaccard + substring_bonus)
+
+
+def _graph_proximity(memory: MemoryAtom) -> float:
+    raw_distance = memory.metadata.get("graph_distance")
+    if not isinstance(raw_distance, int | float):
+        return 0.0
+    return 1.0 / (1.0 + float(raw_distance))
+
+
+def _recency(memory: MemoryAtom, *, now: datetime, half_life_days: float) -> float:
+    observed_at = memory.observed_at or memory.created_at
+    age_days = max((now - observed_at).total_seconds() / 86400.0, 0.0)
+    return 1.0 / (1.0 + (age_days / half_life_days))
+
+
+def _reinforcement(memory: MemoryAtom) -> float:
+    return min(log1p(memory.retrieval.access_count) / log1p(10), 1.0)
+
+
+def _modality_match(memory: MemoryAtom) -> float:
+    if memory.modality in {Modality.TEXT, Modality.CHAT, Modality.MARKDOWN, Modality.JSON}:
+        return 1.0
+    return 0.4
+
+
+@dataclass(slots=True)
+class WeightedRanker:
+    """Explainable weighted ranking over memory atoms."""
+
+    profile: WeightProfile
+    now_provider: Callable[[], datetime] = lambda: datetime.now(UTC)
+
+    def score(self, query: str, memories: Sequence[MemoryAtom]) -> tuple[ScoredMemory, ...]:
+        now = self.now_provider()
+        scored: list[ScoredMemory] = []
+
+        for memory in memories:
+            factors = (
+                FactorScore(
+                    name="semantic_similarity",
+                    value=_semantic_similarity(query, memory),
+                    rationale="Token overlap and exact-substring matching.",
+                ),
+                FactorScore(
+                    name="graph_proximity",
+                    value=_graph_proximity(memory),
+                    rationale="Candidate expansion distance from lexical seed memories.",
+                ),
+                FactorScore(
+                    name="recency",
+                    value=_recency(
+                        memory,
+                        now=now,
+                        half_life_days=self.profile.recency_half_life_days,
+                    ),
+                    rationale="Age-decayed freshness score.",
+                ),
+                FactorScore(
+                    name="salience",
+                    value=memory.salience_score,
+                    rationale="Importance carried on the memory object.",
+                ),
+                FactorScore(
+                    name="trust",
+                    value=memory.trust_score,
+                    rationale="Reliability score carried on the memory object.",
+                ),
+                FactorScore(
+                    name="reinforcement",
+                    value=_reinforcement(memory),
+                    rationale="Log-scaled retrieval reinforcement count.",
+                ),
+                FactorScore(
+                    name="modality_match",
+                    value=_modality_match(memory),
+                    rationale="Prefer text-like modalities for text queries.",
+                ),
+            )
+            total = (
+                self.profile.semantic_similarity * factors[0].value
+                + self.profile.graph_proximity * factors[1].value
+                + self.profile.recency * factors[2].value
+                + self.profile.salience * factors[3].value
+                + self.profile.trust * factors[4].value
+                + self.profile.reinforcement * factors[5].value
+                + self.profile.modality_match * factors[6].value
+            )
+            scored.append(ScoredMemory(memory=memory, score=round(total, 6), factors=factors))
+
+        return tuple(sorted(scored, key=lambda item: item.score, reverse=True))

--- a/src/cellin/retrieval/__init__.py
+++ b/src/cellin/retrieval/__init__.py
@@ -1,0 +1,6 @@
+"""Retrieval services for Cellin."""
+
+from cellin.retrieval.candidate_generation import RetrievalCandidateGenerator
+from cellin.retrieval.service import WeightedRetriever
+
+__all__ = ["RetrievalCandidateGenerator", "WeightedRetriever"]

--- a/src/cellin/retrieval/candidate_generation.py
+++ b/src/cellin/retrieval/candidate_generation.py
@@ -1,0 +1,95 @@
+"""Candidate generation for deterministic memory retrieval."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, replace
+
+from cellin.core import GraphStore, MemoryAtom, MemoryStore
+
+TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _tokenize(text: str) -> set[str]:
+    return set(TOKEN_RE.findall(text.lower()))
+
+
+def _lexical_seed_score(query: str, memory: MemoryAtom) -> float:
+    query_tokens = _tokenize(query)
+    memory_tokens = _tokenize(memory.text)
+    if not query_tokens or not memory_tokens:
+        return 0.0
+
+    overlap = query_tokens & memory_tokens
+    if not overlap:
+        return 0.0
+
+    return len(overlap) / len(query_tokens)
+
+
+def _annotate_distance(memory: MemoryAtom, distance: int) -> MemoryAtom:
+    return replace(
+        memory,
+        metadata={**memory.metadata, "graph_distance": distance},
+    )
+
+
+@dataclass(slots=True)
+class RetrievalCandidateGenerator:
+    """Generates retrieval candidates from lexical seeds plus graph expansion."""
+
+    memory_store: MemoryStore
+    graph_store: GraphStore | None = None
+    lexical_limit: int = 4
+
+    def collect(self, query: str, *, limit: int) -> tuple[MemoryAtom, ...]:
+        memories = tuple(self.memory_store.list())
+        if not memories:
+            return ()
+
+        ranked_by_seed = sorted(
+            memories,
+            key=lambda memory: _lexical_seed_score(query, memory),
+            reverse=True,
+        )
+        seed_candidates = [
+            _annotate_distance(memory, 0)
+            for memory in ranked_by_seed[: self.lexical_limit]
+            if _lexical_seed_score(query, memory) > 0.0
+        ]
+        if not seed_candidates:
+            seed_candidates = [
+                _annotate_distance(memory, 0)
+                for memory in ranked_by_seed[: min(limit, self.lexical_limit)]
+            ]
+
+        candidates: dict[str, MemoryAtom] = {memory.memory_id: memory for memory in seed_candidates}
+
+        if self.graph_store is not None:
+            for seed in seed_candidates:
+                for edge in self.graph_store.neighbors(seed.memory_id):
+                    neighbor_id = (
+                        edge.target_id if edge.source_id == seed.memory_id else edge.source_id
+                    )
+                    if neighbor_id in candidates:
+                        continue
+
+                    neighbor = self.graph_store.get_memory(neighbor_id) or self.memory_store.get(
+                        neighbor_id
+                    )
+                    if neighbor is None:
+                        continue
+
+                    candidates[neighbor_id] = _annotate_distance(neighbor, 1)
+                    if len(candidates) >= limit:
+                        break
+
+        ordered_ids = [
+            memory.memory_id for memory in ranked_by_seed if memory.memory_id in candidates
+        ]
+        ordered = tuple(candidates[memory_id] for memory_id in ordered_ids[:limit])
+        if len(ordered) >= limit:
+            return ordered
+
+        missing = [memory for memory in ranked_by_seed if memory.memory_id not in candidates]
+        return ordered + tuple(missing[: max(0, limit - len(ordered))])

--- a/src/cellin/retrieval/service.py
+++ b/src/cellin/retrieval/service.py
@@ -1,0 +1,63 @@
+"""Retrieval service that assembles explainable memory bundles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from cellin.core import MemoryBundle, ScoredMemory
+from cellin.ranking.profiles import WeightProfile
+from cellin.ranking.weighted import WeightedRanker
+from cellin.retrieval.candidate_generation import RetrievalCandidateGenerator
+
+
+def _estimate_token_cost(item: ScoredMemory) -> int:
+    metadata_cost = item.memory.metadata.get("token_count")
+    if isinstance(metadata_cost, int):
+        return metadata_cost
+    return max(1, len(item.memory.text.split()))
+
+
+@dataclass(slots=True)
+class WeightedRetriever:
+    """Retrieves explainable memory bundles from candidate memory atoms."""
+
+    candidate_generator: RetrievalCandidateGenerator
+    ranker: WeightedRanker
+    profile: WeightProfile
+
+    def retrieve(self, query: str, top_k: int = 5) -> MemoryBundle:
+        candidates = self.candidate_generator.collect(
+            query,
+            limit=max(top_k, self.profile.candidate_limit),
+        )
+        ranked = self.ranker.score(query, candidates)
+        selected = self._fit_to_budget(ranked[:top_k], token_budget=self.profile.token_budget)
+        total_score = round(sum(item.score for item in selected), 6)
+        summary = ", ".join(item.memory.memory_id for item in selected) if selected else None
+        return MemoryBundle(
+            query=query,
+            memories=selected,
+            total_score=total_score,
+            summary=summary,
+            token_budget=self.profile.token_budget,
+        )
+
+    def _fit_to_budget(
+        self,
+        ranked: tuple[ScoredMemory, ...],
+        *,
+        token_budget: int,
+    ) -> tuple[ScoredMemory, ...]:
+        selected: list[ScoredMemory] = []
+        consumed = 0
+
+        for item in ranked:
+            cost = _estimate_token_cost(item)
+            if selected and consumed + cost > token_budget:
+                continue
+            selected.append(item)
+            consumed += cost
+            if consumed >= token_budget:
+                break
+
+        return tuple(selected)

--- a/tests/integration/retrieval/test_weighted_retriever.py
+++ b/tests/integration/retrieval/test_weighted_retriever.py
@@ -1,0 +1,208 @@
+"""Integration tests for retrieval, ranking, and bundle assembly."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+
+from cellin.core import (
+    DecayState,
+    EdgeKind,
+    GraphStore,
+    MemoryAtom,
+    MemoryEdge,
+    MemoryKind,
+    MemoryStore,
+    Modality,
+    Provenance,
+    RetrievalStats,
+)
+from cellin.evals.retrieval_benchmarks import seeded_benchmark_cases
+from cellin.ranking import WeightedRanker, get_weight_profile
+from cellin.retrieval import RetrievalCandidateGenerator, WeightedRetriever
+
+
+class InMemoryMemoryStore(MemoryStore):
+    def __init__(self, memories: tuple[MemoryAtom, ...]) -> None:
+        self._memories = {memory.memory_id: memory for memory in memories}
+
+    def put(self, memory: MemoryAtom) -> None:
+        self._memories[memory.memory_id] = memory
+
+    def get(self, memory_id: str) -> MemoryAtom | None:
+        return self._memories.get(memory_id)
+
+    def list(self) -> tuple[MemoryAtom, ...]:
+        return tuple(self._memories.values())
+
+
+class InMemoryGraphStore(GraphStore):
+    def __init__(
+        self,
+        memories: tuple[MemoryAtom, ...],
+        edges: tuple[MemoryEdge, ...],
+    ) -> None:
+        self._memories = {memory.memory_id: memory for memory in memories}
+        self._edges = list(edges)
+
+    def upsert_memory(self, memory: MemoryAtom) -> None:
+        self._memories[memory.memory_id] = memory
+
+    def upsert_edge(self, edge: MemoryEdge) -> None:
+        self._edges.append(edge)
+
+    def get_memory(self, memory_id: str) -> MemoryAtom | None:
+        return self._memories.get(memory_id)
+
+    def neighbors(self, memory_id: str) -> tuple[MemoryEdge, ...]:
+        return tuple(
+            edge
+            for edge in self._edges
+            if edge.source_id == memory_id or edge.target_id == memory_id
+        )
+
+
+def _memory(
+    memory_id: str,
+    text: str,
+    *,
+    observed_at: datetime,
+    salience: float,
+    trust: float,
+    access_count: int = 0,
+    token_count: int | None = None,
+) -> MemoryAtom:
+    metadata = {}
+    if token_count is not None:
+        metadata["token_count"] = token_count
+
+    provenance = Provenance(source_id=memory_id, source_type="fixture")
+    return MemoryAtom(
+        memory_id=memory_id,
+        kind=MemoryKind.ATOM,
+        text=text,
+        provenance=provenance,
+        modality=Modality.TEXT,
+        created_at=observed_at,
+        observed_at=observed_at,
+        salience_score=salience,
+        trust_score=trust,
+        decay=DecayState(half_life_days=14.0),
+        retrieval=RetrievalStats(access_count=access_count),
+        metadata=metadata,
+    )
+
+
+def _seeded_memories() -> tuple[tuple[MemoryAtom, ...], tuple[MemoryEdge, ...]]:
+    now = datetime(2026, 4, 4, tzinfo=UTC)
+    atlas_arch = _memory(
+        "atlas-arch",
+        "Atlas architecture uses a memory graph and weighted retrieval for planning.",
+        observed_at=now - timedelta(days=7),
+        salience=0.95,
+        trust=0.9,
+        access_count=4,
+        token_count=8,
+    )
+    atlas_vision = _memory(
+        "atlas-vision",
+        "Atlas roadmap focuses on graph consolidation and memory abstractions.",
+        observed_at=now - timedelta(days=60),
+        salience=0.76,
+        trust=0.85,
+        access_count=1,
+        token_count=8,
+    )
+    deploy_yesterday = _memory(
+        "deploy-yesterday",
+        "Yesterday the staging rollout completed with green checks.",
+        observed_at=now - timedelta(days=1),
+        salience=0.7,
+        trust=0.95,
+        access_count=2,
+        token_count=7,
+    )
+    unrelated = _memory(
+        "gardening-note",
+        "Compost ratios and tomato pruning notes for the garden shed.",
+        observed_at=now - timedelta(days=2),
+        salience=0.2,
+        trust=0.7,
+        token_count=7,
+    )
+
+    edges = (
+        MemoryEdge(
+            edge_id="edge-arch-vision",
+            source_id="atlas-arch",
+            target_id="atlas-vision",
+            kind=EdgeKind.SUPPORTS,
+            provenance=Provenance(source_id="edge-arch-vision", source_type="fixture"),
+            created_at=now - timedelta(days=7),
+        ),
+    )
+    return (atlas_arch, atlas_vision, deploy_yesterday, unrelated), edges
+
+
+def test_concept_profile_uses_graph_expansion_for_related_memory() -> None:
+    memories, edges = _seeded_memories()
+    memory_store = InMemoryMemoryStore(memories)
+    graph_store = InMemoryGraphStore(memories, edges)
+    profile = get_weight_profile("concept_sensitive")
+    retriever = WeightedRetriever(
+        candidate_generator=RetrievalCandidateGenerator(memory_store, graph_store),
+        ranker=WeightedRanker(
+            profile=profile,
+            now_provider=lambda: datetime(2026, 4, 4, tzinfo=UTC),
+        ),
+        profile=profile,
+    )
+    benchmark = seeded_benchmark_cases()[0]
+
+    bundle = retriever.retrieve(benchmark.query, top_k=benchmark.top_k)
+
+    assert tuple(item.memory.memory_id for item in bundle.memories) == benchmark.expected_memory_ids
+    assert bundle.memories[1].factors[1].name == "graph_proximity"
+    assert bundle.memories[1].factors[1].value > 0.0
+
+
+def test_recency_profile_prefers_recent_memory() -> None:
+    memories, edges = _seeded_memories()
+    memory_store = InMemoryMemoryStore(memories)
+    graph_store = InMemoryGraphStore(memories, edges)
+    profile = get_weight_profile("recency_sensitive")
+    retriever = WeightedRetriever(
+        candidate_generator=RetrievalCandidateGenerator(memory_store, graph_store),
+        ranker=WeightedRanker(
+            profile=profile,
+            now_provider=lambda: datetime(2026, 4, 4, tzinfo=UTC),
+        ),
+        profile=profile,
+    )
+    benchmark = seeded_benchmark_cases()[1]
+
+    bundle = retriever.retrieve(benchmark.query, top_k=benchmark.top_k)
+
+    assert tuple(item.memory.memory_id for item in bundle.memories) == benchmark.expected_memory_ids
+    assert bundle.memories[0].factors[2].name == "recency"
+    assert bundle.memories[0].factors[2].value > 0.8
+
+
+def test_bundle_respects_token_budget() -> None:
+    memories, edges = _seeded_memories()
+    memory_store = InMemoryMemoryStore(memories)
+    graph_store = InMemoryGraphStore(memories, edges)
+    profile = replace(get_weight_profile("balanced"), token_budget=8)
+    retriever = WeightedRetriever(
+        candidate_generator=RetrievalCandidateGenerator(memory_store, graph_store),
+        ranker=WeightedRanker(
+            profile=profile,
+            now_provider=lambda: datetime(2026, 4, 4, tzinfo=UTC),
+        ),
+        profile=profile,
+    )
+
+    bundle = retriever.retrieve("Explain the Atlas architecture and roadmap", top_k=3)
+
+    assert len(bundle.memories) == 1
+    assert bundle.memories[0].memory.memory_id == "atlas-arch"


### PR DESCRIPTION
## Issue

Closes #5.

Cellin needed a retrieval path that could combine more than vector similarity. The merged core contracts were in place, but there was still no candidate generation, no weighted ranking, no explainable factor scoring, and no bundle assembly.

## Cause and impact

Without a deterministic retrieval layer, later ingestion and dreaming work would have nothing stable to optimize against and no benchmarkable memory-bundle behavior.

## Root cause

The project had not yet turned the retrieval section of the implementation plan into executable code.

## Fix

This PR adds the first deterministic retrieval stack for Cellin:

- adds built-in retrieval weight profiles for balanced, recency-sensitive, and concept-sensitive behavior
- implements an explainable weighted ranker with factor-level scores for semantic similarity, graph proximity, recency, salience, trust, reinforcement, and modality match
- implements candidate generation that combines lexical seeding with graph-neighbor expansion
- implements a `WeightedRetriever` that assembles token-budget-aware memory bundles
- adds installed retrieval benchmark definitions plus repo-level benchmark assets
- adds integration tests for concept-sensitive retrieval, recency-sensitive retrieval, explainability, graph expansion, and bundle budgeting
- fixes a real candidate-generation bug where fallback memories could accidentally receive full graph-proximity credit

## Validation

- `make ci`
- hook-backed `git push`
