### PR TITLE
docs(readme): add release badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # cellin
 
+[![PyPI](https://img.shields.io/pypi/v/cellin)](https://pypi.org/project/cellin/)
+[![Release](https://img.shields.io/github/v/release/ben-ranford/cellin)](https://github.com/ben-ranford/cellin/releases)
+
 Cellin builds long-lived multimodal memory, dreams over it to consolidate ideas, and
 retrieves context with transparent weighted ranking.
 


### PR DESCRIPTION
## Issue
The root README did not expose the new public package and release surfaces at a glance.

## Cause and Impact
Readers landing on the repository had to scan the text or leave the page to confirm whether the library was published and what the latest tagged release was.

## Fix
Add a PyPI badge and a GitHub release badge directly under the README title.

## Validation
- `make release-smoke`
