### PR TITLE
docs(readme): link PyPI install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ cd cellin
 make bootstrap
 ```
 
-After the first public PyPI release:
+Install from [PyPI](https://pypi.org/project/cellin/):
 
 ```bash
 python3 -m pip install cellin


### PR DESCRIPTION
## Issue
The install section still used transitional language from before the package was published.

## Fix
Replace that line with direct PyPI install wording and a link to the published package page.

## Validation
- `make release-smoke`
