### PR TITLE
fix(governance): repair codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,38 +2,3 @@
 
 /docs/ @ben-ranford
 /.github/ @ben-ranford
-*** Add File: /Users/benranford/Projects/cellin-feat-pluggable-evals-rigor-plan/CONTRIBUTING.md
-# Contributing
-
-## Development Setup
-
-1. Install Python `3.12`.
-2. Install `uv`.
-3. Run `make bootstrap`.
-
-## Expected Workflow
-
-1. Branch from `main` using `feat/<issue-number>-<slug>` or `bug/<issue-number>-<slug>`.
-2. Keep work scoped to a single issue stream.
-3. Run `make ci` before pushing.
-4. Open a draft PR until the stream is ready for review.
-
-## Quality Gates
-
-The canonical checks are:
-
-- `make fmt`
-- `make lint`
-- `make typecheck`
-- `make test`
-- `make eval-smoke`
-- `make ci`
-
-## Pull Requests
-
-PRs should explain:
-
-- the issue being solved
-- the implementation approach
-- validation that was run
-- any follow-up work or known limitations


### PR DESCRIPTION
## Issue
`CODEOWNERS` on `main` contained stray patch text after the intended owner mappings.

Closes #23.

## Cause and impact
The extra text made the ownership file malformed and undermined the governance surface that the release-grade uplift depends on.

## Root cause
Residual patch content was committed into `CODEOWNERS` in an earlier change and survived until the final verification pass.

## Fix
Remove the accidental patch residue so `CODEOWNERS` contains only the expected owner mappings.

## Validation
- `python3 -m uv run pytest`
- `python3 -m uv run python -m cellin.evals smoke --output eval-results/smoke.json`
- `nl -ba CODEOWNERS`
