### PR TITLE
feat(dreaming): add dream scheduler and reversible rewrites

### DIFF
--- a/evals/benchmarks/dreaming/__init__.py
+++ b/evals/benchmarks/dreaming/__init__.py
@@ -1,0 +1,5 @@
+"""Dream benchmark assets for Cellin."""
+
+from cellin.dreaming.benchmarks import DreamBenchmarkCase, seeded_dream_benchmark_cases
+
+__all__ = ["DreamBenchmarkCase", "seeded_dream_benchmark_cases"]

--- a/evals/benchmarks/dreaming/cases.py
+++ b/evals/benchmarks/dreaming/cases.py
@@ -1,0 +1,5 @@
+"""Deterministic dream benchmark cases."""
+
+from cellin.dreaming.benchmarks import DreamBenchmarkCase, seeded_dream_benchmark_cases
+
+__all__ = ["DreamBenchmarkCase", "seeded_dream_benchmark_cases"]

--- a/evals/fixtures/dreaming/__init__.py
+++ b/evals/fixtures/dreaming/__init__.py
@@ -1,0 +1,1 @@
+"""Deterministic dreaming fixtures."""

--- a/evals/fixtures/dreaming/atlas_corpus.json
+++ b/evals/fixtures/dreaming/atlas_corpus.json
@@ -1,0 +1,35 @@
+[
+  {
+    "memory_id": "atlas-modalities",
+    "text": "Atlas stores multimodal artifacts in long-term memory for later recall.",
+    "observed_at": "2026-03-28T00:00:00+00:00",
+    "salience_score": 0.74,
+    "trust_score": 0.93,
+    "metadata": {
+      "topic": "atlas",
+      "token_count": 10
+    }
+  },
+  {
+    "memory_id": "atlas-retrieval",
+    "text": "Weighted retrieval ranks memories using trust, salience, and graph proximity.",
+    "observed_at": "2026-03-30T00:00:00+00:00",
+    "salience_score": 0.79,
+    "trust_score": 0.92,
+    "metadata": {
+      "topic": "atlas",
+      "token_count": 10
+    }
+  },
+  {
+    "memory_id": "atlas-dreaming",
+    "text": "Dream passes consolidate graph memories so future retrieval needs fewer hops.",
+    "observed_at": "2026-04-02T00:00:00+00:00",
+    "salience_score": 0.82,
+    "trust_score": 0.9,
+    "metadata": {
+      "topic": "atlas",
+      "token_count": 11
+    }
+  }
+]

--- a/src/cellin/core/contracts.py
+++ b/src/cellin/core/contracts.py
@@ -106,6 +106,9 @@ class GraphStore(Protocol):
     def neighbors(self, memory_id: str) -> Sequence[MemoryEdge]:
         """Return adjacent graph edges."""
 
+    def list_edges(self) -> Sequence[MemoryEdge]:
+        """Return all active graph edges."""
+
 
 class MemoryStore(Protocol):
     """Persistence operations for retrievable memory atoms."""

--- a/src/cellin/dreaming/__init__.py
+++ b/src/cellin/dreaming/__init__.py
@@ -1,0 +1,30 @@
+"""Dream scheduling and consolidation for Cellin."""
+
+from cellin.dreaming.benchmarks import DreamBenchmarkCase, seeded_dream_benchmark_cases
+from cellin.dreaming.models import (
+    DreamDiff,
+    DreamEdgeChange,
+    DreamMemoryChange,
+    DreamRunResult,
+)
+from cellin.dreaming.scheduler import DeterministicDreamScheduler
+from cellin.dreaming.service import DreamRunner
+from cellin.dreaming.strategies import (
+    AbstractionDreamStrategy,
+    ContradictionRepairDreamStrategy,
+    DeduplicationDreamStrategy,
+)
+
+__all__ = [
+    "AbstractionDreamStrategy",
+    "ContradictionRepairDreamStrategy",
+    "DeduplicationDreamStrategy",
+    "DeterministicDreamScheduler",
+    "DreamBenchmarkCase",
+    "DreamDiff",
+    "DreamEdgeChange",
+    "DreamMemoryChange",
+    "DreamRunResult",
+    "DreamRunner",
+    "seeded_dream_benchmark_cases",
+]

