### PR TITLE
fix(evals): harden eval asset loaders

### DIFF
--- a/src/cellin/evals/assets.py
+++ b/src/cellin/evals/assets.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 from cellin.core import DecayState, MemoryAtom, MemoryKind, Modality, Provenance, RetrievalStats
 from cellin.core.models import JSONValue
@@ -16,31 +16,97 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[3]
 
 
+def _evals_root() -> Path:
+    return _repo_root() / "evals"
+
+
+def _corpora_root() -> Path:
+    return _evals_root() / "corpora"
+
+
+def _resolve_within_root(path: Path, root: Path, *, descriptor: str) -> Path:
+    resolved_root = root.resolve()
+    resolved_path = path.resolve(strict=False)
+    if not resolved_path.is_relative_to(resolved_root):
+        raise ValueError(f"{descriptor} resolves outside {resolved_root}")
+    return resolved_path
+
+
 def _load_json(relative_path: str) -> JSONValue:
-    with (_repo_root() / relative_path).open(encoding="utf-8") as handle:
+    path = _resolve_within_root(
+        _repo_root() / relative_path,
+        _evals_root(),
+        descriptor=f"Eval asset path {relative_path!r}",
+    )
+    with path.open(encoding="utf-8") as handle:
         return cast(JSONValue, json.load(handle))
 
 
-def load_memory_records(relative_path: str) -> tuple[MemoryAtom, ...]:
-    raw = _load_json(relative_path)
-    assert isinstance(raw, list)
+def _load_corpus_json(name: str) -> JSONValue:
+    path = _resolve_within_root(
+        _corpora_root() / f"{name}.json",
+        _corpora_root(),
+        descriptor=f"Eval corpus name {name!r}",
+    )
+    with path.open(encoding="utf-8") as handle:
+        return cast(JSONValue, json.load(handle))
+
+
+def _as_corpus_list(raw: JSONValue, *, loader_name: str) -> list[JSONValue]:
+    if not isinstance(raw, list):
+        raise ValueError(f"{loader_name} corpus must be a JSON list")
+    return raw
+
+
+def _require_type(
+    item: dict[str, JSONValue],
+    key: str,
+    expected: type[Any] | tuple[type[Any], ...],
+    *,
+    context: str,
+) -> Any:
+    if key not in item:
+        raise ValueError(f"{context} missing required field {key!r}")
+    value = item[key]
+    if not isinstance(value, expected):
+        raise ValueError(f"{context}.{key} has invalid type {type(value).__name__}")
+    return value
+
+
+def _require_number(item: dict[str, JSONValue], key: str, *, context: str) -> float:
+    value = _require_type(item, key, (int, float), context=context)
+    if isinstance(value, bool):
+        raise ValueError(f"{context}.{key} has invalid type bool")
+    return float(value)
+
+
+def _parse_iso_datetime(value: str, *, context: str) -> datetime:
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(f"{context} must be an ISO-8601 datetime string") from exc
+
+
+def _load_memory_atoms(raw: JSONValue, *, context: str) -> tuple[MemoryAtom, ...]:
+    records = _as_corpus_list(raw, loader_name=context)
     memories: list[MemoryAtom] = []
