### PR TITLE
chore(release): skip release-please labeling

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,3 +34,4 @@ jobs:
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          skip-labeling: true


### PR DESCRIPTION
## Issue
After enabling `RELEASE_PLEASE_TOKEN`, the `release-please` workflow on `main` created PR #45 and then failed while trying to apply labels.

## Cause and Impact
The actual release PR automation is working, but the workflow run on `main` is red even though it successfully created the next release PR.

## Root Cause
The workflow was not passing `skip-labeling: true` to `googleapis/release-please-action@v4`, so the action still attempted its default label workflow despite the repo being set up to avoid that path.

## Fix
Pass `skip-labeling: true` explicitly in `.github/workflows/release-please.yml` so the action matches the repo’s intended non-labeling configuration.

## Validation
- `make release-smoke`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-please.yml"); puts "yaml-ok"'`