--- a/src/cellin/dreaming/benchmarks.py
+++ b/src/cellin/dreaming/benchmarks.py
@@ -1,0 +1,26 @@
+"""Dream benchmark metadata used by tests and evals."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class DreamBenchmarkCase:
+    """A deterministic retrieval-improvement check over a dream corpus."""
+
+    benchmark_id: str
+    query: str
+    expected_top_memory_id_after: str
+    minimum_score_gain: float
+
+
+def seeded_dream_benchmark_cases() -> tuple[DreamBenchmarkCase, ...]:
+    return (
+        DreamBenchmarkCase(
+            benchmark_id="atlas-summary-improves-combined-query",
+            query="How does Atlas consolidate multimodal memory for retrieval?",
+            expected_top_memory_id_after="dream-atlas-20260404000000",
+            minimum_score_gain=0.03,
+        ),
+    )

--- a/src/cellin/dreaming/models.py
+++ b/src/cellin/dreaming/models.py
@@ -1,0 +1,110 @@
+"""Dream execution models and machine-readable diff output."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from cellin.core import DreamArtifact, MemoryAtom, MemoryEdge
+from cellin.core.models import JSONValue
+
+
+def _format_datetime(value: datetime | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def _memory_snapshot(memory: MemoryAtom | None) -> JSONValue:
+    if memory is None:
+        return None
+
+    return {
+        "memory_id": memory.memory_id,
+        "kind": memory.kind.value,
+        "text": memory.text,
+        "modality": memory.modality.value,
+        "artifact_id": memory.artifact_id,
+        "created_at": memory.created_at.isoformat(),
+        "observed_at": _format_datetime(memory.observed_at),
+        "salience_score": memory.salience_score,
+        "trust_score": memory.trust_score,
+        "archived": memory.decay.archived,
+        "access_count": memory.retrieval.access_count,
+        "metadata": memory.metadata,
+    }
+
+
+def _edge_snapshot(edge: MemoryEdge | None) -> JSONValue:
+    if edge is None:
+        return None
+
+    return {
+        "edge_id": edge.edge_id,
+        "source_id": edge.source_id,
+        "target_id": edge.target_id,
+        "kind": edge.kind.value,
+        "created_at": edge.created_at.isoformat(),
+        "weight": edge.weight,
+        "metadata": edge.metadata,
+    }
+
+
+@dataclass(slots=True)
+class DreamMemoryChange:
+    """A before/after mutation applied to a memory atom."""
+
+    memory_id: str
+    before: MemoryAtom | None
+    after: MemoryAtom | None
+
+    def to_dict(self) -> dict[str, JSONValue]:
+        return {
+            "memory_id": self.memory_id,
+            "before": _memory_snapshot(self.before),
+            "after": _memory_snapshot(self.after),
+        }
+
+
+@dataclass(slots=True)
+class DreamEdgeChange:
+    """A before/after mutation applied to a graph edge."""
+
+    edge_id: str
+    before: MemoryEdge | None
+    after: MemoryEdge | None
+
+    def to_dict(self) -> dict[str, JSONValue]:
+        return {
+            "edge_id": self.edge_id,
+            "before": _edge_snapshot(self.before),
+            "after": _edge_snapshot(self.after),
+        }
+
+
+@dataclass(slots=True)
+class DreamDiff:
+    """A reversible, machine-readable dream mutation log."""
+
+    run_id: str
+    strategy_name: str
+    created_at: datetime
+    memory_changes: tuple[DreamMemoryChange, ...] = ()
+    edge_changes: tuple[DreamEdgeChange, ...] = ()
+    notes: dict[str, JSONValue] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, JSONValue]:
+        return {
+            "run_id": self.run_id,
+            "strategy_name": self.strategy_name,
+            "created_at": self.created_at.isoformat(),
+            "memory_changes": [change.to_dict() for change in self.memory_changes],
+            "edge_changes": [change.to_dict() for change in self.edge_changes],
+            "notes": self.notes,
+        }
+
+
+@dataclass(slots=True)
+class DreamRunResult:
+    """A fully applied dream run and its reversible diff."""
+
+    artifact: DreamArtifact
+    diff: DreamDiff

