### PR TITLE
feat(release): add semver library publish surface

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,22 +5,23 @@ name: release
     tags:
       - "v*"
 
-permissions:
-  contents: write
-
 concurrency:
   group: release-${{ github.ref_name }}
   cancel-in-progress: false
 
 jobs:
-  release:
+  build-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      package_version: ${{ steps.version.outputs.package_version }}
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref_name }}
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -33,6 +34,15 @@ jobs:
       - name: Sync dependencies
         run: python -m uv sync --dev --frozen
 
+      - name: Validate stable release version
+        id: version
+        shell: bash
+        run: |
+          python -m uv run python scripts/release/verify_version.py \
+            --tag "${GITHUB_REF_NAME}" \
+            --release-kind stable
+          echo "package_version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: Run release smoke
         run: make release-smoke
 
@@ -40,11 +50,31 @@ jobs:
         shell: bash
         run: shasum -a 256 dist/* > dist/SHA256SUMS.txt
 
+      - name: Upload Python distributions
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-dist-${{ github.ref_name }}
+          path: |
+            dist/*.tar.gz
+            dist/*.whl
+
       - name: Upload release bundle
         uses: actions/upload-artifact@v7
         with:
-          name: release-${{ github.ref_name }}
+          name: release-bundle-${{ github.ref_name }}
           path: dist/*
+
+  publish-github-release:
+    needs: build-release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download release bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: release-bundle-${{ github.ref_name }}
+          path: dist
 
       - name: Publish GitHub release
         env:
@@ -52,3 +82,21 @@ jobs:
           TAG: ${{ github.ref_name }}
         shell: bash
         run: gh release create "$TAG" dist/* --title "$TAG" --generate-notes
+
+  publish-pypi:
+    needs: build-release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/cellin
+    steps:
+      - name: Download Python distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: python-dist-${{ github.ref_name }}
+          path: dist
+
+      - name: Publish distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -4,23 +4,24 @@ name: rolling-release
   workflow_dispatch:
     inputs:
       version:
-        description: "Semver prerelease version without the leading v, for example 0.2.0-rc.1"
+        description: "PEP 440 prerelease version without the leading v, for example 0.2.0rc1"
         required: true
       target_ref:
         description: "Git ref to publish from when cutting a prerelease"
         required: false
         default: "main"
 
-permissions:
-  contents: write
-
 concurrency:
   group: rolling-release-${{ inputs.version }}
   cancel-in-progress: false
 
 jobs:
-  rolling-release:
+  build-prerelease:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      package_version: ${{ steps.version.outputs.package_version }}
 
     steps:
       - name: Checkout target ref
@@ -39,6 +40,16 @@ jobs:
       - name: Sync dependencies
         run: python -m uv sync --dev --frozen
 
+      - name: Validate prerelease version
+        id: version
+        shell: bash
+        run: |
+          python -m uv run python scripts/release/verify_version.py \
+            --tag "v${{ inputs.version }}" \
+            --expect-version "${{ inputs.version }}" \
+            --release-kind prerelease
+          echo "package_version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+
       - name: Run release smoke
         run: make release-smoke
 
@@ -46,11 +57,31 @@ jobs:
         shell: bash
         run: shasum -a 256 dist/* > dist/SHA256SUMS.txt
 
+      - name: Upload Python distributions
+        uses: actions/upload-artifact@v7
+        with:
+          name: python-dist-v${{ inputs.version }}
+          path: |
+            dist/*.tar.gz
+            dist/*.whl
+
       - name: Upload rolling release bundle
         uses: actions/upload-artifact@v7
         with:
           name: rolling-release-v${{ inputs.version }}
           path: dist/*
+
+  publish-github-prerelease:
+    needs: build-prerelease
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download rolling release bundle
+        uses: actions/download-artifact@v8
+        with:
+          name: rolling-release-v${{ inputs.version }}
+          path: dist
 
       - name: Publish rolling prerelease
         env:
@@ -59,3 +90,21 @@ jobs:
           TARGET_REF: ${{ inputs.target_ref }}
         shell: bash
         run: gh release create "$TAG" dist/* --title "$TAG" --generate-notes --target "$TARGET_REF" --prerelease
+
+  publish-pypi-prerelease:
+    needs: build-prerelease
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment:
+      name: pypi-prerelease
+      url: https://pypi.org/p/cellin
+    steps:
+      - name: Download Python distributions
+        uses: actions/download-artifact@v8
+        with:
+          name: python-dist-v${{ inputs.version }}
+          path: dist
+
+      - name: Publish prerelease distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,9 @@ The canonical checks are:
 ## Release Workflow
 
 - Stable releases are cut from semver tags such as `v0.1.0`.
+- Prerelease versions use semver-compatible PEP 440 syntax such as `0.2.0rc1`.
 - Manual prereleases are created through the GitHub Actions `rolling-release` workflow.
+- Run `make version-check` when you change the package version or prepare a release branch.
 - Run `make release-smoke` before you cut or approve a release-related change.
 - Use the guidance in `RELEASING.md` for tag naming, release channels, and artifact expectations.
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 UV ?= python3 -m uv
+TAG ?=
+EXPECT_VERSION ?=
+RELEASE_KIND ?= any
 
-.PHONY: bootstrap hooks fmt fmt-check lint typecheck test eval-smoke eval-full eval package package-smoke release-smoke verify ci docs
+.PHONY: bootstrap hooks fmt fmt-check lint typecheck test eval-smoke eval-full eval package package-smoke version-check release-smoke verify ci docs
 
 bootstrap:
 	$(UV) sync --dev
@@ -10,13 +13,13 @@ hooks:
 	$(UV) run lefthook install
 
 fmt:
-	$(UV) run ruff format src tests docs
+	$(UV) run ruff format src tests docs scripts
 
 fmt-check:
-	$(UV) run ruff format --check src tests docs
+	$(UV) run ruff format --check src tests docs scripts
 
 lint:
-	$(UV) run ruff check src tests docs
+	$(UV) run ruff check src tests docs scripts
 
 typecheck:
 	$(UV) run mypy src
@@ -39,15 +42,20 @@ package:
 package-smoke: package
 	$(UV) run twine check --strict dist/*
 	tmpdir=$$(mktemp -d); \
-	python3 -m venv "$$tmpdir/venv"; \
-	"$$tmpdir/venv/bin/pip" install --upgrade pip >/dev/null; \
-	"$$tmpdir/venv/bin/pip" install dist/*.whl >/dev/null; \
-	"$$tmpdir/venv/bin/cellin" plugin list | grep -q "in-memory-trace-sink"; \
-	rm -rf "$$tmpdir"
+		python3 -m venv "$$tmpdir/venv"; \
+		"$$tmpdir/venv/bin/pip" install --upgrade pip >/dev/null; \
+		"$$tmpdir/venv/bin/pip" install dist/*.whl >/dev/null; \
+		expected_version=$$(python3 scripts/release/verify_version.py --print-version); \
+		"$$tmpdir/venv/bin/cellin" --version | grep -q "$$expected_version"; \
+		"$$tmpdir/venv/bin/cellin" plugin list | grep -q "in-memory-trace-sink"; \
+		rm -rf "$$tmpdir"
+
+version-check:
+	$(UV) run python scripts/release/verify_version.py $(if $(TAG),--tag $(TAG),) $(if $(EXPECT_VERSION),--expect-version $(EXPECT_VERSION),) --release-kind $(RELEASE_KIND)
 
 release-smoke: ci package-smoke
 
-verify: fmt-check lint typecheck test eval-smoke
+verify: fmt-check lint typecheck test eval-smoke version-check
 
 ci: verify docs
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,35 @@ The current local-first MVP already includes:
 4. Run `make ci`.
 5. Run `python3 -m uv run cellin plugin list`.
 
+## Install
+
+Stable release from PyPI:
+
+```bash
+pip install cellin
+```
+
+Prerelease from PyPI:
+
+```bash
+pip install --pre cellin
+```
+
+## Library Surface
+
+Cellin can be used as a Python library as well as a CLI:
+
+```python
+from cellin.ingest import ArtifactEnvelope, CanonicalIngestor
+from cellin.ranking import WeightedRanker, get_weight_profile
+from cellin.retrieval import RetrievalCandidateGenerator, WeightedRetriever
+from cellin.stores import InMemoryVectorIndex, SQLiteGraphStore, SQLiteMemoryStore
+```
+
+The stable import surfaces today are the subpackages under `cellin.core`, `cellin.ingest`,
+`cellin.retrieval`, `cellin.ranking`, `cellin.dreaming`, `cellin.evals`, `cellin.runtime`,
+and `cellin.stores`.
+
 ## Starter Workflow
 
 Run the local MVP loop from the repository root:
@@ -98,5 +127,6 @@ Treat the MVP as shippable only if these stay green:
 
 ## Release Channels
 
-- Stable releases are published from pushed semver tags through `.github/workflows/release.yml`.
+- Stable releases are published from pushed semver tags such as `v0.1.0` through `.github/workflows/release.yml`.
 - Prereleases are published from manual GitHub Actions runs through `.github/workflows/rolling-release.yml`.
+- Python package versions follow semver-compatible PEP 440 syntax: stable `X.Y.Z`, prerelease `X.Y.ZrcN`, `X.Y.ZbN`, or `X.Y.ZaN`.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,11 +1,12 @@
 # Releasing
 
-Cellin uses a release-grade split between stable semver tags and manual prereleases.
+Cellin uses a semver library release model with a stable tag channel and a manual prerelease channel.
 
 ## Planning
 
 - Delivery planning stays on the calendar milestone train, for example `2026-04`.
-- External release artifacts are cut from semver tags such as `v0.1.0` or `v0.2.0-rc.1`.
+- Git tags use `vX.Y.Z` for stable releases and `vX.Y.ZrcN`, `vX.Y.ZbN`, or `vX.Y.ZaN` for prereleases.
+- Python package versions use the same value without the leading `v`.
 - Use `release-candidate` for work intended for the next cut and `release-blocker` for issues that must land before a stable release.
 
 ## Local Validation
@@ -17,24 +18,51 @@ Run these commands before creating or approving a release:
 3. `make release-smoke`
 
 `make package-smoke` builds the wheel and sdist, runs `twine check`, installs the wheel into a fresh virtualenv, and verifies the installed CLI entrypoint.
+`make version-check` validates that the package version surface is internally consistent and, when provided, matches the intended release tag.
 
 ## Stable Release Path
 
-Stable releases are tag-driven.
+Stable library releases are tag-driven and publish to both GitHub Releases and PyPI.
 
 1. Ensure the target commit is on `main`.
 2. Create and push a semver tag such as `v0.1.0`.
 3. GitHub Actions runs `.github/workflows/release.yml`.
-4. The workflow runs `make release-smoke`, attaches built artifacts plus `SHA256SUMS.txt`, and publishes a GitHub Release with generated notes.
+4. The workflow validates that the tag matches the package version, runs `make release-smoke`, and uploads wheel plus sdist artifacts.
+5. The workflow publishes a GitHub Release with generated notes and publishes the package distributions to PyPI.
 
 ## Prerelease Path
 
-Prereleases are workflow-dispatch driven through a dedicated rolling channel workflow.
+Prereleases are workflow-dispatch driven through `.github/workflows/rolling-release.yml`.
 
-1. Open the `rolling-release` workflow in GitHub Actions.
-2. Provide `version` without the leading `v`, for example `0.2.0-rc.1`.
-3. Provide the `target_ref` to release from, usually `main` or a release branch.
-4. Run the workflow to create the tag and publish a prerelease with the same artifact bundle as a stable release.
+1. Commit a prerelease package version such as `0.2.0rc1` on the target branch or release branch.
+2. Open the `rolling-release` workflow in GitHub Actions.
+3. Provide the same prerelease version without the leading `v`, for example `0.2.0rc1`.
+4. Provide the `target_ref` to release from, usually `main` or a release branch.
+5. The workflow validates that the input matches the committed package version, then publishes a GitHub prerelease and the package distributions to PyPI.
+
+## Trusted Publishing Setup
+
+Cellin's publish jobs are designed for PyPI trusted publishing with GitHub OIDC.
+
+Configure these trusted publishers on PyPI before the first live publish:
+
+- stable publisher:
+  - repository: `ben-ranford/cellin`
+  - workflow: `.github/workflows/release.yml`
+  - environment: `pypi`
+- prerelease publisher:
+  - repository: `ben-ranford/cellin`
+  - workflow: `.github/workflows/rolling-release.yml`
+  - environment: `pypi-prerelease`
+
+The GitHub repository does not need long-lived `PYPI_API_TOKEN` secrets when trusted publishing is configured correctly.
+
+## Library Metadata
+
+The package metadata is built from `pyproject.toml` plus `src/cellin/__about__.py`.
+Use `src/cellin/__about__.py` as the single source of truth for the package version.
+
+Before the first public PyPI release, decide and add an explicit project license file if Cellin is intended for third-party reuse.
 
 ## Remote Enforcement
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,14 +4,32 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cellin"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Pluggable multimodal memory, retrieval, and dreaming system."
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = []
+authors = [{ name = "Ben Ranford" }]
+keywords = ["memory", "retrieval", "multimodal", "agents", "evals"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.12",
+  "Typing :: Typed",
+  "Topic :: Software Development :: Libraries",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
 
 [project.scripts]
 cellin = "cellin.cli:main"
+
+[project.urls]
+Documentation = "https://github.com/ben-ranford/cellin/tree/main/docs"
+Issues = "https://github.com/ben-ranford/cellin/issues"
+Releases = "https://github.com/ben-ranford/cellin/releases"
+Source = "https://github.com/ben-ranford/cellin"
 
 [dependency-groups]
 dev = [
@@ -26,6 +44,9 @@ dev = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/cellin"]
+
+[tool.hatch.version]
+path = "src/cellin/__about__.py"
 
 [tool.pytest.ini_options]
 addopts = "-ra"

--- a/scripts/release/verify_version.py
+++ b/scripts/release/verify_version.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Validate Cellin's release version surface."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+VERSION_PATTERN = re.compile(
+    r'^__version__\s*=\s*"(?P<version>\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?)"\s*$', re.MULTILINE
+)
+STABLE_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
+PRERELEASE_PATTERN = re.compile(r"^\d+\.\d+\.\d+(?:a|b|rc)\d+$")
+
+
+def load_version(version_path: Path) -> str:
+    match = VERSION_PATTERN.search(version_path.read_text(encoding="utf-8"))
+    if match is None:
+        raise ValueError(f"Unable to locate __version__ in {version_path}")
+    return match.group("version")
+
+
+def validate_pyproject(pyproject_path: Path, version_path: str) -> None:
+    payload = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    project = payload["project"]
+    dynamic = project.get("dynamic", [])
+    if "version" not in dynamic:
+        raise ValueError("pyproject.toml must declare project.dynamic = ['version']")
+
+    configured_path = payload["tool"]["hatch"]["version"]["path"]
+    if configured_path != version_path:
+        raise ValueError(
+            f"tool.hatch.version.path must be {version_path!r}, found {configured_path!r}"
+        )
+
+
+def validate_release_kind(version: str, release_kind: str) -> None:
+    if release_kind == "stable" and STABLE_PATTERN.fullmatch(version) is None:
+        raise ValueError(f"Stable releases must use X.Y.Z, found {version!r}")
+    if release_kind == "prerelease" and PRERELEASE_PATTERN.fullmatch(version) is None:
+        raise ValueError(
+            "Prereleases must use PEP 440 prerelease versions like X.Y.ZrcN, X.Y.ZbN, or X.Y.ZaN"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate the Cellin package version surface.")
+    parser.add_argument("--tag", help="Git tag to compare against, for example v0.1.0")
+    parser.add_argument("--expect-version", help="Expected package version")
+    parser.add_argument(
+        "--release-kind",
+        choices=("any", "stable", "prerelease"),
+        default="any",
+        help="Validate stable or prerelease policy",
+    )
+    parser.add_argument(
+        "--version-path",
+        default="src/cellin/__about__.py",
+        help="Path to the version source file",
+    )
+    parser.add_argument(
+        "--pyproject-path",
+        default="pyproject.toml",
+        help="Path to pyproject.toml",
+    )
+    parser.add_argument(
+        "--print-version",
+        action="store_true",
+        help="Print the resolved package version",
+    )
+    args = parser.parse_args()
+
+    version_path = Path(args.version_path)
+    pyproject_path = Path(args.pyproject_path)
+    version = load_version(version_path)
+    validate_pyproject(pyproject_path, args.version_path)
+    if args.release_kind != "any":
+        validate_release_kind(version, args.release_kind)
+
+    if args.expect_version is not None and version != args.expect_version:
+        raise ValueError(f"Expected package version {args.expect_version!r}, found {version!r}")
+
+    if args.tag is not None:
+        if not args.tag.startswith("v"):
+            raise ValueError(f"Tags must be prefixed with 'v', found {args.tag!r}")
+        if args.tag[1:] != version:
+            raise ValueError(f"Tag {args.tag!r} does not match package version {version!r}")
+
+    if args.print_version:
+        print(version)
+    else:
+        print(f"version={version} release_kind={args.release_kind}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/src/cellin/__about__.py
+++ b/src/cellin/__about__.py
@@ -1,0 +1,5 @@
+"""Single-source package version metadata."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/src/cellin/__init__.py
+++ b/src/cellin/__init__.py
@@ -1,5 +1,5 @@
 """Cellin package root."""
 
-__all__ = ["__version__"]
+from cellin.__about__ import __version__
 
-__version__ = "0.1.0"
+__all__ = ["__version__"]

--- a/src/cellin/cli/app.py
+++ b/src/cellin/cli/app.py
@@ -8,6 +8,7 @@ from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
 
+from cellin import __version__
 from cellin.cli.config import append_trace, init_workspace, load_workspace, read_traces
 from cellin.core import Modality
 from cellin.core.models import JSONValue
@@ -202,6 +203,7 @@ def cmd_trace_inspect(args: argparse.Namespace) -> int:
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Cellin local-first CLI")
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     init_parser = subparsers.add_parser("init")

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from pytest import CaptureFixture
 
+from cellin import __version__
 from cellin.cli import main
 
 
@@ -81,3 +83,11 @@ def test_cli_end_to_end_flow(tmp_path: Path, capsys: CaptureFixture[str]) -> Non
     trace_output = capsys.readouterr().out
     assert "name=cli.ingest" in trace_output
     assert "name=cli.eval" in trace_output
+
+
+def test_cli_version_flag(capsys: CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--version"])
+    assert excinfo.value.code == 0
+    version_output = capsys.readouterr().out.strip()
+    assert version_output.endswith(__version__)

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -1,7 +1,9 @@
 """Package-level smoke tests."""
 
+from importlib.metadata import version as package_version
+
 from cellin import __version__
 
 
 def test_package_version_is_defined() -> None:
-    assert __version__ == "0.1.0"
+    assert __version__ == package_version("cellin")

--- a/uv.lock
+++ b/uv.lock
@@ -41,7 +41,6 @@ wheels = [
 
 [[package]]
 name = "cellin"
-version = "0.1.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Issue
Cellin could cut GitHub release assets, but it still did not have a coherent Python library release surface comparable in discipline to the release model used in `ben-ranford/lopper`.

Closes #27.

## Cause and impact
The package version was duplicated, published metadata was sparse, the CLI had no version flag, and the release workflows stopped at GitHub artifacts rather than publishing the library to PyPI. That meant Cellin was buildable, but not really set up to ship as a semver versioned Python library.

## Root cause
The earlier release-grade uplift focused on repo rigor, CI gates, and GitHub release mechanics first. It did not yet finish the library distribution surface.

## Fix
This change adds the semver library release surface by:
- moving package versioning to a single source in `src/cellin/__about__.py` and wiring Hatch dynamic versioning to it
- enriching package metadata in `pyproject.toml`
- adding `scripts/release/verify_version.py` and `make version-check` to validate stable vs prerelease version rules and tag alignment
- adding `cellin --version` and extending package smoke to validate the installed CLI version
- updating stable and prerelease workflows to publish Python distributions to PyPI via trusted publishing environments
- documenting install, semver, prerelease syntax, and the PyPI trusted publisher setup in the README and release docs
- creating the matching GitHub environments `pypi` and `pypi-prerelease`

## Validation
- `python3 scripts/release/verify_version.py --tag v0.1.0 --release-kind stable`
- `make release-smoke`
- GitHub environments created: `pypi`, `pypi-prerelease`

## Follow-up external setup
PyPI trusted publishing still needs to be configured on the PyPI project side for:
- repository `ben-ranford/cellin`, workflow `.github/workflows/release.yml`, environment `pypi`
- repository `ben-ranford/cellin`, workflow `.github/workflows/rolling-release.yml`, environment `pypi-prerelease`

GitHub-side workflow and environment support is now in place.
