### PR TITLE
chore(release): fix GitHub release repo context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,13 +79,14 @@ jobs:
       - name: Publish GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
         shell: bash
         run: |
-          if gh release view "$TAG" >/dev/null 2>&1; then
-            gh release upload "$TAG" dist/* --clobber
+          if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            gh release upload "$TAG" dist/* --repo "$REPO" --clobber
           else
-            gh release create "$TAG" dist/* --title "$TAG" --generate-notes
+            gh release create "$TAG" dist/* --repo "$REPO" --title "$TAG" --generate-notes
           fi
 
   publish-pypi:


### PR DESCRIPTION
## Issue
The bootstrap `v0.1.1` publish succeeded to PyPI, but the `publish-github-release` job failed when trying to create the GitHub release.

## Cause and Impact
That left the first stable release only partially automated: the package was live on PyPI, but the GitHub release had to be created manually.

## Root Cause
The job invoked `gh release view/create/upload` without a checked out git repository and without passing `--repo`, so `gh` tried to infer repo context from `.git` and failed.

## Fix
Pass `github.repository` explicitly into the `gh release` commands in `.github/workflows/release.yml`. That makes the release job independent of local checkout state while preserving the existing create-or-upload behavior.

## Validation
- `make release-smoke`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml-ok"'`

## Release Result
- `v0.1.1` is live on PyPI
- `v0.1.1` GitHub release was created manually to complete the bootstrap release