--- a/src/cellin/dreaming/scheduler.py
+++ b/src/cellin/dreaming/scheduler.py
@@ -1,0 +1,72 @@
+"""Deterministic scheduling for Cellin dream runs."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+
+from cellin.core import GraphStore, MemoryStore, ScheduledDreamRun
+
+
+@dataclass(slots=True)
+class DeterministicDreamScheduler:
+    """Schedules dream strategies from memory pressure and graph signals."""
+
+    memory_store: MemoryStore
+    graph_store: GraphStore
+    cadence_hours: int = 24
+    minimum_memory_count: int = 4
+    last_run_at: dict[str, datetime] = field(default_factory=dict)
+
+    def plan(self, now: datetime) -> tuple[ScheduledDreamRun, ...]:
+        active_memories = tuple(
+            memory for memory in self.memory_store.list() if not memory.decay.archived
+        )
+        active_edges = self.graph_store.list_edges()
+        runs: list[ScheduledDreamRun] = []
+
+        if len(active_memories) >= self.minimum_memory_count and self._due("deduplication", now):
+            runs.append(
+                ScheduledDreamRun(
+                    strategy_name="deduplication",
+                    scheduled_for=now,
+                    reason=f"memory-pressure:{len(active_memories)}",
+                )
+            )
+
+        contradiction_count = sum(1 for edge in active_edges if edge.kind.value == "contradicts")
+        if contradiction_count > 0 and self._due("contradiction_repair", now):
+            runs.append(
+                ScheduledDreamRun(
+                    strategy_name="contradiction_repair",
+                    scheduled_for=now,
+                    reason=f"contradictions:{contradiction_count}",
+                )
+            )
+
+        topics = Counter(
+            str(topic)
+            for topic in (memory.metadata.get("topic") for memory in active_memories)
+            if isinstance(topic, str)
+        )
+        summarizable_topics = sum(1 for count in topics.values() if count >= 2)
+        if summarizable_topics > 0 and self._due("abstraction", now):
+            runs.append(
+                ScheduledDreamRun(
+                    strategy_name="abstraction",
+                    scheduled_for=now,
+                    reason=f"summarizable-topics:{summarizable_topics}",
+                )
+            )
+
+        return tuple(runs)
+
+    def record_run(self, strategy_name: str, when: datetime) -> None:
+        self.last_run_at[strategy_name] = when
+
+    def _due(self, strategy_name: str, now: datetime) -> bool:
+        last = self.last_run_at.get(strategy_name)
+        if last is None:
+            return True
+        return now - last >= timedelta(hours=self.cadence_hours)

--- a/src/cellin/dreaming/service.py
+++ b/src/cellin/dreaming/service.py
@@ -1,0 +1,96 @@
+"""Dream execution and rollback orchestration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import replace
+from datetime import UTC, datetime
+from typing import Protocol
+
+from cellin.core import GraphStore, MemoryStore
+from cellin.dreaming.models import DreamDiff, DreamRunResult
+from cellin.dreaming.scheduler import DeterministicDreamScheduler
+from cellin.dreaming.strategies import (
+    AbstractionDreamStrategy,
+    ContradictionRepairDreamStrategy,
+    DeduplicationDreamStrategy,
+)
+
+
+class DreamExecutable(Protocol):
+    def execute(
+        self,
+        graph_store: GraphStore,
+        memory_store: MemoryStore,
+        *,
+        at: datetime | None = None,
+    ) -> DreamRunResult | None:
+        """Execute a deterministic dream strategy."""
+
+
+class DreamRunner:
+    """Runs deterministic dream strategies and can roll them back."""
+
+    def __init__(
+        self,
+        *,
+        graph_store: GraphStore,
+        memory_store: MemoryStore,
+        scheduler: DeterministicDreamScheduler | None = None,
+        strategies: Mapping[str, DreamExecutable] | None = None,
+    ) -> None:
+        self.graph_store = graph_store
+        self.memory_store = memory_store
+        self.scheduler = scheduler or DeterministicDreamScheduler(memory_store, graph_store)
+        self.strategies = strategies or {
+            "deduplication": DeduplicationDreamStrategy(),
+            "contradiction_repair": ContradictionRepairDreamStrategy(),
+            "abstraction": AbstractionDreamStrategy(),
+        }
+
+    def run_strategy(
+        self, strategy_name: str, *, at: datetime | None = None
+    ) -> DreamRunResult | None:
+        strategy = self.strategies[strategy_name]
+        when = at or datetime.now(UTC)
+        result = strategy.execute(self.graph_store, self.memory_store, at=when)
+        if result is not None:
+            self.scheduler.record_run(strategy_name, when)
+        return result
+
+    def run_pending(self, *, now: datetime | None = None) -> tuple[DreamRunResult, ...]:
+        when = now or datetime.now(UTC)
+        results: list[DreamRunResult] = []
+        for scheduled in self.scheduler.plan(when):
+            result = self.run_strategy(scheduled.strategy_name, at=scheduled.scheduled_for)
+            if result is not None:
+                results.append(result)
+        return tuple(results)
+
+    def rollback(self, diff: DreamDiff) -> None:
+        for edge_change in reversed(diff.edge_changes):
+            if edge_change.before is None and edge_change.after is not None:
+                self.graph_store.upsert_edge(
+                    replace(
+                        edge_change.after,
+                        metadata={**edge_change.after.metadata, "archived": True},
+                    )
+                )
+                continue
+
+            if edge_change.before is not None:
+                self.graph_store.upsert_edge(edge_change.before)
+
+        for memory_change in reversed(diff.memory_changes):
+            if memory_change.before is None and memory_change.after is not None:
+                archived = replace(
+                    memory_change.after,
+                    decay=replace(memory_change.after.decay, archived=True),
+                )
+                self.memory_store.put(archived)
+                self.graph_store.upsert_memory(archived)
+                continue
+
+            if memory_change.before is not None:
+                self.memory_store.put(memory_change.before)
+                self.graph_store.upsert_memory(memory_change.before)