-    for item in raw:
-        assert isinstance(item, dict)
-        memory_id = item["memory_id"]
-        observed_at = item["observed_at"]
-        text = item["text"]
-        metadata = item["metadata"]
-        salience_score = item["salience_score"]
-        trust_score = item["trust_score"]
-        access_count = item.get("access_count", 0)
-        assert isinstance(memory_id, str)
-        assert isinstance(observed_at, str)
-        assert isinstance(text, str)
-        assert isinstance(metadata, dict)
-        assert isinstance(salience_score, int | float)
-        assert isinstance(trust_score, int | float)
-        assert isinstance(access_count, int)
+    for index, raw_item in enumerate(records):
+        item_context = f"{context}[{index}]"
+        if not isinstance(raw_item, dict):
+            raise ValueError(f"{item_context} must be a JSON object")
+        item = raw_item
+        memory_id = _require_type(item, "memory_id", str, context=item_context)
+        observed_at_raw = _require_type(item, "observed_at", str, context=item_context)
+        text = _require_type(item, "text", str, context=item_context)
+        metadata = _require_type(item, "metadata", dict, context=item_context)
+        salience_score = _require_number(item, "salience_score", context=item_context)
+        trust_score = _require_number(item, "trust_score", context=item_context)
+        access_count_raw = item.get("access_count", 0)
+        if not isinstance(access_count_raw, int) or isinstance(access_count_raw, bool):
+            raise ValueError(
+                f"{item_context}.access_count has invalid type {type(access_count_raw).__name__}"
+            )
+        observed_at = _parse_iso_datetime(observed_at_raw, context=f"{item_context}.observed_at")
         memories.append(
             MemoryAtom(
                 memory_id=memory_id,
@@ -48,45 +114,66 @@ def load_memory_records(relative_path: str) -> tuple[MemoryAtom, ...]:
                 text=text,
                 provenance=Provenance(source_id=memory_id, source_type="eval-corpus"),
                 modality=Modality.TEXT,
-                created_at=datetime.fromisoformat(observed_at),
-                observed_at=datetime.fromisoformat(observed_at),
-                salience_score=float(salience_score),
-                trust_score=float(trust_score),
+                created_at=observed_at,
+                observed_at=observed_at,
+                salience_score=salience_score,
+                trust_score=trust_score,
                 decay=DecayState(half_life_days=14.0),
-                retrieval=RetrievalStats(access_count=access_count),
+                retrieval=RetrievalStats(access_count=access_count_raw),
                 metadata=dict(metadata),
             )
         )
     return tuple(memories)
 
 
-def load_memory_corpus(name: str) -> tuple[MemoryAtom, ...]:
-    return load_memory_records(f"evals/corpora/{name}.json")
+def load_memory_records(relative_path: str) -> tuple[MemoryAtom, ...]:
+    return _load_memory_atoms(_load_json(relative_path), context="memory corpus")
 
 
-def load_envelope_corpus(name: str) -> tuple[ArtifactEnvelope, ...]:
-    raw = _load_json(f"evals/corpora/{name}.json")
-    assert isinstance(raw, list)
+def _load_envelopes(raw: JSONValue, *, context: str) -> tuple[ArtifactEnvelope, ...]:
+    records = _as_corpus_list(raw, loader_name=context)
     envelopes: list[ArtifactEnvelope] = []
-    for item in raw:
-        assert isinstance(item, dict)
-        modality = item["modality"]
-        observed_at = item["observed_at"]
-        payload = item["payload"]
-        metadata = item["metadata"]
-        assert isinstance(modality, str)
-        assert isinstance(observed_at, str)
-        assert isinstance(metadata, dict)
-        assert isinstance(payload, str | dict | list)
+    for index, raw_item in enumerate(records):
+        item_context = f"{context}[{index}]"
+        if not isinstance(raw_item, dict):
+            raise ValueError(f"{item_context} must be a JSON object")
+        item = raw_item
+        envelope_id = _require_type(item, "envelope_id", str, context=item_context)
+        modality_name = _require_type(item, "modality", str, context=item_context)
+        source_id = _require_type(item, "source_id", str, context=item_context)
+        source_type = _require_type(item, "source_type", str, context=item_context)
+        observed_at_raw = _require_type(item, "observed_at", str, context=item_context)
+        metadata = _require_type(item, "metadata", dict, context=item_context)
+        payload = _require_type(
+            item,
+            "payload",
+            (str, dict, list),
+            context=item_context,
+        )
+        observed_at = _parse_iso_datetime(observed_at_raw, context=f"{item_context}.observed_at")
+        try:
+            modality = Modality(modality_name)
+        except ValueError as exc:
+            raise ValueError(
+                f"{item_context}.modality has unknown value {modality_name!r}"
+            ) from exc
         envelopes.append(
             ArtifactEnvelope(
-                envelope_id=str(item["envelope_id"]),
-                modality=Modality(modality),
+                envelope_id=envelope_id,
+                modality=modality,
                 payload=payload,
-                source_id=str(item["source_id"]),
-                source_type=str(item["source_type"]),
-                observed_at=datetime.fromisoformat(observed_at),
+                source_id=source_id,
+                source_type=source_type,
+                observed_at=observed_at,
                 metadata=dict(metadata),
             )
         )
     return tuple(envelopes)
+
+
+def load_memory_corpus(name: str) -> tuple[MemoryAtom, ...]:
+    return _load_memory_atoms(_load_corpus_json(name), context="memory corpus")
+
+
+def load_envelope_corpus(name: str) -> tuple[ArtifactEnvelope, ...]:
+    return _load_envelopes(_load_corpus_json(name), context="envelope corpus")

