### PR TITLE
feat(evals): add deterministic harness and smoke gates

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -5,9 +5,13 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+  schedule:
+    - cron: "0 13 * * *"
 
 jobs:
   verify:
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest
 
     steps:
@@ -27,3 +31,38 @@ jobs:
 
       - name: Run CI target
         run: make ci
+
+      - name: Upload smoke eval report
+        if: always() && hashFiles('eval-results/smoke.json') != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-eval-report
+          path: eval-results/smoke.json
+
+  nightly-evals:
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version
+
+      - name: Install uv
+        run: python -m pip install uv
+
+      - name: Sync dependencies
+        run: python -m uv sync --dev
+
+      - name: Run full eval suite
+        run: make eval-full
+
+      - name: Upload full eval report
+        uses: actions/upload-artifact@v4
+        with:
+          name: full-eval-report
+          path: eval-results/full.json

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 UV ?= python3 -m uv
 
-.PHONY: bootstrap hooks fmt fmt-check lint typecheck test eval-smoke eval verify ci docs
+.PHONY: bootstrap hooks fmt fmt-check lint typecheck test eval-smoke eval-full eval verify ci docs
 
 bootstrap:
 	$(UV) sync --dev
@@ -25,9 +25,12 @@ test:
 	$(UV) run pytest
 
 eval-smoke:
-	$(UV) run pytest tests/evals -q
+	$(UV) run python -m cellin.evals smoke --output eval-results/smoke.json
 
-eval: eval-smoke
+eval-full:
+	$(UV) run python -m cellin.evals full --output eval-results/full.json
+
+eval: eval-full
 
 verify: fmt-check lint typecheck test eval-smoke
 

--- a/docs/evals/README.md
+++ b/docs/evals/README.md
@@ -1,11 +1,32 @@
 # Evals
 
-Cellin evals are product assets, not ad hoc experiments.
+Cellin evals are version-controlled product assets, not notebooks or one-off experiments.
 
-The initial repo surface provides a bootstrap smoke eval so every PR exercises the same
-command path. Later streams will add:
+## Suites
 
-- ingestion correctness evals
-- retrieval quality benchmarks
-- dream quality and regression checks
-- performance signals such as memory bloat and bundle efficiency
+- `make eval-smoke`
+  Runs the deterministic PR gate and writes `eval-results/smoke.json`.
+- `make eval-full`
+  Runs the broader benchmark suite and writes `eval-results/full.json`.
+
+## Seeded corpora
+
+The repository tracks deterministic corpora under `evals/corpora/` for:
+
+- conversational memory and duplicate-note pressure
+- project memory and graph-linked retrieval
+- multimodal artifact ingestion
+- contradiction repair
+- recency traps
+
+## Reporting
+
+Every report includes:
+
+- per-case metrics
+- baseline metrics
+- delta metrics for before/after comparisons
+- machine-readable notes such as dream diffs and expected ids
+
+PR CI runs the smoke suite. Scheduled and manually dispatched workflow runs execute the full
+suite and upload the resulting JSON artifact.

--- a/evals/corpora/contradiction_memory.json
+++ b/evals/corpora/contradiction_memory.json
@@ -1,0 +1,26 @@
+[
+  {
+    "memory_id": "atlas-rollout-green",
+    "text": "Atlas rollout is green and stable in staging.",
+    "observed_at": "2026-04-01T00:00:00+00:00",
+    "salience_score": 0.72,
+    "trust_score": 0.95,
+    "access_count": 1,
+    "metadata": {
+      "topic": "atlas-rollout",
+      "token_count": 8
+    }
+  },
+  {
+    "memory_id": "atlas-rollout-rollback",
+    "text": "Atlas rollout was rolled back after failures in staging.",
+    "observed_at": "2026-04-02T00:00:00+00:00",
+    "salience_score": 0.7,
+    "trust_score": 0.92,
+    "access_count": 1,
+    "metadata": {
+      "topic": "atlas-rollout",
+      "token_count": 9
+    }
+  }
+]