--- a/src/cellin/dreaming/strategies.py
+++ b/src/cellin/dreaming/strategies.py
@@ -1,0 +1,414 @@
+"""Deterministic dream strategies for Cellin's local-first MVP."""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+
+from cellin.core import (
+    DreamArtifact,
+    EdgeKind,
+    GraphStore,
+    MemoryAtom,
+    MemoryEdge,
+    MemoryKind,
+    MemoryStore,
+    Modality,
+    Provenance,
+)
+from cellin.core.models import JSONValue
+from cellin.dreaming.models import DreamDiff, DreamEdgeChange, DreamMemoryChange, DreamRunResult
+
+TOKEN_RE = re.compile(r"[a-z0-9]+")
+NEGATION_MARKERS = {
+    "cancelled",
+    "canceled",
+    "blocked",
+    "failed",
+    "rolled",
+    "rollback",
+    "removed",
+    "not",
+}
+SUCCESS_MARKERS = {"completed", "green", "released", "shipped", "stable", "active", "enabled"}
+
+
+def _tokenize(text: str) -> set[str]:
+    return set(TOKEN_RE.findall(text.lower()))
+
+
+def _similarity(left: MemoryAtom, right: MemoryAtom) -> float:
+    left_tokens = _tokenize(left.text)
+    right_tokens = _tokenize(right.text)
+    if not left_tokens or not right_tokens:
+        return 0.0
+    return len(left_tokens & right_tokens) / len(left_tokens | right_tokens)
+
+
+def _contains_conflict(left: MemoryAtom, right: MemoryAtom) -> bool:
+    left_tokens = _tokenize(left.text)
+    right_tokens = _tokenize(right.text)
+    left_negative = bool(left_tokens & NEGATION_MARKERS)
+    right_negative = bool(right_tokens & NEGATION_MARKERS)
+    left_positive = bool(left_tokens & SUCCESS_MARKERS)
+    right_positive = bool(right_tokens & SUCCESS_MARKERS)
+    if left_negative != right_negative and (left_positive or right_positive):
+        return True
+
+    left_numbers = {token for token in left_tokens if token.isdigit()}
+    right_numbers = {token for token in right_tokens if token.isdigit()}
+    return bool(left_numbers and right_numbers and left_numbers != right_numbers)
+
+
+def _active_edges(graph_store: GraphStore) -> dict[str, MemoryEdge]:
+    return {edge.edge_id: edge for edge in graph_store.list_edges()}
+
+
+def _best_memory(memories: tuple[MemoryAtom, ...]) -> MemoryAtom:
+    return max(
+        memories,
+        key=lambda memory: (
+            memory.trust_score,
+            memory.salience_score,
+            memory.retrieval.access_count,
+            memory.observed_at or memory.created_at,
+        ),
+    )
+
+
+def _summary_text(topic: str, members: tuple[MemoryAtom, ...]) -> str:
+    snippets = []
+    for memory in members:
+        cleaned = memory.text.strip().rstrip(".")
+        if cleaned and cleaned not in snippets:
+            snippets.append(cleaned)
+        if len(snippets) == 3:
+            break
+    body = "; ".join(snippets)
+    return f"{topic.title()} memory summary: {body}."
+
+
+def _string_list(value: JSONValue) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+@dataclass(slots=True)
+class DeduplicationDreamStrategy:
+    """Archives near-identical memories and links them to a canonical node."""
+
+    strategy_name: str = "deduplication"
+    similarity_threshold: float = 0.92
+
+    def execute(
+        self,
+        graph_store: GraphStore,
+        memory_store: MemoryStore,
+        *,
+        at: datetime | None = None,
+    ) -> DreamRunResult | None:
+        when = at or datetime.now(UTC)
+        topic_groups: dict[str, list[MemoryAtom]] = defaultdict(list)
+        for memory in memory_store.list():
+            if memory.decay.archived:
+                continue
+            topic = memory.metadata.get("topic")
+            if isinstance(topic, str):
+                topic_groups[topic].append(memory)
+
+        memory_changes: list[DreamMemoryChange] = []
+        edge_changes: list[DreamEdgeChange] = []
+        merged_pairs: list[tuple[str, str]] = []
+
+        for _topic, members in topic_groups.items():
+            if len(members) < 2:
+                continue
+
+            for index, left in enumerate(members[:-1]):
+                for right in members[index + 1 :]:
+                    if _contains_conflict(left, right):
+                        continue
+                    if _similarity(left, right) < self.similarity_threshold:
+                        continue
+
+                    canonical = _best_memory((left, right))
+                    duplicate = right if canonical.memory_id == left.memory_id else left
+                    if duplicate.decay.archived:
+                        continue
+
+                    merged_pairs.append((duplicate.memory_id, canonical.memory_id))
+
+                    deduplicated_ids: list[JSONValue] = [
+                        memory_id
+                        for memory_id in sorted(
+                            {
+                                *_string_list(canonical.metadata.get("deduplicated_memory_ids")),
+                                duplicate.memory_id,
+                            }
+                        )
+                    ]
+                    canonical_after = replace(
+                        canonical,
+                        salience_score=min(1.0, canonical.salience_score + 0.05),
+                        retrieval=replace(
+                            canonical.retrieval,
+                            access_count=canonical.retrieval.access_count
+                            + duplicate.retrieval.access_count,
+                        ),
+                        decay=replace(canonical.decay, last_reinforced_at=when),
+                        metadata={
+                            **canonical.metadata,
+                            "deduplicated_memory_ids": deduplicated_ids,
+                        },
+                    )
+                    duplicate_after = replace(
+                        duplicate,
+                        decay=replace(duplicate.decay, archived=True, last_reinforced_at=when),
+                        metadata={**duplicate.metadata, "canonical_memory_id": canonical.memory_id},
+                    )
+                    edge_after = MemoryEdge(
+                        edge_id=f"same-as:{duplicate.memory_id}:{canonical.memory_id}",
+                        source_id=duplicate.memory_id,
+                        target_id=canonical.memory_id,
+                        kind=EdgeKind.SAME_AS,
+                        provenance=Provenance(source_id=self.strategy_name, source_type="dream"),
+                        created_at=when,
+                        metadata={"dream_run": self.strategy_name},
+                    )
+
+                    memory_store.put(canonical_after)
+                    graph_store.upsert_memory(canonical_after)
+                    memory_store.put(duplicate_after)
+                    graph_store.upsert_memory(duplicate_after)
+                    graph_store.upsert_edge(edge_after)
+
+                    memory_changes.extend(
+                        (
+                            DreamMemoryChange(canonical.memory_id, canonical, canonical_after),
+                            DreamMemoryChange(duplicate.memory_id, duplicate, duplicate_after),
+                        )
+                    )
+                    edge_changes.append(DreamEdgeChange(edge_after.edge_id, None, edge_after))
+
+        if not merged_pairs:
+            return None
+
+        run_id = f"{self.strategy_name}:{when.isoformat()}"
+        artifact = DreamArtifact(
+            dream_id=run_id,
+            strategy_name=self.strategy_name,
+            provenance=Provenance(source_id=run_id, source_type="dream"),
+            created_at=when,
+            summary=f"Archived {len(merged_pairs)} duplicate memories.",
+            affected_memory_ids=tuple(memory_id for pair in merged_pairs for memory_id in pair),
+            metadata={"merged_pairs": [list(pair) for pair in merged_pairs]},
+        )
+        diff = DreamDiff(
+            run_id=run_id,
+            strategy_name=self.strategy_name,
+            created_at=when,
+            memory_changes=tuple(memory_changes),
+            edge_changes=tuple(edge_changes),
+            notes={"merged_pairs": [list(pair) for pair in merged_pairs]},
+        )
+        return DreamRunResult(artifact=artifact, diff=diff)
+
+
+@dataclass(slots=True)
+class ContradictionRepairDreamStrategy:
+    """Links contradictory memories and down-ranks stale claims."""
+
+    strategy_name: str = "contradiction_repair"
+
+    def execute(
+        self,
+        graph_store: GraphStore,
+        memory_store: MemoryStore,
+        *,
+        at: datetime | None = None,
+    ) -> DreamRunResult | None:
+        when = at or datetime.now(UTC)
+        topic_groups: dict[str, list[MemoryAtom]] = defaultdict(list)
+        for memory in memory_store.list():
+            if memory.decay.archived:
+                continue
+            topic = memory.metadata.get("topic")
+            if isinstance(topic, str):
+                topic_groups[topic].append(memory)
+
+        existing_edges = _active_edges(graph_store)
+        memory_changes: list[DreamMemoryChange] = []
+        edge_changes: list[DreamEdgeChange] = []
+        repaired_pairs: list[tuple[str, str]] = []
+
+        for members in topic_groups.values():
+            ordered = sorted(members, key=lambda memory: memory.observed_at or memory.created_at)
+            for older in ordered[:-1]:
+                for newer in ordered[1:]:
+                    if not _contains_conflict(older, newer):
+                        continue
+
+                    edge_id = f"contradicts:{older.memory_id}:{newer.memory_id}"
+                    if edge_id in existing_edges:
+                        continue
+
+                    older_after = replace(
+                        older,
+                        trust_score=max(0.1, round(older.trust_score - 0.25, 6)),
+                        metadata={**older.metadata, "superseded_by": newer.memory_id},
+                    )
+                    newer_after = replace(
+                        newer,
+                        salience_score=min(1.0, round(newer.salience_score + 0.1, 6)),
+                        metadata={**newer.metadata, "contradicts": older.memory_id},
+                    )
+                    edge_after = MemoryEdge(
+                        edge_id=edge_id,
+                        source_id=older.memory_id,
+                        target_id=newer.memory_id,
+                        kind=EdgeKind.CONTRADICTS,
+                        provenance=Provenance(source_id=self.strategy_name, source_type="dream"),
+                        created_at=when,
+                        metadata={"dream_run": self.strategy_name},
+                    )
+
+                    memory_store.put(older_after)
+                    graph_store.upsert_memory(older_after)
+                    memory_store.put(newer_after)
+                    graph_store.upsert_memory(newer_after)
+                    graph_store.upsert_edge(edge_after)
+                    existing_edges[edge_id] = edge_after
+
+                    repaired_pairs.append((older.memory_id, newer.memory_id))
+                    memory_changes.extend(
+                        (
+                            DreamMemoryChange(older.memory_id, older, older_after),
+                            DreamMemoryChange(newer.memory_id, newer, newer_after),
+                        )
+                    )
+                    edge_changes.append(DreamEdgeChange(edge_id, None, edge_after))
+
+        if not repaired_pairs:
+            return None
+
+        run_id = f"{self.strategy_name}:{when.isoformat()}"
+        artifact = DreamArtifact(
+            dream_id=run_id,
+            strategy_name=self.strategy_name,
+            provenance=Provenance(source_id=run_id, source_type="dream"),
+            created_at=when,
+            summary=f"Linked {len(repaired_pairs)} contradictory memory pairs.",
+            affected_memory_ids=tuple(memory_id for pair in repaired_pairs for memory_id in pair),
+            metadata={"repaired_pairs": [list(pair) for pair in repaired_pairs]},
+        )
+        diff = DreamDiff(
+            run_id=run_id,
+            strategy_name=self.strategy_name,
+            created_at=when,
+            memory_changes=tuple(memory_changes),
+            edge_changes=tuple(edge_changes),
+            notes={"repaired_pairs": [list(pair) for pair in repaired_pairs]},
+        )
+        return DreamRunResult(artifact=artifact, diff=diff)
+
+
+@dataclass(slots=True)
+class AbstractionDreamStrategy:
+    """Builds deterministic summary memories over a topic cluster."""
+
+    strategy_name: str = "abstraction"
+
+    def execute(
+        self,
+        graph_store: GraphStore,
+        memory_store: MemoryStore,
+        *,
+        at: datetime | None = None,
+    ) -> DreamRunResult | None:
+        when = at or datetime.now(UTC)
+        topic_groups: dict[str, list[MemoryAtom]] = defaultdict(list)
+        active_memories = tuple(
+            memory for memory in memory_store.list() if not memory.decay.archived
+        )
+        for memory in active_memories:
+            topic = memory.metadata.get("topic")
+            if isinstance(topic, str) and memory.kind != MemoryKind.DREAM:
+                topic_groups[topic].append(memory)
+
+        existing_summaries = {
+            memory.metadata.get("topic")
+            for memory in active_memories
+            if memory.kind == MemoryKind.DREAM and isinstance(memory.metadata.get("topic"), str)
+        }
+
+        memory_changes: list[DreamMemoryChange] = []
+        edge_changes: list[DreamEdgeChange] = []
+        created_ids: list[str] = []
+
+        for topic, members in topic_groups.items():
+            if len(members) < 2 or topic in existing_summaries:
+                continue
+
+            summary_memory = MemoryAtom(
+                memory_id=f"dream-{topic}-{when.strftime('%Y%m%d%H%M%S')}",
+                kind=MemoryKind.DREAM,
+                text=_summary_text(
+                    topic,
+                    tuple(sorted(members, key=lambda item: item.salience_score, reverse=True)),
+                ),
+                provenance=Provenance(source_id=self.strategy_name, source_type="dream"),
+                modality=Modality.TEXT,
+                created_at=when,
+                observed_at=when,
+                salience_score=min(1.0, max(memory.salience_score for memory in members) + 0.05),
+                trust_score=min(memory.trust_score for memory in members),
+                metadata={
+                    "topic": topic,
+                    "dream_strategy": self.strategy_name,
+                    "summary_for": [memory.memory_id for memory in members],
+                    "token_count": len(_summary_text(topic, tuple(members)).split()),
+                },
+            )
+            memory_store.put(summary_memory)
+            graph_store.upsert_memory(summary_memory)
+            memory_changes.append(DreamMemoryChange(summary_memory.memory_id, None, summary_memory))
+            created_ids.append(summary_memory.memory_id)
+
+            for member in members:
+                edge_after = MemoryEdge(
+                    edge_id=f"summarizes:{summary_memory.memory_id}:{member.memory_id}",
+                    source_id=summary_memory.memory_id,
+                    target_id=member.memory_id,
+                    kind=EdgeKind.SUMMARIZES,
+                    provenance=Provenance(source_id=self.strategy_name, source_type="dream"),
+                    created_at=when,
+                    metadata={"topic": topic},
+                )
+                graph_store.upsert_edge(edge_after)
+                edge_changes.append(DreamEdgeChange(edge_after.edge_id, None, edge_after))
+
+        if not created_ids:
+            return None
+
+        run_id = f"{self.strategy_name}:{when.isoformat()}"
+        artifact = DreamArtifact(
+            dream_id=run_id,
+            strategy_name=self.strategy_name,
+            provenance=Provenance(source_id=run_id, source_type="dream"),
+            created_at=when,
+            summary=f"Created {len(created_ids)} summary memories.",
+            affected_memory_ids=tuple(created_ids),
+            metadata={"created_memory_ids": [memory_id for memory_id in created_ids]},
+        )
+        diff = DreamDiff(
+            run_id=run_id,
+            strategy_name=self.strategy_name,
+            created_at=when,
+            memory_changes=tuple(memory_changes),
+            edge_changes=tuple(edge_changes),
+            notes={"created_memory_ids": [memory_id for memory_id in created_ids]},
+        )
+        return DreamRunResult(artifact=artifact, diff=diff)

