### PR TITLE
fix(dreaming): align abstraction token counts

### DIFF
--- a/src/cellin/dreaming/strategies.py
+++ b/src/cellin/dreaming/strategies.py
@@ -352,13 +352,14 @@ class AbstractionDreamStrategy:
             if len(members) < 2 or topic in existing_summaries:
                 continue
 
+            ordered_members = tuple(
+                sorted(members, key=lambda item: item.salience_score, reverse=True)
+            )
+            summary_text = _summary_text(topic, ordered_members)
             summary_memory = MemoryAtom(
                 memory_id=f"dream-{topic}-{when.strftime('%Y%m%d%H%M%S')}",
                 kind=MemoryKind.DREAM,
-                text=_summary_text(
-                    topic,
-                    tuple(sorted(members, key=lambda item: item.salience_score, reverse=True)),
-                ),
+                text=summary_text,
                 provenance=Provenance(source_id=self.strategy_name, source_type="dream"),
                 modality=Modality.TEXT,
                 created_at=when,
@@ -369,7 +370,7 @@ class AbstractionDreamStrategy:
                     "topic": topic,
                     "dream_strategy": self.strategy_name,
                     "summary_for": [memory.memory_id for memory in members],
-                    "token_count": len(_summary_text(topic, tuple(members)).split()),
+                    "token_count": len(summary_text.split()),
                 },
             )
             memory_store.put(summary_memory)

--- a/tests/integration/dreaming/test_dreaming.py
+++ b/tests/integration/dreaming/test_dreaming.py
@@ -254,3 +254,34 @@ def test_abstraction_benchmark_improves_retrieval_for_combined_queries() -> None
     assert result is not None
     assert after.memories[0].memory.memory_id == benchmark.expected_top_memory_id_after
     assert after.total_score >= before.total_score + benchmark.minimum_score_gain
+
+
+def test_abstraction_summary_token_count_matches_rendered_summary() -> None:
+    now = datetime(2026, 4, 4, tzinfo=UTC)
+    memories = (
+        _memory(
+            "atlas-summary-low",
+            "Atlas keeps a durable memory graph.",
+            observed_at=now - timedelta(days=2),
+            topic="atlas",
+            salience=0.4,
+        ),
+        _memory(
+            "atlas-summary-high",
+            "Atlas retrieval favors higher-salience evidence first.",
+            observed_at=now - timedelta(days=1),
+            topic="atlas",
+            salience=0.9,
+        ),
+    )
+    memory_store = InMemoryMemoryStore(memories)
+    graph_store = InMemoryGraphStore(memories)
+    strategy = AbstractionDreamStrategy()
+
+    result = strategy.execute(graph_store, memory_store, at=now)
+
+    assert result is not None
+    created_memory_id = result.artifact.affected_memory_ids[0]
+    summary_memory = memory_store.get(created_memory_id)
+    assert summary_memory is not None
+    assert summary_memory.metadata["token_count"] == len(summary_memory.text.split())


### PR DESCRIPTION
## Issue
`AbstractionDreamStrategy` rendered summary text from salience-sorted members but computed `metadata["token_count"]` from a second pass over unsorted members.

## Cause and Impact
The stored token metadata could undercount the actual summary text, which makes downstream budgeting and summary introspection less trustworthy.

## Fix
Render the abstraction summary once from the ordered members, reuse that exact string for the stored memory text, and derive `token_count` from the same rendered summary. Add a regression that checks metadata against the created dream memory text.

## Validation
- `make release-smoke`