--- a/evals/corpora/conversation_memory.json
+++ b/evals/corpora/conversation_memory.json
@@ -1,0 +1,38 @@
+[
+  {
+    "memory_id": "chat-standup-1",
+    "text": "Standup note: Atlas planning note tracks open retrieval blockers for the memory graph.",
+    "observed_at": "2026-04-01T08:00:00+00:00",
+    "salience_score": 0.74,
+    "trust_score": 0.92,
+    "access_count": 2,
+    "metadata": {
+      "topic": "atlas-standup",
+      "token_count": 12
+    }
+  },
+  {
+    "memory_id": "chat-standup-2",
+    "text": "Standup note: Atlas planning note tracks open retrieval blockers for the memory graph.",
+    "observed_at": "2026-04-01T08:05:00+00:00",
+    "salience_score": 0.72,
+    "trust_score": 0.9,
+    "access_count": 1,
+    "metadata": {
+      "topic": "atlas-standup",
+      "token_count": 12
+    }
+  },
+  {
+    "memory_id": "chat-action",
+    "text": "Action item: tighten eval reporting so quality regressions show up in pull requests.",
+    "observed_at": "2026-04-01T08:07:00+00:00",
+    "salience_score": 0.68,
+    "trust_score": 0.94,
+    "access_count": 1,
+    "metadata": {
+      "topic": "atlas-standup",
+      "token_count": 11
+    }
+  }
+]

--- a/evals/corpora/multimodal_artifacts.json
+++ b/evals/corpora/multimodal_artifacts.json
@@ -1,0 +1,62 @@
+[
+  {
+    "envelope_id": "mm-text-1",
+    "modality": "text",
+    "payload": "Atlas stores memory atoms in a graph for retrieval.",
+    "source_id": "doc:text-1",
+    "source_type": "fixture",
+    "observed_at": "2026-04-01T10:00:00+00:00",
+    "metadata": {
+      "topic": "atlas"
+    }
+  },
+  {
+    "envelope_id": "mm-markdown-1",
+    "modality": "markdown",
+    "payload": "# Atlas\\nWeighted retrieval keeps responses grounded in graph evidence.",
+    "source_id": "doc:markdown-1",
+    "source_type": "fixture",
+    "observed_at": "2026-04-01T10:01:00+00:00",
+    "metadata": {
+      "topic": "atlas"
+    }
+  },
+  {
+    "envelope_id": "mm-chat-1",
+    "modality": "chat",
+    "payload": {
+      "conversation_id": "atlas-sync",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Can Atlas consolidate duplicate planning notes?"
+        },
+        {
+          "role": "assistant",
+          "content": "Yes, dream passes can rewrite the graph deterministically."
+        }
+      ]
+    },
+    "source_id": "chat:atlas-sync",
+    "source_type": "fixture",
+    "observed_at": "2026-04-01T10:02:00+00:00",
+    "metadata": {
+      "topic": "atlas"
+    }
+  },
+  {
+    "envelope_id": "mm-image-1",
+    "modality": "image",
+    "payload": {
+      "path": "fixtures/atlas-whiteboard.png",
+      "caption": "Whiteboard sketch of a memory graph and ranking pipeline",
+      "ocr_text": "graph memory retrieval pipeline"
+    },
+    "source_id": "image:atlas-whiteboard",
+    "source_type": "fixture",
+    "observed_at": "2026-04-01T10:03:00+00:00",
+    "metadata": {
+      "topic": "atlas"
+    }
+  }
+]

--- a/evals/corpora/project_memory.json
+++ b/evals/corpora/project_memory.json
@@ -1,0 +1,38 @@
+[
+  {
+    "memory_id": "atlas-arch",
+    "text": "Atlas architecture uses a memory graph and weighted retrieval for planning.",
+    "observed_at": "2026-03-28T00:00:00+00:00",
+    "salience_score": 0.95,
+    "trust_score": 0.9,
+    "access_count": 4,
+    "metadata": {
+      "topic": "atlas",
+      "token_count": 10
+    }
+  },
+  {
+    "memory_id": "atlas-vision",
+    "text": "Atlas roadmap focuses on graph consolidation and memory abstractions.",
+    "observed_at": "2026-02-05T00:00:00+00:00",
+    "salience_score": 0.76,
+    "trust_score": 0.85,
+    "access_count": 1,
+    "metadata": {
+      "topic": "atlas",
+      "token_count": 9
+    }
+  },
+  {
+    "memory_id": "garden-note",
+    "text": "Compost ratios and tomato pruning notes for the garden shed.",
+    "observed_at": "2026-04-02T00:00:00+00:00",
+    "salience_score": 0.2,
+    "trust_score": 0.7,
+    "access_count": 0,
+    "metadata": {
+      "topic": "garden",
+      "token_count": 10
+    }
+  }
+]