--- a/src/cellin/retrieval/candidate_generation.py
+++ b/src/cellin/retrieval/candidate_generation.py
@@ -43,7 +43,7 @@ class RetrievalCandidateGenerator:
     lexical_limit: int = 4
 
     def collect(self, query: str, *, limit: int) -> tuple[MemoryAtom, ...]:
-        memories = tuple(self.memory_store.list())
+        memories = tuple(memory for memory in self.memory_store.list() if not memory.decay.archived)
         if not memories:
             return ()
 
@@ -78,6 +78,8 @@ class RetrievalCandidateGenerator:
                         neighbor_id
                     )
                     if neighbor is None:
+                        continue
+                    if neighbor.decay.archived:
                         continue
 
                     candidates[neighbor_id] = _annotate_distance(neighbor, 1)

--- a/src/cellin/stores/sqlite.py
+++ b/src/cellin/stores/sqlite.py
@@ -131,6 +131,11 @@ def _load_edge(payload: str) -> MemoryEdge:
     )
 
 
+def _edge_archived(edge: MemoryEdge) -> bool:
+    archived = edge.metadata.get("archived")
+    return bool(archived) if isinstance(archived, bool) else False
+
+
 class _SQLiteBase:
     def __init__(self, database_path: str) -> None:
         self._database_path = database_path
