### PR TITLE
docs(readme): refresh MVP landing surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,21 @@ Cellin is a pluggable multimodal memory system for large knowledge graphs. It in
 artifacts into a long-lived memory substrate, retrieves context with weighted ranking, and
 runs "dream" passes that consolidate and simplify memory over time.
 
-## Status
+## MVP Surface
 
-The repository is in active bootstrap. The current goal is to land the local-first MVP:
+The current local-first MVP already includes:
 
-- Python workspace and repo rigor foundations
-- typed memory and plugin contracts
-- multimodal ingestion with local stores
-- weighted retrieval and memory bundles
-- dream scheduling and graph consolidation
-- eval harnesses and starter workflows
+- typed memory objects and plugin contracts for ingestion, retrieval, dreaming, evaluation,
+  and storage
+- first-party adapters for `text`, `markdown`, `chat`, `json`, and `image` envelopes
+- local persistence through SQLite-backed graph and memory stores plus an in-memory vector
+  index for retrieval candidates
+- weighted retrieval with explainable factor scoring across semantic similarity, graph
+  proximity, recency, salience, trust, reinforcement, and modality match
+- dream passes for `deduplication`, `contradiction_repair`, and `abstraction`
+- a thin local CLI for `init`, `ingest`, `retrieve`, `dream`, `plugin list`, `eval run`,
+  and `trace inspect`
+- deterministic eval suites, a runnable starter example, and release-grade repo rigor
 
 ## Quickstart
 
@@ -21,6 +26,50 @@ The repository is in active bootstrap. The current goal is to land the local-fir
 2. Install `uv`.
 3. Run `make bootstrap`.
 4. Run `make ci`.
+5. Run `python3 -m uv run cellin plugin list`.
+
+## Starter Workflow
+
+Run the local MVP loop from the repository root:
+
+1. `python3 -m uv run cellin ingest --config examples/starter/cellin-starter.json --input examples/starter/seed_envelopes.json`
+2. `python3 -m uv run cellin retrieve --config examples/starter/cellin-starter.json --query "memory graph retrieval" --top-k 2`
+3. `python3 -m uv run cellin dream --config examples/starter/cellin-starter.json --strategy abstraction`
+4. `python3 -m uv run cellin eval run --suite smoke --config examples/starter/cellin-starter.json --output eval-results/starter-smoke.json`
+5. `python3 -m uv run cellin trace inspect --config examples/starter/cellin-starter.json --limit 5`
+
+If you want a fresh workspace instead of the seeded starter config:
+
+1. `python3 -m uv run cellin init --workspace ./.cellin-local`
+2. Edit `./.cellin-local/cellin.json` if you want a non-default database path, trace path, or retrieval profile.
+3. Point the same `ingest`, `retrieve`, `dream`, `eval run`, and `trace inspect` commands at that config.
+
+## MVP Landing Checklist
+
+Treat the MVP as shippable only if these stay green:
+
+- `make ci`
+- `make eval-full`
+- `make package-smoke`
+- `make release-smoke`
+- the starter workflow in [examples/starter/README.md](examples/starter/README.md)
+
+## CLI Surface
+
+- `python3 -m uv run cellin init --workspace <dir-or-config>`
+  Creates a workspace config with local SQLite and trace paths.
+- `python3 -m uv run cellin ingest --config <path> --input <json>`
+  Normalizes envelopes and writes artifacts, memories, and graph edges.
+- `python3 -m uv run cellin retrieve --config <path> --query <text> --top-k <n>`
+  Returns a scored memory bundle with explainable factor output.
+- `python3 -m uv run cellin dream --config <path> [--strategy abstraction|deduplication|contradiction_repair]`
+  Runs one dream strategy or any pending scheduled strategies.
+- `python3 -m uv run cellin plugin list`
+  Lists built-in and entry-point plugins discoverable by the runtime.
+- `python3 -m uv run cellin eval run --suite smoke|full [--config <path>] [--output <json>]`
+  Runs deterministic eval suites and writes machine-readable reports.
+- `python3 -m uv run cellin trace inspect --config <path> --limit <n>`
+  Reads recent structured trace events emitted by the CLI workflow.
 
 ## Developer Commands
 
@@ -30,6 +79,10 @@ The repository is in active bootstrap. The current goal is to land the local-fir
 - `make typecheck`
 - `make test`
 - `make eval-smoke`
+- `make eval-full`
+- `make eval`
+- `make docs`
+- `make package`
 - `make package-smoke`
 - `make release-smoke`
 - `make verify`
@@ -39,6 +92,7 @@ The repository is in active bootstrap. The current goal is to land the local-fir
 
 - [Architecture Overview](docs/architecture/README.md)
 - [Eval Strategy](docs/evals/README.md)
+- [Starter Example](examples/starter/README.md)
 - [Release Guide](RELEASING.md)
 - [Implementation Plan](docs/pluggable-evals-rigor-plan.md)
 


### PR DESCRIPTION
## Issue
The root README lagged behind the actual shipped MVP surface.

Closes #25.

## Cause and impact
It described the repo as active bootstrap, omitted the current CLI surface, and did not show the runnable starter workflow or the concrete checks needed to treat the local-first MVP as shippable. That made the landing page undersell and partially hide the product that now exists.

## Root cause
Implementation work landed faster than the root README was updated, so the product, eval, and release surfaces drifted away from the repo's primary entrypoint.

## Fix
Refresh the root README to:
- describe the actual current MVP surface
- document the starter ingest -> retrieve -> dream -> eval -> trace loop
- show the fresh-workspace path and CLI command surface
- include the checks required to treat the MVP as ready to land
- align command examples with the working `python3 -m uv run ...` toolchain path

## Validation
- `make docs`
- `python3 -m uv run cellin plugin list`
- `python3 -m uv run cellin init --workspace <tempdir>`
- `python3 -m uv run cellin ingest --config examples/starter/cellin-starter.json --input examples/starter/seed_envelopes.json`
- `python3 -m uv run cellin retrieve --config examples/starter/cellin-starter.json --query "memory graph retrieval" --top-k 2`
- `python3 -m uv run cellin dream --config examples/starter/cellin-starter.json --strategy abstraction`
- `python3 -m uv run cellin eval run --suite smoke --config examples/starter/cellin-starter.json --output eval-results/starter-smoke.json`
- `python3 -m uv run cellin trace inspect --config examples/starter/cellin-starter.json --limit 5`