--- a/evals/corpora/recency_trap.json
+++ b/evals/corpora/recency_trap.json
@@ -1,0 +1,26 @@
+[
+  {
+    "memory_id": "deploy-last-quarter",
+    "text": "Last quarter the rollout stalled during staging verification.",
+    "observed_at": "2026-01-10T00:00:00+00:00",
+    "salience_score": 0.6,
+    "trust_score": 0.8,
+    "access_count": 0,
+    "metadata": {
+      "topic": "deployment",
+      "token_count": 8
+    }
+  },
+  {
+    "memory_id": "deploy-yesterday",
+    "text": "Yesterday the staging rollout completed with green checks.",
+    "observed_at": "2026-04-03T00:00:00+00:00",
+    "salience_score": 0.7,
+    "trust_score": 0.95,
+    "access_count": 2,
+    "metadata": {
+      "topic": "deployment",
+      "token_count": 8
+    }
+  }
+]

--- a/src/cellin/evals/__init__.py
+++ b/src/cellin/evals/__init__.py
@@ -1,1 +1,18 @@
 """Evaluation helpers for Cellin."""
+
+from cellin.evals.runner import (
+    EvaluationCaseResult,
+    EvaluationReport,
+    run_evaluation_suite,
+    write_report,
+)
+from cellin.evals.smoke import SmokeEvalResult, run_smoke_eval
+
+__all__ = [
+    "EvaluationCaseResult",
+    "EvaluationReport",
+    "SmokeEvalResult",
+    "run_evaluation_suite",
+    "run_smoke_eval",
+    "write_report",
+]

--- a/src/cellin/evals/__main__.py
+++ b/src/cellin/evals/__main__.py
@@ -1,0 +1,27 @@
+"""Command-line entry point for deterministic eval suites."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from cellin.evals.runner import run_evaluation_suite
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run deterministic Cellin eval suites.")
+    parser.add_argument("suite", choices=("smoke", "full"))
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Path to the JSON report to write.",
+    )
+    args = parser.parse_args()
+    output_path = args.output or Path("eval-results") / f"{args.suite}.json"
+    report = run_evaluation_suite(args.suite, output_path=output_path)
+    print(f"{report.suite}: {report.status} -> {output_path}")
+    return 0 if report.status == "ok" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cellin/evals/assets.py
+++ b/src/cellin/evals/assets.py
@@ -1,0 +1,92 @@
+"""Load version-controlled corpora for deterministic evals."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import cast
+
+from cellin.core import DecayState, MemoryAtom, MemoryKind, Modality, Provenance, RetrievalStats
+from cellin.core.models import JSONValue
+from cellin.ingest import ArtifactEnvelope
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _load_json(relative_path: str) -> JSONValue:
+    with (_repo_root() / relative_path).open(encoding="utf-8") as handle:
+        return cast(JSONValue, json.load(handle))
+
+
+def load_memory_records(relative_path: str) -> tuple[MemoryAtom, ...]:
+    raw = _load_json(relative_path)
+    assert isinstance(raw, list)
+    memories: list[MemoryAtom] = []
+    for item in raw:
+        assert isinstance(item, dict)
+        memory_id = item["memory_id"]
+        observed_at = item["observed_at"]
+        text = item["text"]
+        metadata = item["metadata"]
+        salience_score = item["salience_score"]
+        trust_score = item["trust_score"]
+        access_count = item.get("access_count", 0)
+        assert isinstance(memory_id, str)
+        assert isinstance(observed_at, str)
+        assert isinstance(text, str)
+        assert isinstance(metadata, dict)
+        assert isinstance(salience_score, int | float)
+        assert isinstance(trust_score, int | float)
+        assert isinstance(access_count, int)
+        memories.append(
+            MemoryAtom(
+                memory_id=memory_id,
+                kind=MemoryKind.ATOM,
+                text=text,
+                provenance=Provenance(source_id=memory_id, source_type="eval-corpus"),
+                modality=Modality.TEXT,
+                created_at=datetime.fromisoformat(observed_at),
+                observed_at=datetime.fromisoformat(observed_at),
+                salience_score=float(salience_score),
+                trust_score=float(trust_score),
+                decay=DecayState(half_life_days=14.0),
+                retrieval=RetrievalStats(access_count=access_count),
+                metadata=dict(metadata),
+            )
+        )
+    return tuple(memories)
+
+
+def load_memory_corpus(name: str) -> tuple[MemoryAtom, ...]:
+    return load_memory_records(f"evals/corpora/{name}.json")
+
+
+def load_envelope_corpus(name: str) -> tuple[ArtifactEnvelope, ...]:
+    raw = _load_json(f"evals/corpora/{name}.json")
+    assert isinstance(raw, list)
+    envelopes: list[ArtifactEnvelope] = []
+    for item in raw:
+        assert isinstance(item, dict)
+        modality = item["modality"]
+        observed_at = item["observed_at"]
+        payload = item["payload"]
+        metadata = item["metadata"]
+        assert isinstance(modality, str)
+        assert isinstance(observed_at, str)
+        assert isinstance(metadata, dict)
+        assert isinstance(payload, str | dict | list)
+        envelopes.append(
+            ArtifactEnvelope(
+                envelope_id=str(item["envelope_id"]),
+                modality=Modality(modality),
+                payload=payload,
+                source_id=str(item["source_id"]),
+                source_type=str(item["source_type"]),
+                observed_at=datetime.fromisoformat(observed_at),
+                metadata=dict(metadata),
+            )
+        )
+    return tuple(envelopes)