@@ -222,4 +227,9 @@ class SQLiteGraphStore(_SQLiteBase):
                 """,
                 (memory_id, memory_id),
             ).fetchall()
-        return tuple(_load_edge(row[0]) for row in rows)
+        return tuple(edge for row in rows if not _edge_archived(edge := _load_edge(row[0])))
+
+    def list_edges(self) -> tuple[MemoryEdge, ...]:
+        with self._connect() as connection:
+            rows = connection.execute("SELECT payload FROM edges ORDER BY edge_id").fetchall()
+        return tuple(edge for row in rows if not _edge_archived(edge := _load_edge(row[0])))

--- a/tests/integration/dreaming/test_dreaming.py
+++ b/tests/integration/dreaming/test_dreaming.py
@@ -1,0 +1,256 @@
+"""Integration tests for deterministic dream scheduling and rollback."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+from cellin.core import (
+    DecayState,
+    EdgeKind,
+    GraphStore,
+    MemoryAtom,
+    MemoryEdge,
+    MemoryKind,
+    MemoryStore,
+    Modality,
+    Provenance,
+    RetrievalStats,
+)
+from cellin.dreaming import (
+    AbstractionDreamStrategy,
+    ContradictionRepairDreamStrategy,
+    DeduplicationDreamStrategy,
+    DreamRunner,
+)
+from cellin.dreaming.benchmarks import seeded_dream_benchmark_cases
+from cellin.ranking import WeightedRanker, get_weight_profile
+from cellin.retrieval import RetrievalCandidateGenerator, WeightedRetriever
+
+
+class InMemoryMemoryStore(MemoryStore):
+    def __init__(self, memories: tuple[MemoryAtom, ...]) -> None:
+        self._memories = {memory.memory_id: memory for memory in memories}
+
+    def put(self, memory: MemoryAtom) -> None:
+        self._memories[memory.memory_id] = memory
+
+    def get(self, memory_id: str) -> MemoryAtom | None:
+        return self._memories.get(memory_id)
+
+    def list(self) -> tuple[MemoryAtom, ...]:
+        return tuple(self._memories.values())
+
+
+class InMemoryGraphStore(GraphStore):
+    def __init__(
+        self,
+        memories: tuple[MemoryAtom, ...],
+        edges: tuple[MemoryEdge, ...] = (),
+    ) -> None:
+        self._memories = {memory.memory_id: memory for memory in memories}
+        self._edges = {edge.edge_id: edge for edge in edges}
+
+    def upsert_memory(self, memory: MemoryAtom) -> None:
+        self._memories[memory.memory_id] = memory
+
+    def upsert_edge(self, edge: MemoryEdge) -> None:
+        self._edges[edge.edge_id] = edge
+
+    def get_memory(self, memory_id: str) -> MemoryAtom | None:
+        return self._memories.get(memory_id)
+
+    def neighbors(self, memory_id: str) -> tuple[MemoryEdge, ...]:
+        return tuple(
+            edge
+            for edge in self.list_edges()
+            if edge.source_id == memory_id or edge.target_id == memory_id
+        )
+
+    def list_edges(self) -> tuple[MemoryEdge, ...]:
+        return tuple(
+            edge for edge in self._edges.values() if edge.metadata.get("archived") is not True
+        )
+
+
+def _memory(
+    memory_id: str,
+    text: str,
+    *,
+    observed_at: datetime,
+    topic: str,
+    salience: float = 0.7,
+    trust: float = 0.9,
+    access_count: int = 0,
+) -> MemoryAtom:
+    return MemoryAtom(
+        memory_id=memory_id,
+        kind=MemoryKind.ATOM,
+        text=text,
+        provenance=Provenance(source_id=memory_id, source_type="fixture"),
+        modality=Modality.TEXT,
+        created_at=observed_at,
+        observed_at=observed_at,
+        salience_score=salience,
+        trust_score=trust,
+        decay=DecayState(half_life_days=14.0),
+        retrieval=RetrievalStats(access_count=access_count),
+        metadata={"topic": topic, "token_count": len(text.split())},
+    )
+
+
+def _retriever(memory_store: MemoryStore, graph_store: GraphStore) -> WeightedRetriever:
+    profile = get_weight_profile("balanced")
+    return WeightedRetriever(
+        candidate_generator=RetrievalCandidateGenerator(memory_store, graph_store),
+        ranker=WeightedRanker(
+            profile=profile,
+            now_provider=lambda: datetime(2026, 4, 4, tzinfo=UTC),
+        ),
+        profile=profile,
+    )
+
+
+def _fixture_memories() -> tuple[MemoryAtom, ...]:
+    with open("evals/fixtures/dreaming/atlas_corpus.json", encoding="utf-8") as handle:
+        raw = json.load(handle)
+
+    return tuple(
+        MemoryAtom(
+            memory_id=item["memory_id"],
+            kind=MemoryKind.ATOM,
+            text=item["text"],
+            provenance=Provenance(source_id=item["memory_id"], source_type="fixture"),
+            modality=Modality.TEXT,
+            created_at=datetime.fromisoformat(item["observed_at"]),
+            observed_at=datetime.fromisoformat(item["observed_at"]),
+            salience_score=float(item["salience_score"]),
+            trust_score=float(item["trust_score"]),
+            decay=DecayState(half_life_days=14.0),
+            retrieval=RetrievalStats(),
+            metadata=item["metadata"],
+        )
+        for item in raw
+    )
+
+
+def test_deduplication_diff_is_machine_readable_and_reversible() -> None:
+    now = datetime(2026, 4, 4, tzinfo=UTC)
+    memories = (
+        _memory(
+            "atlas-plan-a",
+            "Atlas planning uses weighted retrieval for memory search.",
+            observed_at=now - timedelta(days=2),
+            topic="atlas",
+            access_count=2,
+        ),
+        _memory(
+            "atlas-plan-b",
+            "Atlas planning uses weighted retrieval for memory search.",
+            observed_at=now - timedelta(days=1),
+            topic="atlas",
+            access_count=1,
+        ),
+    )
+    memory_store = InMemoryMemoryStore(memories)
+    graph_store = InMemoryGraphStore(memories)
+    runner = DreamRunner(
+        graph_store=graph_store,
+        memory_store=memory_store,
+        strategies={"deduplication": DeduplicationDreamStrategy()},
+    )
+
+    result = runner.run_strategy("deduplication", at=now)
+
+    assert result is not None
+    serialized = result.diff.to_dict()
+    assert serialized["memory_changes"]
+    assert serialized["edge_changes"]
+    archived_memories = [memory for memory in memory_store.list() if memory.decay.archived]
+    assert len(archived_memories) == 1
+
+    runner.rollback(result.diff)
+
+    assert all(not memory.decay.archived for memory in memory_store.list())
+    assert graph_store.list_edges() == ()
+
+
+def test_deduplication_rejects_false_merges_when_numeric_claims_conflict() -> None:
+    now = datetime(2026, 4, 4, tzinfo=UTC)
+    memories = (
+        _memory(
+            "atlas-capacity-12",
+            "Atlas cluster is active in 12 regions with stable failover.",
+            observed_at=now - timedelta(days=2),
+            topic="atlas",
+        ),
+        _memory(
+            "atlas-capacity-15",
+            "Atlas cluster is active in 15 regions with stable failover.",
+            observed_at=now - timedelta(days=1),
+            topic="atlas",
+        ),
+    )
+    memory_store = InMemoryMemoryStore(memories)
+    graph_store = InMemoryGraphStore(memories)
+    strategy = DeduplicationDreamStrategy()
+
+    result = strategy.execute(graph_store, memory_store, at=now)
+
+    assert result is None
+    assert all(not memory.decay.archived for memory in memory_store.list())
+
+
+def test_contradiction_repair_creates_edge_and_down_ranks_older_claim() -> None:
+    now = datetime(2026, 4, 4, tzinfo=UTC)
+    memories = (
+        _memory(
+            "atlas-rollout-green",
+            "Atlas rollout is green and stable in staging.",
+            observed_at=now - timedelta(days=2),
+            topic="atlas-rollout",
+            trust=0.95,
+        ),
+        _memory(
+            "atlas-rollout-rollback",
+            "Atlas rollout was rolled back after failures in staging.",
+            observed_at=now - timedelta(days=1),
+            topic="atlas-rollout",
+            trust=0.92,
+        ),
+    )
+    memory_store = InMemoryMemoryStore(memories)
+    graph_store = InMemoryGraphStore(memories)
+    strategy = ContradictionRepairDreamStrategy()
+
+    result = strategy.execute(graph_store, memory_store, at=now)
+
+    assert result is not None
+    older = memory_store.get("atlas-rollout-green")
+    newer = memory_store.get("atlas-rollout-rollback")
+    assert older is not None and newer is not None
+    assert older.trust_score < 0.95
+    assert newer.salience_score > 0.7
+    contradiction_edge = graph_store.list_edges()[0]
+    assert contradiction_edge.kind is EdgeKind.CONTRADICTS
+
+
+def test_abstraction_benchmark_improves_retrieval_for_combined_queries() -> None:
+    memories = _fixture_memories()
+    memory_store = InMemoryMemoryStore(memories)
+    graph_store = InMemoryGraphStore(memories)
+    retriever = _retriever(memory_store, graph_store)
+    benchmark = seeded_dream_benchmark_cases()[0]
+    before = retriever.retrieve(benchmark.query, top_k=1)
+    runner = DreamRunner(
+        graph_store=graph_store,
+        memory_store=memory_store,
+        strategies={"abstraction": AbstractionDreamStrategy()},
+    )
+
+    result = runner.run_strategy("abstraction", at=datetime(2026, 4, 4, tzinfo=UTC))
+    after = retriever.retrieve(benchmark.query, top_k=1)
+
+    assert result is not None
+    assert after.memories[0].memory.memory_id == benchmark.expected_top_memory_id_after
+    assert after.total_score >= before.total_score + benchmark.minimum_score_gain

