### PR TITLE
fix(retrieval): enforce token budgets

### DIFF
--- a/src/cellin/retrieval/service.py
+++ b/src/cellin/retrieval/service.py
@@ -48,12 +48,18 @@ class WeightedRetriever:
         *,
         token_budget: int,
     ) -> tuple[ScoredMemory, ...]:
+        """Select ranked memories whose cumulative token cost never exceeds budget."""
+        if token_budget <= 0:
+            return ()
+
         selected: list[ScoredMemory] = []
         consumed = 0
 
         for item in ranked:
             cost = _estimate_token_cost(item)
-            if selected and consumed + cost > token_budget:
+            # Never include a memory that would exceed the remaining budget,
+            # including the top-ranked candidate when it is oversized.
+            if consumed + cost > token_budget:
                 continue
             selected.append(item)
             consumed += cost

--- a/tests/integration/retrieval/test_weighted_retriever.py
+++ b/tests/integration/retrieval/test_weighted_retriever.py
@@ -209,3 +209,72 @@ def test_bundle_respects_token_budget() -> None:
 
     assert len(bundle.memories) == 1
     assert bundle.memories[0].memory.memory_id == "atlas-arch"
+
+
+def test_bundle_returns_empty_when_top_k_one_candidate_is_oversized() -> None:
+    memories, edges = _seeded_memories()
+    memory_store = InMemoryMemoryStore(memories)
+    graph_store = InMemoryGraphStore(memories, edges)
+    profile = replace(get_weight_profile("balanced"), token_budget=7)
+    retriever = WeightedRetriever(
+        candidate_generator=RetrievalCandidateGenerator(memory_store, graph_store),
+        ranker=WeightedRanker(
+            profile=profile,
+            now_provider=lambda: datetime(2026, 4, 4, tzinfo=UTC),
+        ),
+        profile=profile,
+    )
+
+    bundle = retriever.retrieve(
+        "Atlas architecture uses a memory graph and weighted retrieval for planning.",
+        top_k=1,
+    )
+
+    assert bundle.memories == ()
+    assert bundle.total_score == 0.0
+    assert bundle.summary is None
+
+
+def test_bundle_skips_oversized_first_candidate_and_selects_in_budget_next() -> None:
+    now = datetime(2026, 4, 4, tzinfo=UTC)
+    memories = (
+        _memory(
+            "oversized-candidate",
+            "Atlas architecture weighted retrieval memory graph planning",
+            observed_at=now - timedelta(days=1),
+            salience=0.99,
+            trust=0.99,
+            access_count=9,
+            token_count=20,
+        ),
+        _memory(
+            "fits-budget",
+            "Atlas architecture weighted retrieval memory graph planning",
+            observed_at=now - timedelta(days=1),
+            salience=0.45,
+            trust=0.75,
+            access_count=0,
+            token_count=5,
+        ),
+    )
+    memory_store = InMemoryMemoryStore(memories)
+    graph_store = InMemoryGraphStore(memories, ())
+    profile = replace(get_weight_profile("balanced"), token_budget=6)
+    retriever = WeightedRetriever(
+        candidate_generator=RetrievalCandidateGenerator(memory_store, graph_store),
+        ranker=WeightedRanker(
+            profile=profile,
+            now_provider=lambda: now,
+        ),
+        profile=profile,
+    )
+
+    bundle = retriever.retrieve(
+        "Atlas architecture weighted retrieval memory graph planning",
+        top_k=2,
+    )
+
+    assert tuple(item.memory.memory_id for item in bundle.memories) == ("fits-budget",)
+    assert (
+        sum(item.memory.metadata["token_count"] for item in bundle.memories) <= profile.token_budget
+    )


### PR DESCRIPTION
## Issue
Closes #33.

`WeightedRetriever` could return a bundle whose selected memories exceeded `token_budget` when the top-ranked memory alone was oversized.

## Cause and Impact
The budget fitter always admitted the first ranked item, then only enforced the budget once something had already been selected. Downstream callers could therefore trust a budget that the bundle had already violated.

## Root Cause
The retrieval budget logic treated the first candidate as a special case instead of enforcing a strict cumulative budget invariant for every candidate.

## Fix
This PR enforces the budget contract by:
- skipping any candidate that would exceed the remaining token budget, including rank 1
- returning an empty bundle for non-positive budgets
- adding regression tests for `top_k=1` oversized-first behavior and oversized-first fallback selection

## Validation
- `make release-smoke`
- `PYTHONPATH=src .venv/bin/python -m pytest tests/integration/retrieval/test_weighted_retriever.py tests/integration/dreaming/test_dreaming.py`