--- a/tests/evals/test_assets.py
+++ b/tests/evals/test_assets.py
@@ -1,0 +1,116 @@
+"""Regression tests for eval asset loading hardening."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from cellin.evals import assets
+
+
+def test_load_memory_records_rejects_traversal_outside_evals_tree() -> None:
+    with pytest.raises(ValueError, match="outside"):
+        assets.load_memory_records("../pyproject.toml")
+
+
+def test_load_memory_corpus_rejects_corpus_name_traversal() -> None:
+    with pytest.raises(ValueError, match="outside"):
+        assets.load_memory_corpus("../fixtures/dreaming/atlas_corpus")
+
+
+def test_load_envelope_corpus_rejects_corpus_name_traversal() -> None:
+    with pytest.raises(ValueError, match="outside"):
+        assets.load_envelope_corpus("../fixtures/dreaming/atlas_corpus")
+
+
+def test_load_memory_corpus_schema_validation_raises_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(assets, "_load_corpus_json", lambda _: {"unexpected": "mapping"})
+
+    with pytest.raises(ValueError, match="JSON list"):
+        assets.load_memory_corpus("project_memory")
+
+
+def test_load_envelope_corpus_schema_validation_raises_runtime_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        assets,
+        "_load_corpus_json",
+        lambda _: [
+            {
+                "envelope_id": "bad-envelope",
+                "modality": "text",
+                "payload": "payload",
+                "source_id": "source",
+                "source_type": "fixture",
+                "observed_at": "2026-04-01T10:00:00+00:00",
+                "metadata": "not-a-mapping",
+            }
+        ],
+    )
+
+    with pytest.raises(ValueError, match="metadata has invalid type"):
+        assets.load_envelope_corpus("multimodal_artifacts")
+
+
+def test_schema_validation_still_fails_under_python_optimized_mode(tmp_path: Path) -> None:
+    corpus_root = tmp_path / "evals" / "corpora"
+    corpus_root.mkdir(parents=True)
+    (corpus_root / "bad_memory.json").write_text(
+        json.dumps({"unexpected": "mapping"}),
+        encoding="utf-8",
+    )
+    (corpus_root / "bad_envelope.json").write_text(
+        json.dumps(
+            [
+                {
+                    "envelope_id": "bad-envelope",
+                    "modality": "text",
+                    "payload": "payload",
+                    "source_id": "source",
+                    "source_type": "fixture",
+                    "observed_at": "2026-04-01T10:00:00+00:00",
+                    "metadata": "not-a-mapping",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    script = f"""
+from pathlib import Path
+from cellin.evals import assets
+
+assets._repo_root = lambda: Path({str(tmp_path)!r})
+
+def expect_failure(callable_):
+    try:
+        callable_()
+    except ValueError:
+        return
+    raise RuntimeError("expected ValueError")
+
+expect_failure(lambda: assets.load_memory_records("evals/corpora/bad_memory.json"))
+expect_failure(lambda: assets.load_envelope_corpus("bad_envelope"))
+"""
+    env = dict(os.environ)
+    src_path = str(Path(__file__).resolve().parents[2] / "src")
+    current_pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        src_path if not current_pythonpath else f"{src_path}{os.pathsep}{current_pythonpath}"
+    )
+    result = subprocess.run(
+        [sys.executable, "-O", "-c", script],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Issue
Closes #31.
Closes #32.

Eval asset helpers could read JSON outside the intended eval corpus tree, and their schema validation relied on `assert`, which disappears under `python -O`.

## Cause and Impact
The loaders joined caller-supplied paths directly onto the repo root and used assert statements as their only structural validation. That left a path traversal boundary hole and made malformed corpus data silently acceptable in optimized Python.

## Root Cause
The eval helper surface never established a canonical root boundary and treated deterministic eval fixtures like trusted internal data instead of validating them as runtime inputs.

## Fix
This PR hardens the eval asset layer by:
- canonicalizing and validating paths before opening files
- constraining `load_memory_records()` to the `evals/` tree and named corpus loaders to `evals/corpora/`
- replacing assert-based checks with explicit `ValueError` validation for structure, field types, datetimes, and modality values
- adding regression tests for traversal attempts and `python -O` validation behavior

## Validation
- `make release-smoke`
- `PYTHONPATH=src .venv/bin/python -m pytest tests/evals/test_assets.py tests/evals/test_runner.py tests/evals/test_smoke.py`
