### PR TITLE
feat(cli): add starter workflow and local commands

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -11,3 +11,8 @@ Cellin is being built around these boundaries:
 
 The system is intended to stay local-first and pluggable at every boundary where modality,
 storage, ranking, or dream policy may vary.
+
+The `cellin.cli` layer is intentionally thin. It creates a workspace config, then calls the
+same `cellin.ingest`, `cellin.retrieval`, `cellin.dreaming`, and `cellin.evals` modules that
+the integration tests and eval harness already exercise. This keeps the starter workflow
+representative of the actual runtime rather than introducing a second orchestration path.

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,3 +12,14 @@ consolidate or simplify that graph over time.
 - weighted retrieval and explainable bundles
 - dream-driven consolidation
 - evals that measure pre- and post-dream quality
+
+## Local workflow
+
+The CLI exercises the same ingest, retrieval, dreaming, and eval paths that the tests use.
+
+1. `python -m cellin.cli init --workspace ./.cellin`
+2. `python -m cellin.cli ingest --config examples/starter/cellin-starter.json --input examples/starter/seed_envelopes.json`
+3. `python -m cellin.cli retrieve --config examples/starter/cellin-starter.json --query "memory graph retrieval" --top-k 2`
+4. `python -m cellin.cli dream --config examples/starter/cellin-starter.json --strategy abstraction`
+5. `python -m cellin.cli eval run --suite smoke --config examples/starter/cellin-starter.json --output eval-results/starter-smoke.json`
+6. `python -m cellin.cli trace inspect --config examples/starter/cellin-starter.json --limit 5`

--- a/examples/starter/README.md
+++ b/examples/starter/README.md
@@ -1,0 +1,9 @@
+# Starter Example
+
+Use this local-first workflow from the repository root:
+
+1. `python -m cellin.cli ingest --config examples/starter/cellin-starter.json --input examples/starter/seed_envelopes.json`
+2. `python -m cellin.cli retrieve --config examples/starter/cellin-starter.json --query "memory graph retrieval" --top-k 2`
+3. `python -m cellin.cli dream --config examples/starter/cellin-starter.json --strategy abstraction`
+4. `python -m cellin.cli eval run --suite smoke --config examples/starter/cellin-starter.json --output eval-results/starter-smoke.json`
+5. `python -m cellin.cli trace inspect --config examples/starter/cellin-starter.json --limit 5`

--- a/examples/starter/cellin-starter.json
+++ b/examples/starter/cellin-starter.json
@@ -1,0 +1,6 @@
+{
+  "database_path": "starter.sqlite",
+  "profile_name": "balanced",
+  "runtime_id": "starter-workspace",
+  "trace_path": "starter-traces.jsonl"
+}

--- a/examples/starter/seed_envelopes.json
+++ b/examples/starter/seed_envelopes.json
@@ -1,0 +1,62 @@
+[
+  {
+    "envelope_id": "starter-text-1",
+    "modality": "text",
+    "payload": "Atlas stores memory atoms in a graph for retrieval.",
+    "source_id": "starter:text-1",
+    "source_type": "example",
+    "observed_at": "2026-04-01T10:00:00+00:00",
+    "metadata": {
+      "topic": "atlas"
+    }
+  },
+  {
+    "envelope_id": "starter-markdown-1",
+    "modality": "markdown",
+    "payload": "# Atlas\\nWeighted retrieval keeps responses grounded in graph evidence.",
+    "source_id": "starter:markdown-1",
+    "source_type": "example",
+    "observed_at": "2026-04-01T10:01:00+00:00",
+    "metadata": {
+      "topic": "atlas"
+    }
+  },
+  {
+    "envelope_id": "starter-chat-1",
+    "modality": "chat",
+    "payload": {
+      "conversation_id": "atlas-demo",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Can Atlas dream to consolidate duplicate notes?"
+        },
+        {
+          "role": "assistant",
+          "content": "Yes, the dream runner can create summary memories and repair contradictions."
+        }
+      ]
+    },
+    "source_id": "starter:chat-1",
+    "source_type": "example",
+    "observed_at": "2026-04-01T10:02:00+00:00",
+    "metadata": {
+      "topic": "atlas"
+    }
+  },
+  {
+    "envelope_id": "starter-image-1",
+    "modality": "image",
+    "payload": {
+      "path": "starter-whiteboard.png",
+      "caption": "Whiteboard sketch of a memory graph and dream loop",
+      "ocr_text": "memory graph dream loop"
+    },
+    "source_id": "starter:image-1",
+    "source_type": "example",
+    "observed_at": "2026-04-01T10:03:00+00:00",
+    "metadata": {
+      "topic": "atlas"
+    }
+  }
+]