--- a/src/cellin/evals/runner.py
+++ b/src/cellin/evals/runner.py
@@ -1,0 +1,404 @@
+"""Deterministic eval runner for Cellin's local-first quality gates."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from cellin.core import (
+    EdgeKind,
+    GraphStore,
+    MemoryAtom,
+    MemoryEdge,
+    MemoryStore,
+    Provenance,
+    ScoredMemory,
+)
+from cellin.core.models import JSONValue
+from cellin.dreaming import (
+    AbstractionDreamStrategy,
+    ContradictionRepairDreamStrategy,
+    DeduplicationDreamStrategy,
+    DreamRunner,
+    seeded_dream_benchmark_cases,
+)
+from cellin.evals.assets import load_envelope_corpus, load_memory_corpus, load_memory_records
+from cellin.evals.retrieval_benchmarks import seeded_benchmark_cases
+from cellin.ingest import CanonicalIngestor
+from cellin.ranking import WeightedRanker, get_weight_profile
+from cellin.retrieval import RetrievalCandidateGenerator, WeightedRetriever
+from cellin.stores import InMemoryVectorIndex, SQLiteGraphStore, SQLiteMemoryStore
+
+
+def _json_float_map(values: dict[str, float]) -> dict[str, JSONValue]:
+    return {key: value for key, value in values.items()}
+
+
+def _token_cost(bundle_memories: tuple[ScoredMemory, ...]) -> float:
+    total = 0
+    for item in bundle_memories:
+        memory = item.memory
+        token_count = memory.metadata.get("token_count")
+        if isinstance(token_count, int):
+            total += token_count
+            continue
+        total += len(memory.text.split())
+    return float(total)
+
+
+class _InMemoryMemoryStore(MemoryStore):
+    def __init__(self, memories: tuple[MemoryAtom, ...]) -> None:
+        self._memories = {memory.memory_id: memory for memory in memories}
+
+    def put(self, memory: MemoryAtom) -> None:
+        self._memories[memory.memory_id] = memory
+
+    def get(self, memory_id: str) -> MemoryAtom | None:
+        return self._memories.get(memory_id)
+
+    def list(self) -> tuple[MemoryAtom, ...]:
+        return tuple(self._memories.values())
+
+
+class _InMemoryGraphStore(GraphStore):
+    def __init__(
+        self,
+        memories: tuple[MemoryAtom, ...],
+        edges: tuple[MemoryEdge, ...] = (),
+    ) -> None:
+        self._memories = {memory.memory_id: memory for memory in memories}
+        self._edges = {edge.edge_id: edge for edge in edges}
+
+    def upsert_memory(self, memory: MemoryAtom) -> None:
+        self._memories[memory.memory_id] = memory
+
+    def upsert_edge(self, edge: MemoryEdge) -> None:
+        self._edges[edge.edge_id] = edge
+
+    def get_memory(self, memory_id: str) -> MemoryAtom | None:
+        return self._memories.get(memory_id)
+
+    def neighbors(self, memory_id: str) -> tuple[MemoryEdge, ...]:
+        return tuple(
+            edge
+            for edge in self.list_edges()
+            if edge.source_id == memory_id or edge.target_id == memory_id
+        )
+
+    def list_edges(self) -> tuple[MemoryEdge, ...]:
+        return tuple(
+            edge for edge in self._edges.values() if edge.metadata.get("archived") is not True
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationCaseResult:
+    """One deterministic evaluation result."""
+
+    case_id: str
+    status: str
+    metrics: dict[str, float]
+    baseline_metrics: dict[str, float] = field(default_factory=dict)
+    delta_metrics: dict[str, float] = field(default_factory=dict)
+    notes: dict[str, JSONValue] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, JSONValue]:
+        metrics = _json_float_map(self.metrics)
+        baseline_metrics = _json_float_map(self.baseline_metrics)
+        delta_metrics = _json_float_map(self.delta_metrics)
+        return {
+            "case_id": self.case_id,
+            "status": self.status,
+            "metrics": metrics,
+            "baseline_metrics": baseline_metrics,
+            "delta_metrics": delta_metrics,
+            "notes": self.notes,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluationReport:
+    """A machine-readable eval report for CI or nightly runs."""
+
+    suite: str
+    status: str
+    generated_at: datetime
+    cases: tuple[EvaluationCaseResult, ...]
+    summary_metrics: dict[str, float]
+    output_path: str | None = None
+
+    def to_dict(self) -> dict[str, JSONValue]:
+        cases: list[JSONValue] = [case.to_dict() for case in self.cases]
+        return {
+            "suite": self.suite,
+            "status": self.status,
+            "generated_at": self.generated_at.isoformat(),
+            "summary_metrics": _json_float_map(self.summary_metrics),
+            "cases": cases,
+            "output_path": self.output_path,
+        }
+
+
+def _delta(metrics: dict[str, float], baseline: dict[str, float]) -> dict[str, float]:
+    return {key: round(metrics[key] - baseline[key], 6) for key in metrics.keys() & baseline.keys()}
+
+
+def _retriever(
+    memory_store: MemoryStore, graph_store: GraphStore, profile_name: str
+) -> WeightedRetriever:
+    profile = get_weight_profile(profile_name)
+    return WeightedRetriever(
+        candidate_generator=RetrievalCandidateGenerator(memory_store, graph_store),
+        ranker=WeightedRanker(
+            profile=profile,
+            now_provider=lambda: datetime(2026, 4, 4, tzinfo=UTC),
+        ),
+        profile=profile,
+    )
+
+
+def _project_edges() -> tuple[MemoryEdge, ...]:
+    return (
+        MemoryEdge(
+            edge_id="supports:atlas-arch:atlas-vision",
+            source_id="atlas-arch",
+            target_id="atlas-vision",
+            kind=EdgeKind.SUPPORTS,
+            provenance=Provenance(source_id="project-memory", source_type="eval-corpus"),
+            created_at=datetime(2026, 3, 28, tzinfo=UTC),
+            metadata={"label": "atlas"},
+        ),
+    )
+
+
+def _run_ingest_case() -> EvaluationCaseResult:
+    with TemporaryDirectory() as directory:
+        database_path = Path(directory) / "cellin.sqlite"
+        graph_store = SQLiteGraphStore(str(database_path))
+        memory_store = SQLiteMemoryStore(str(database_path))
+        vector_index = InMemoryVectorIndex()
+        ingestor = CanonicalIngestor.with_built_in_adapters(
+            graph_store=graph_store,
+            memory_store=memory_store,
+            vector_index=vector_index,
+        )
+        result = ingestor.ingest_envelopes(load_envelope_corpus("multimodal_artifacts"))
+        vector_results = vector_index.search("memory graph retrieval pipeline", limit=1)
+        metrics = {
+            "memory_count": float(len(result.memories)),
+            "edge_count": float(len(result.edges)),
+            "vector_top_score": vector_results[0].score,
+        }
+        baseline = {"memory_count": 4.0, "edge_count": 2.0, "vector_top_score": 0.0}
+        status = (
+            "ok" if metrics["memory_count"] == 4.0 and metrics["edge_count"] >= 2.0 else "failed"
+        )
+        return EvaluationCaseResult(
+            case_id="ingest-multimodal",
+            status=status,
+            metrics=metrics,
+            baseline_metrics=baseline,
+            delta_metrics=_delta(metrics, baseline),
+            notes={"top_memory_id": vector_results[0].memory_id},
+        )
+
+
+def _run_retrieval_case(
+    *, benchmark_index: int, corpus_name: str, case_id: str
+) -> EvaluationCaseResult:
+    benchmark = seeded_benchmark_cases()[benchmark_index]
+    memories = load_memory_corpus(corpus_name)
+    graph_store = _InMemoryGraphStore(
+        memories, _project_edges() if corpus_name == "project_memory" else ()
+    )
+    memory_store = _InMemoryMemoryStore(memories)
+    bundle = _retriever(memory_store, graph_store, benchmark.profile_name).retrieve(
+        benchmark.query,
+        top_k=benchmark.top_k,
+    )
+    actual_ids = tuple(item.memory.memory_id for item in bundle.memories)
+    hit_rate = float(actual_ids == benchmark.expected_memory_ids)
+    metrics = {"hit_rate": hit_rate, "top_score": bundle.memories[0].score}
+    baseline = {"hit_rate": 1.0}
+    return EvaluationCaseResult(
+        case_id=case_id,
+        status="ok" if hit_rate == 1.0 else "failed",
+        metrics=metrics,
+        baseline_metrics=baseline,
+        delta_metrics=_delta(metrics, baseline),
+        notes={
+            "expected_memory_ids": list(benchmark.expected_memory_ids),
+            "actual_memory_ids": list(actual_ids),
+        },
+    )
+
+
+def _run_dream_case() -> EvaluationCaseResult:
+    benchmark = seeded_dream_benchmark_cases()[0]
+    memories = load_memory_records("evals/fixtures/dreaming/atlas_corpus.json")
+    memory_store = _InMemoryMemoryStore(memories)
+    graph_store = _InMemoryGraphStore(memories)
+    retriever = _retriever(memory_store, graph_store, "balanced")
+    before = retriever.retrieve(benchmark.query, top_k=1)
+    result = DreamRunner(
+        graph_store=graph_store,
+        memory_store=memory_store,
+        strategies={"abstraction": AbstractionDreamStrategy()},
+    ).run_strategy("abstraction", at=datetime(2026, 4, 4, tzinfo=UTC))
+    after = retriever.retrieve(benchmark.query, top_k=1)
+    assert result is not None
+    metrics = {
+        "top_score": after.total_score,
+        "bundle_tokens": _token_cost(after.memories),
+        "score_gain": round(after.total_score - before.total_score, 6),
+    }
+    baseline = {
+        "top_score": before.total_score,
+        "bundle_tokens": _token_cost(before.memories),
+        "score_gain": 0.0,
+    }
+    status = (
+        "ok"
+        if after.memories[0].memory.memory_id == benchmark.expected_top_memory_id_after
+        and metrics["score_gain"] >= benchmark.minimum_score_gain
+        else "failed"
+    )
+    return EvaluationCaseResult(
+        case_id="dream-atlas",
+        status=status,
+        metrics=metrics,
+        baseline_metrics=baseline,
+        delta_metrics=_delta(metrics, baseline),
+        notes={"diff": result.diff.to_dict()},
+    )
+
+
+def _run_contradiction_case() -> EvaluationCaseResult:
+    memories = load_memory_corpus("contradiction_memory")
+    memory_store = _InMemoryMemoryStore(memories)
+    graph_store = _InMemoryGraphStore(memories)
+    result = DreamRunner(
+        graph_store=graph_store,
+        memory_store=memory_store,
+        strategies={"contradiction_repair": ContradictionRepairDreamStrategy()},
+    ).run_strategy("contradiction_repair", at=datetime(2026, 4, 4, tzinfo=UTC))
+    older = memory_store.get("atlas-rollout-green")
+    assert result is not None
+    assert older is not None
+    metrics = {
+        "contradiction_edges": float(len(graph_store.list_edges())),
+        "older_trust": older.trust_score,
+    }
+    baseline = {"contradiction_edges": 0.0, "older_trust": 0.95}
+    return EvaluationCaseResult(
+        case_id="contradiction-repair",
+        status="ok"
+        if metrics["contradiction_edges"] == 1.0 and older.trust_score < 0.95
+        else "failed",
+        metrics=metrics,
+        baseline_metrics=baseline,
+        delta_metrics=_delta(metrics, baseline),
+        notes={"affected_memory_ids": list(result.artifact.affected_memory_ids)},
+    )
+
+
+def _run_performance_case() -> EvaluationCaseResult:
+    memories = load_memory_corpus("conversation_memory")
+    memory_store = _InMemoryMemoryStore(memories)
+    graph_store = _InMemoryGraphStore(memories)
+    retriever = _retriever(memory_store, graph_store, "balanced")
+    before = retriever.retrieve("Atlas planning note retrieval blockers", top_k=2)
+    before_active = float(sum(not memory.decay.archived for memory in memory_store.list()))
+    result = DreamRunner(
+        graph_store=graph_store,
+        memory_store=memory_store,
+        strategies={"deduplication": DeduplicationDreamStrategy()},
+    ).run_strategy("deduplication", at=datetime(2026, 4, 4, tzinfo=UTC))
+    after = retriever.retrieve("Atlas planning note retrieval blockers", top_k=2)
+    after_active = float(sum(not memory.decay.archived for memory in memory_store.list()))
+    assert result is not None
+    metrics = {
+        "active_memories": after_active,
+        "bundle_tokens": _token_cost(after.memories),
+        "compression_ratio": round(after_active / before_active, 6),
+    }
+    baseline = {
+        "active_memories": before_active,
+        "bundle_tokens": _token_cost(before.memories),
+    }
+    return EvaluationCaseResult(
+        case_id="performance-dedup",
+        status="ok"
+        if metrics["active_memories"] < baseline["active_memories"]
+        and metrics["bundle_tokens"] < baseline["bundle_tokens"]
+        else "failed",
+        metrics=metrics,
+        baseline_metrics=baseline,
+        delta_metrics=_delta(metrics, baseline),
+        notes={
+            "archived_memory_ids": [
+                memory.memory_id for memory in memory_store.list() if memory.decay.archived
+            ]
+        },
+    )
+
+
+def _suite_cases(suite: str) -> tuple[EvaluationCaseResult, ...]:
+    if suite == "smoke":
+        return (
+            _run_ingest_case(),
+            _run_retrieval_case(
+                benchmark_index=0,
+                corpus_name="project_memory",
+                case_id="retrieval-project",
+            ),
+            _run_dream_case(),
+        )
+
+    if suite == "full":
+        return (
+            _run_ingest_case(),
+            _run_retrieval_case(
+                benchmark_index=0,
+                corpus_name="project_memory",
+                case_id="retrieval-project",
+            ),
+            _run_retrieval_case(
+                benchmark_index=1,
+                corpus_name="recency_trap",
+                case_id="retrieval-recency",
+            ),
+            _run_dream_case(),
+            _run_contradiction_case(),
+            _run_performance_case(),
+        )
+
+    raise ValueError(f"Unknown eval suite: {suite}")
+
+
+def write_report(report: EvaluationReport, output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(report.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+
+
+def run_evaluation_suite(suite: str, *, output_path: Path | None = None) -> EvaluationReport:
+    cases = _suite_cases(suite)
+    status = "ok" if all(case.status == "ok" for case in cases) else "failed"
+    summary_metrics = {
+        "case_count": float(len(cases)),
+        "passed_case_count": float(sum(case.status == "ok" for case in cases)),
+    }
+    report = EvaluationReport(
+        suite=suite,
+        status=status,
+        generated_at=datetime.now(UTC),
+        cases=cases,
+        summary_metrics=summary_metrics,
+        output_path=str(output_path) if output_path is not None else None,
+    )
+    if output_path is not None:
+        write_report(report, output_path)
+    return report

--- a/src/cellin/evals/smoke.py
+++ b/src/cellin/evals/smoke.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
+
+from cellin.evals.runner import run_evaluation_suite
 
 
 @dataclass(frozen=True)
@@ -12,13 +15,17 @@ class SmokeEvalResult:
     system: str
     status: str
     checks: tuple[str, ...]
+    report_path: str
 
 
-def run_smoke_eval() -> SmokeEvalResult:
+def run_smoke_eval(output_path: Path | None = None) -> SmokeEvalResult:
     """Return a deterministic bootstrap result for local and CI validation."""
 
+    resolved_output = output_path or Path("eval-results/smoke.json")
+    report = run_evaluation_suite("smoke", output_path=resolved_output)
     return SmokeEvalResult(
         system="cellin",
-        status="ok",
-        checks=("package-import", "eval-surface"),
+        status=report.status,
+        checks=tuple(case.case_id for case in report.cases),
+        report_path=str(resolved_output),
     )

--- a/tests/evals/test_runner.py
+++ b/tests/evals/test_runner.py
@@ -1,0 +1,35 @@
+"""Tests for the deterministic eval runner."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from cellin.evals.runner import run_evaluation_suite
+
+
+def test_smoke_suite_writes_report_with_deltas(tmp_path: Path) -> None:
+    output_path = tmp_path / "smoke.json"
+
+    report = run_evaluation_suite("smoke", output_path=output_path)
+
+    assert report.status == "ok"
+    assert output_path.exists()
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["suite"] == "smoke"
+    assert payload["summary_metrics"]["case_count"] == 3.0
+    assert payload["cases"][2]["case_id"] == "dream-atlas"
+    assert "delta_metrics" in payload["cases"][2]
+
+
+def test_full_suite_includes_performance_and_contradiction_cases(tmp_path: Path) -> None:
+    output_path = tmp_path / "full.json"
+
+    report = run_evaluation_suite("full", output_path=output_path)
+
+    case_ids = tuple(case.case_id for case in report.cases)
+    assert report.status == "ok"
+    assert case_ids[-2:] == ("contradiction-repair", "performance-dedup")
+    performance_case = report.cases[-1]
+    assert performance_case.delta_metrics["active_memories"] < 0.0
+    assert performance_case.delta_metrics["bundle_tokens"] < 0.0

