### PR TITLE
fix(release): tighten version surface checks

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Sync dependencies
         run: python -m uv sync --dev --frozen
 
-      - name: Run CI target
+      - name: Run CI target (verify + docs + version-check)
         run: make ci
 
       - name: Upload smoke eval report

--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,9 @@ version-check:
 
 release-smoke: ci package-smoke
 
-verify: fmt-check lint typecheck test eval-smoke version-check
+verify: fmt-check lint typecheck test eval-smoke
 
-ci: verify docs
+ci: verify docs version-check
 
 docs:
 	$(UV) run mkdocs build --strict

--- a/src/cellin/runtime/builtins.py
+++ b/src/cellin/runtime/builtins.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 
+from cellin.__about__ import __version__
 from cellin.core.contracts import Capability, PluginContext, PluginManifest
 from cellin.core.models import TraceEvent
 
@@ -18,7 +19,7 @@ class InMemoryTraceSinkPlugin:
 
     manifest = PluginManifest(
         plugin_id="in-memory-trace-sink",
-        version="0.1.0",
+        version=__version__,
         capabilities=(Capability.TRACE_SINK,),
         display_name="In-memory trace sink",
         description="Stores trace events in memory for tests and local development.",

--- a/tests/contracts/test_registry.py
+++ b/tests/contracts/test_registry.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 import pytest
 
+from cellin import __version__
 from cellin.core import Capability, PluginContext, RuntimeConfig
 from cellin.runtime import InMemoryTraceSinkPlugin, PluginRegistry
 
@@ -42,6 +43,10 @@ def test_registry_rejects_duplicate_plugin_ids() -> None:
 
     with pytest.raises(ValueError, match="already registered"):
         registry.register(InMemoryTraceSinkPlugin())
+
+
+def test_builtin_plugin_manifest_version_matches_package_version() -> None:
+    assert InMemoryTraceSinkPlugin.manifest.version == __version__
 
 
 @dataclass


### PR DESCRIPTION
## Issue
Closes #34.

The release metadata validation path was too easy to drift: the built-in plugin manifest carried a hardcoded version, and the verification targets did not clearly separate source checks from version-surface checks.

## Cause and Impact
A normal package version bump could leave the built-in plugin metadata behind, and the Makefile target split made it harder to see exactly where version drift was supposed to fail.

## Root Cause
The built-in plugin version was duplicated instead of deriving from the package version source, and the verification target naming blurred together source checks and version checks.

## Fix
This PR tightens the version surface by:
- deriving the built-in plugin manifest version from `cellin.__about__.__version__`
- adding a contract test that locks the built-in plugin version to the package version
- moving `version-check` under `make ci` explicitly while leaving `make verify` as source-level checks
- clarifying the GitHub Actions verify step name to match the target split

## Validation
- `make release-smoke`
- `python3 -m uv run pytest tests/contracts/test_registry.py tests/unit/test_package.py`