--- a/src/cellin/cli/__init__.py
+++ b/src/cellin/cli/__init__.py
@@ -1,0 +1,5 @@
+"""CLI package for Cellin."""
+
+from cellin.cli.app import build_parser, main
+
+__all__ = ["build_parser", "main"]

--- a/src/cellin/cli/__main__.py
+++ b/src/cellin/cli/__main__.py
@@ -1,0 +1,8 @@
+"""Module entry point for `python -m cellin.cli`."""
+
+from __future__ import annotations
+
+from cellin.cli.app import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cellin/cli/app.py
+++ b/src/cellin/cli/app.py
@@ -1,0 +1,257 @@
+"""Argparse-based local CLI for Cellin."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from datetime import datetime
+from pathlib import Path
+
+from cellin.cli.config import append_trace, init_workspace, load_workspace, read_traces
+from cellin.core import Modality
+from cellin.core.models import JSONValue
+from cellin.dreaming import DreamRunner
+from cellin.evals import run_evaluation_suite
+from cellin.ingest import ArtifactEnvelope, CanonicalIngestor
+from cellin.ranking import WeightedRanker, get_weight_profile
+from cellin.retrieval import RetrievalCandidateGenerator, WeightedRetriever
+from cellin.runtime import InMemoryTraceSinkPlugin, PluginRegistry
+from cellin.stores import InMemoryVectorIndex, SQLiteGraphStore, SQLiteMemoryStore
+
+
+def _load_envelopes(input_path: Path) -> tuple[ArtifactEnvelope, ...]:
+    raw = json.loads(input_path.read_text(encoding="utf-8"))
+    assert isinstance(raw, list)
+    envelopes: list[ArtifactEnvelope] = []
+    for item in raw:
+        assert isinstance(item, dict)
+        metadata = item["metadata"]
+        payload = item["payload"]
+        assert isinstance(metadata, dict)
+        assert isinstance(payload, str | dict | list)
+        envelopes.append(
+            ArtifactEnvelope(
+                envelope_id=str(item["envelope_id"]),
+                modality=Modality(str(item["modality"])),
+                payload=payload,
+                source_id=str(item["source_id"]),
+                source_type=str(item["source_type"]),
+                observed_at=datetime.fromisoformat(str(item["observed_at"])),
+                metadata=dict(metadata),
+            )
+        )
+    return tuple(envelopes)
+
+
+def _retriever(config_path: Path) -> WeightedRetriever:
+    workspace = load_workspace(config_path)
+    memory_store = SQLiteMemoryStore(str(workspace.database_path))
+    graph_store = SQLiteGraphStore(str(workspace.database_path))
+    profile = get_weight_profile(workspace.profile_name)
+    return WeightedRetriever(
+        candidate_generator=RetrievalCandidateGenerator(memory_store, graph_store),
+        ranker=WeightedRanker(profile=profile),
+        profile=profile,
+    )
+
+
+def _record(config_path: Path, name: str, payload: dict[str, JSONValue]) -> None:
+    append_trace(load_workspace(config_path), name=name, payload=payload)
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    config_path = init_workspace(Path(args.workspace))
+    print(f"initialized workspace config={config_path}")
+    return 0
+
+
+def cmd_ingest(args: argparse.Namespace) -> int:
+    config_path = Path(args.config)
+    workspace = load_workspace(config_path)
+    graph_store = SQLiteGraphStore(str(workspace.database_path))
+    memory_store = SQLiteMemoryStore(str(workspace.database_path))
+    ingestor = CanonicalIngestor.with_built_in_adapters(
+        graph_store=graph_store,
+        memory_store=memory_store,
+        vector_index=InMemoryVectorIndex(),
+    )
+    result = ingestor.ingest_envelopes(_load_envelopes(Path(args.input)))
+    _record(
+        config_path,
+        "cli.ingest",
+        {
+            "artifact_count": len(result.artifacts),
+            "memory_count": len(result.memories),
+            "edge_count": len(result.edges),
+        },
+    )
+    print(
+        "ingested "
+        f"artifacts={len(result.artifacts)} "
+        f"memories={len(result.memories)} "
+        f"edges={len(result.edges)}"
+    )
+    return 0
+
+
+def cmd_retrieve(args: argparse.Namespace) -> int:
+    config_path = Path(args.config)
+    bundle = _retriever(config_path).retrieve(args.query, top_k=args.top_k)
+    _record(
+        config_path,
+        "cli.retrieve",
+        {
+            "query": args.query,
+            "result_count": len(bundle.memories),
+            "total_score": bundle.total_score,
+        },
+    )
+    print(f"query={bundle.query} total_score={bundle.total_score:.6f}")
+    for item in bundle.memories:
+        factor_summary = ", ".join(f"{factor.name}={factor.value:.3f}" for factor in item.factors)
+        print(
+            f"memory_id={item.memory.memory_id} "
+            f"score={item.score:.6f} "
+            f"text={item.memory.text} "
+            f"factors=[{factor_summary}]"
+        )
+    return 0
+
+
+def cmd_dream(args: argparse.Namespace) -> int:
+    config_path = Path(args.config)
+    workspace = load_workspace(config_path)
+    runner = DreamRunner(
+        graph_store=SQLiteGraphStore(str(workspace.database_path)),
+        memory_store=SQLiteMemoryStore(str(workspace.database_path)),
+    )
+    results = (
+        (runner.run_strategy(args.strategy),) if args.strategy is not None else runner.run_pending()
+    )
+    completed = tuple(result for result in results if result is not None)
+    for result in completed:
+        _record(
+            config_path,
+            "cli.dream",
+            {
+                "strategy_name": result.artifact.strategy_name,
+                "affected_count": len(result.artifact.affected_memory_ids),
+            },
+        )
+        print(
+            f"strategy={result.artifact.strategy_name} "
+            f"summary={result.artifact.summary} "
+            f"affected={','.join(result.artifact.affected_memory_ids)}"
+        )
+    if not completed:
+        print("no dream runs executed")
+    return 0
+
+
+def cmd_plugin_list(_: argparse.Namespace) -> int:
+    registry = PluginRegistry()
+    registry.register(InMemoryTraceSinkPlugin())
+    try:
+        registry.load_entry_points()
+    except ValueError:
+        pass
+    for manifest in registry.manifests():
+        capabilities = ",".join(capability.value for capability in manifest.capabilities)
+        print(
+            f"plugin_id={manifest.plugin_id} "
+            f"capabilities={capabilities} "
+            f"description={manifest.description or ''}"
+        )
+    registry.shutdown()
+    return 0
+
+
+def cmd_eval_run(args: argparse.Namespace) -> int:
+    output_path = Path(args.output) if args.output else Path("eval-results") / f"{args.suite}.json"
+    report = run_evaluation_suite(args.suite, output_path=output_path)
+    if args.config is not None:
+        _record(
+            Path(args.config),
+            "cli.eval",
+            {
+                "suite": report.suite,
+                "status": report.status,
+                "case_count": len(report.cases),
+            },
+        )
+    print(f"suite={report.suite} status={report.status} output={output_path}")
+    for case in report.cases:
+        print(f"case_id={case.case_id} status={case.status} metrics={case.metrics}")
+    return 0 if report.status == "ok" else 1
+
+
+def cmd_trace_inspect(args: argparse.Namespace) -> int:
+    events = read_traces(load_workspace(Path(args.config)), limit=args.limit)
+    if not events:
+        print("no trace events recorded")
+        return 0
+    for event in events:
+        print(
+            f"timestamp={event.timestamp.isoformat()} "
+            f"name={event.name} "
+            f"payload={json.dumps(event.payload, sort_keys=True)}"
+        )
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Cellin local-first CLI")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init")
+    init_parser.add_argument("--workspace", required=True)
+    init_parser.set_defaults(handler=cmd_init)
+
+    ingest_parser = subparsers.add_parser("ingest")
+    ingest_parser.add_argument("--config", required=True)
+    ingest_parser.add_argument("--input", required=True)
+    ingest_parser.set_defaults(handler=cmd_ingest)
+
+    retrieve_parser = subparsers.add_parser("retrieve")
+    retrieve_parser.add_argument("--config", required=True)
+    retrieve_parser.add_argument("--query", required=True)
+    retrieve_parser.add_argument("--top-k", type=int, default=3)
+    retrieve_parser.set_defaults(handler=cmd_retrieve)
+
+    dream_parser = subparsers.add_parser("dream")
+    dream_parser.add_argument("--config", required=True)
+    dream_parser.add_argument(
+        "--strategy",
+        choices=("deduplication", "contradiction_repair", "abstraction"),
+    )
+    dream_parser.set_defaults(handler=cmd_dream)
+
+    plugin_parser = subparsers.add_parser("plugin")
+    plugin_subparsers = plugin_parser.add_subparsers(dest="plugin_command", required=True)
+    plugin_list_parser = plugin_subparsers.add_parser("list")
+    plugin_list_parser.set_defaults(handler=cmd_plugin_list)
+
+    eval_parser = subparsers.add_parser("eval")
+    eval_subparsers = eval_parser.add_subparsers(dest="eval_command", required=True)
+    eval_run_parser = eval_subparsers.add_parser("run")
+    eval_run_parser.add_argument("--suite", choices=("smoke", "full"), default="smoke")
+    eval_run_parser.add_argument("--output")
+    eval_run_parser.add_argument("--config")
+    eval_run_parser.set_defaults(handler=cmd_eval_run)
+
+    trace_parser = subparsers.add_parser("trace")
+    trace_subparsers = trace_parser.add_subparsers(dest="trace_command", required=True)
+    trace_inspect_parser = trace_subparsers.add_parser("inspect")
+    trace_inspect_parser.add_argument("--config", required=True)
+    trace_inspect_parser.add_argument("--limit", type=int, default=10)
+    trace_inspect_parser.set_defaults(handler=cmd_trace_inspect)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    handler = args.handler
+    return int(handler(args))

--- a/src/cellin/cli/config.py
+++ b/src/cellin/cli/config.py
@@ -1,0 +1,108 @@
+"""Workspace config and trace helpers for the Cellin CLI."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from cellin.core import TraceEvent
+from cellin.core.models import JSONValue
+
+CONFIG_FILE = "cellin.json"
+
+
+@dataclass(frozen=True, slots=True)
+class WorkspaceConfig:
+    """Serializable CLI workspace config."""
+
+    runtime_id: str = "cellin-cli"
+    database_path: str = "cellin.sqlite"
+    trace_path: str = "traces.jsonl"
+    profile_name: str = "balanced"
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedWorkspace:
+    """Resolved config with absolute storage paths."""
+
+    config_path: Path
+    runtime_id: str
+    database_path: Path
+    trace_path: Path
+    profile_name: str
+
+
+def init_workspace(target: Path) -> Path:
+    """Create a workspace config file if it does not exist."""
+
+    config_path = target if target.suffix == ".json" else target / CONFIG_FILE
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    if not config_path.exists():
+        payload = {
+            "runtime_id": "cellin-cli",
+            "database_path": "cellin.sqlite",
+            "trace_path": "traces.jsonl",
+            "profile_name": "balanced",
+        }
+        config_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    return config_path
+
+
+def load_workspace(config_path: Path) -> ResolvedWorkspace:
+    """Load a workspace config and resolve relative paths."""
+
+    raw = json.loads(config_path.read_text(encoding="utf-8"))
+    workspace = WorkspaceConfig(
+        runtime_id=str(raw.get("runtime_id", "cellin-cli")),
+        database_path=str(raw.get("database_path", "cellin.sqlite")),
+        trace_path=str(raw.get("trace_path", "traces.jsonl")),
+        profile_name=str(raw.get("profile_name", "balanced")),
+    )
+    root = config_path.parent
+    return ResolvedWorkspace(
+        config_path=config_path,
+        runtime_id=workspace.runtime_id,
+        database_path=(root / workspace.database_path).resolve(),
+        trace_path=(root / workspace.trace_path).resolve(),
+        profile_name=workspace.profile_name,
+    )
+
+
+def append_trace(
+    workspace: ResolvedWorkspace, *, name: str, payload: dict[str, JSONValue]
+) -> TraceEvent:
+    """Append a JSONL trace event for later inspection."""
+
+    event = TraceEvent(name=name, timestamp=datetime.now(UTC), payload=payload)
+    workspace.trace_path.parent.mkdir(parents=True, exist_ok=True)
+    line = {
+        "name": event.name,
+        "timestamp": event.timestamp.isoformat(),
+        "payload": event.payload,
+    }
+    with workspace.trace_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(line, sort_keys=True))
+        handle.write("\n")
+    return event
+
+
+def read_traces(workspace: ResolvedWorkspace, *, limit: int) -> tuple[TraceEvent, ...]:
+    """Read the last N trace events from the workspace trace log."""
+
+    if not workspace.trace_path.exists():
+        return ()
+
+    lines = workspace.trace_path.read_text(encoding="utf-8").splitlines()
+    events: list[TraceEvent] = []
+    for line in lines[-limit:]:
+        raw = json.loads(line)
+        events.append(
+            TraceEvent(
+                name=str(raw["name"]),
+                timestamp=datetime.fromisoformat(str(raw["timestamp"])),
+                payload=dict(raw.get("payload", {})),
+            )
+        )
+    return tuple(events)

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -1,0 +1,83 @@
+"""Integration tests for the local CLI workflow."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pytest import CaptureFixture
+
+from cellin.cli import main
+
+
+def _copy_example_input(target: Path) -> Path:
+    source = Path("examples/starter/seed_envelopes.json")
+    destination = target / "seed_envelopes.json"
+    destination.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+    return destination
+
+
+def test_cli_end_to_end_flow(tmp_path: Path, capsys: CaptureFixture[str]) -> None:
+    workspace = tmp_path / "workspace"
+    config_path = workspace / "cellin.json"
+    input_path = _copy_example_input(tmp_path)
+    eval_output = tmp_path / "smoke.json"
+
+    assert main(["init", "--workspace", str(workspace)]) == 0
+    init_output = capsys.readouterr().out
+    assert "initialized workspace" in init_output
+
+    assert main(["ingest", "--config", str(config_path), "--input", str(input_path)]) == 0
+    ingest_output = capsys.readouterr().out
+    assert "memories=4" in ingest_output
+
+    assert (
+        main(
+            [
+                "retrieve",
+                "--config",
+                str(config_path),
+                "--query",
+                "memory graph retrieval",
+                "--top-k",
+                "2",
+            ]
+        )
+        == 0
+    )
+    retrieve_output = capsys.readouterr().out
+    assert "memory_id=" in retrieve_output
+    assert "factors=[" in retrieve_output
+
+    assert main(["dream", "--config", str(config_path), "--strategy", "abstraction"]) == 0
+    dream_output = capsys.readouterr().out
+    assert "strategy=abstraction" in dream_output
+
+    assert main(["plugin", "list"]) == 0
+    plugin_output = capsys.readouterr().out
+    assert "plugin_id=in-memory-trace-sink" in plugin_output
+
+    assert (
+        main(
+            [
+                "eval",
+                "run",
+                "--suite",
+                "smoke",
+                "--config",
+                str(config_path),
+                "--output",
+                str(eval_output),
+            ]
+        )
+        == 0
+    )
+    eval_output_text = capsys.readouterr().out
+    assert "suite=smoke status=ok" in eval_output_text
+    payload = json.loads(eval_output.read_text(encoding="utf-8"))
+    assert payload["status"] == "ok"
+
+    assert main(["trace", "inspect", "--config", str(config_path), "--limit", "5"]) == 0
+    trace_output = capsys.readouterr().out
+    assert "name=cli.ingest" in trace_output
+    assert "name=cli.eval" in trace_output


### PR DESCRIPTION
## Issue
Cellin needed a batteries-included local workflow so contributors can initialize a workspace, ingest data, retrieve explainable bundles, run dream passes, inspect traces, and execute evals without building a separate API first.

## Cause and user impact
The repository had core runtime pieces but no cohesive local interface, no starter assets, and no test-covered path that exercised the end-to-end workflow the same way a new contributor would.

## Root cause
The runtime modules were only reachable through tests and ad hoc scripts. There was no workspace config model, no CLI orchestration layer, and no starter dataset/documentation tied to the real engine paths.

## Fix
- add `cellin.cli` with `init`, `ingest`, `retrieve`, `dream`, `plugin list`, `eval run`, and `trace inspect` commands
- add JSON workspace config and JSONL trace recording for local inspection
- add `examples/starter/` with config, seeded envelopes, and a copy-paste workflow
- add an end-to-end CLI integration test and update docs with the local workflow

## Validation
- `make ci`
- pre-push hook: `python -m cellin.evals smoke --output eval-results/smoke.json` and `pytest`

Closes #8