--- a/tests/integration/retrieval/test_weighted_retriever.py
+++ b/tests/integration/retrieval/test_weighted_retriever.py
@@ -61,6 +61,9 @@ class InMemoryGraphStore(GraphStore):
             if edge.source_id == memory_id or edge.target_id == memory_id
         )
 
+    def list_edges(self) -> tuple[MemoryEdge, ...]:
+        return tuple(self._edges)
+
 
 def _memory(
     memory_id: str,


### PR DESCRIPTION
## Issue
Cellin did not have a controllable dream loop, so memory only accumulated and retrieval quality could not improve through consolidation.

## Cause and user impact
Without deterministic dream strategies, there was no way to deduplicate repeated memories, repair contradictions, or synthesize summary nodes while keeping a reversible audit trail. That left retrieval exposed to graph bloat and stale claims.

## Root cause
The repository had ingestion and retrieval primitives, but no dream scheduler, no reversible diff model, no strategy execution surface, and no benchmark corpus proving that a dream pass helps retrieval.

## Fix
- add a `cellin.dreaming` package with deterministic deduplication, contradiction-repair, and abstraction strategies
- add a scheduler and runner that produce machine-readable diffs and support rollback
- teach retrieval and the SQLite graph store to ignore archived memories and edges
- add a dreaming benchmark corpus plus integration tests for rollback safety, false-merge prevention, contradiction repair, and post-dream retrieval improvement

## Validation
- `make ci`
- pre-push hook: `pytest` and `pytest tests/evals -q`

Closes #6