--- a/tests/evals/test_smoke.py
+++ b/tests/evals/test_smoke.py
@@ -1,11 +1,13 @@
 """Smoke eval tests used by local development and CI."""
 
+from pathlib import Path
+
 from cellin.evals.smoke import run_smoke_eval
 
 
-def test_smoke_eval_returns_ok_status() -> None:
-    result = run_smoke_eval()
+def test_smoke_eval_returns_ok_status(tmp_path: Path) -> None:
+    result = run_smoke_eval(tmp_path / "smoke.json")
 
     assert result.system == "cellin"
     assert result.status == "ok"
-    assert "eval-surface" in result.checks
+    assert "ingest-multimodal" in result.checks


### PR DESCRIPTION
## Issue
Cellin needed a first-class eval harness so ingestion, retrieval, dreaming, and efficiency regressions become visible in CI instead of only after real usage.

## Cause and user impact
The repo only had a placeholder smoke test. There was no reusable runner, no seeded corpora, no comparison-friendly JSON report, and no workflow path for nightly benchmark artifacts.

## Root cause
Evals were not yet modeled as product assets with deterministic suites, version-controlled corpora, or a command surface that CI and local workflows could share.

## Fix
- add deterministic corpora under `evals/corpora/` for conversational memory, project memory, multimodal artifacts, contradiction repair, and recency traps
- add an eval runner and module entry point that write JSON reports with baseline and delta metrics
- wire `make eval-smoke` and `make eval-full` to the runner and keep PR CI on the deterministic smoke suite
- update the verify workflow to upload smoke artifacts and run full evals on scheduled/manual benchmark runs

## Validation
- `make ci`
- pre-push hook: `python -m cellin.evals smoke --output eval-results/smoke.json` and `pytest`

Closes #7
