### PR TITLE
chore(release): fix release-please token gating

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -11,27 +11,23 @@ permissions:
   issues: write
   pull-requests: write
 
-env:
-  RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-
 concurrency:
   group: release-please-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  release-please-disabled:
-    if: ${{ env.RELEASE_PLEASE_TOKEN == '' }}
+  release-please:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
     steps:
       - name: Report missing token
+        if: ${{ env.RELEASE_PLEASE_TOKEN == '' }}
         run: |
           echo "::warning::RELEASE_PLEASE_TOKEN is not configured. Stable release initiation remains disabled until the token is added."
 
-  release-please:
-    if: ${{ env.RELEASE_PLEASE_TOKEN != '' }}
-    runs-on: ubuntu-latest
-    steps:
       - name: Run release-please
+        if: ${{ env.RELEASE_PLEASE_TOKEN != '' }}
         uses: googleapis/release-please-action@v4
         with:
           token: ${{ env.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
## Issue
The new `release-please` workflow merged in #42 failed immediately on GitHub instead of degrading cleanly when `RELEASE_PLEASE_TOKEN` is absent.

## Cause and Impact
The workflow tried to gate whole jobs on an `env` value derived from the secret. GitHub treated that as a workflow-file issue at runtime, so the automation path failed before it could emit the intended warning.

## Root Cause
The token-presence check lived at job scope. That is too early for this pattern and caused the workflow parser/runtime to reject the file.

## Fix
Move the token gating into step-level `if` expressions inside a single `release-please` job. The job now always parses, warns cleanly when `RELEASE_PLEASE_TOKEN` is missing, and only invokes `googleapis/release-please-action` when the secret is present.

## Validation
- `make release-smoke`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-please.yml"); puts "yaml-ok"'`

## Follow-up
- After merge, the `release-please` workflow on `main` should complete successfully with a warning until `RELEASE_PLEASE_TOKEN` is configured.
