### PR TITLE
refactor(stores): reduce sqlite write churn

### DIFF
--- a/src/cellin/ingest/pipeline.py
+++ b/src/cellin/ingest/pipeline.py
@@ -58,9 +58,8 @@ class CanonicalIngestor:
         """Persist a sequence of normalized artifacts as memory atoms."""
 
         memories = tuple(self._artifact_to_memory(artifact) for artifact in artifacts)
+        self._persist_memories(memories)
         for memory in memories:
-            self.memory_store.put(memory)
-            self.graph_store.upsert_memory(memory)
             self.vector_index.upsert(memory.memory_id, memory.text)
         return memories
 
@@ -68,9 +67,42 @@ class CanonicalIngestor:
         artifacts = tuple(self._normalize_envelope(envelope) for envelope in envelopes)
         memories = self.ingest(artifacts)
         edges = self._build_edges(artifacts, memories)
+        self._persist_edges(edges)
+        return IngestionBatchResult(artifacts=artifacts, memories=memories, edges=edges)
+
+    def _persist_memories(self, memories: tuple[MemoryAtom, ...]) -> None:
+        put_many = getattr(self.memory_store, "put_many", None)
+        if callable(put_many):
+            put_many(memories)
+        else:
+            for memory in memories:
+                self.memory_store.put(memory)
+
+        if not self._graph_requires_memory_upserts():
+            return
+
+        upsert_memories = getattr(self.graph_store, "upsert_memories", None)
+        if callable(upsert_memories):
+            upsert_memories(memories)
+            return
+
+        for memory in memories:
+            self.graph_store.upsert_memory(memory)
+
+    def _persist_edges(self, edges: tuple[MemoryEdge, ...]) -> None:
+        upsert_edges = getattr(self.graph_store, "upsert_edges", None)
+        if callable(upsert_edges):
+            upsert_edges(edges)
+            return
+
         for edge in edges:
             self.graph_store.upsert_edge(edge)
-        return IngestionBatchResult(artifacts=artifacts, memories=memories, edges=edges)
+
+    def _graph_requires_memory_upserts(self) -> bool:
+        shares_memory_store = getattr(self.graph_store, "shares_memory_store", None)
+        if callable(shares_memory_store):
+            return not bool(shares_memory_store(self.memory_store))
+        return True
 
     def _normalize_envelope(self, envelope: ArtifactEnvelope) -> Artifact:
         adapter = self.adapters[envelope.modality]

--- a/src/cellin/stores/sqlite.py
+++ b/src/cellin/stores/sqlite.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from datetime import datetime
+from pathlib import Path
 
 from cellin.core import (
     DecayState,
@@ -13,6 +14,7 @@ from cellin.core import (
     MemoryAtom,
     MemoryEdge,
     MemoryKind,
+    MemoryStore,
     Modality,
     Provenance,
     RetrievalStats,
@@ -136,13 +138,15 @@ def _edge_archived(edge: MemoryEdge) -> bool:
     return bool(archived) if isinstance(archived, bool) else False
 
 
-class _SQLiteBase:
+class _SQLiteBackend:
+    """Shared SQLite boundary for memory and graph persistence."""
+
     def __init__(self, database_path: str) -> None:
-        self._database_path = database_path
+        self.database_path = database_path
         self._initialize()
 
     def _connect(self) -> sqlite3.Connection:
-        return sqlite3.connect(self._database_path)
+        return sqlite3.connect(self.database_path)
 
     def _initialize(self) -> None:
         with self._connect() as connection:
@@ -165,22 +169,21 @@ class _SQLiteBase:
                 """
             )
 
-
-class SQLiteMemoryStore(_SQLiteBase):
-    """Persists memory atoms in SQLite as JSON payloads."""
-
-    def put(self, memory: MemoryAtom) -> None:
+    def put_memories(self, memories: tuple[MemoryAtom, ...]) -> None:
+        if not memories:
+            return
+        rows = [(memory.memory_id, _dump_memory(memory)) for memory in memories]
         with self._connect() as connection:
-            connection.execute(
+            connection.executemany(
                 """
                 INSERT INTO memories(memory_id, payload)
                 VALUES (?, ?)
                 ON CONFLICT(memory_id) DO UPDATE SET payload = excluded.payload
                 """,
-                (memory.memory_id, _dump_memory(memory)),
+                rows,
             )
 
-    def get(self, memory_id: str) -> MemoryAtom | None:
+    def get_memory(self, memory_id: str) -> MemoryAtom | None:
         with self._connect() as connection:
             row = connection.execute(
                 "SELECT payload FROM memories WHERE memory_id = ?",
@@ -190,31 +193,24 @@ class SQLiteMemoryStore(_SQLiteBase):
             return None
         return _load_memory(row[0])
 
-    def list(self) -> tuple[MemoryAtom, ...]:
+    def list_memories(self) -> tuple[MemoryAtom, ...]:
         with self._connect() as connection:
             rows = connection.execute("SELECT payload FROM memories ORDER BY memory_id").fetchall()
         return tuple(_load_memory(row[0]) for row in rows)
 
-
-class SQLiteGraphStore(_SQLiteBase):
-    """Persists graph nodes and edges in SQLite."""
-
-    def upsert_memory(self, memory: MemoryAtom) -> None:
-        SQLiteMemoryStore(self._database_path).put(memory)
-
-    def upsert_edge(self, edge: MemoryEdge) -> None:
+    def upsert_edges(self, edges: tuple[MemoryEdge, ...]) -> None:
+        if not edges:
+            return
+        rows = [(edge.edge_id, edge.source_id, edge.target_id, _dump_edge(edge)) for edge in edges]
         with self._connect() as connection:
-            connection.execute(
+            connection.executemany(
                 """
                 INSERT INTO edges(edge_id, source_id, target_id, payload)
                 VALUES (?, ?, ?, ?)
                 ON CONFLICT(edge_id) DO UPDATE SET payload = excluded.payload
                 """,
-                (edge.edge_id, edge.source_id, edge.target_id, _dump_edge(edge)),
+                rows,
             )
-
-    def get_memory(self, memory_id: str) -> MemoryAtom | None:
-        return SQLiteMemoryStore(self._database_path).get(memory_id)
 
     def neighbors(self, memory_id: str) -> tuple[MemoryEdge, ...]:
         with self._connect() as connection:
@@ -233,3 +229,67 @@ class SQLiteGraphStore(_SQLiteBase):
         with self._connect() as connection:
             rows = connection.execute("SELECT payload FROM edges ORDER BY edge_id").fetchall()
         return tuple(edge for row in rows if not _edge_archived(edge := _load_edge(row[0])))
+
+
+_BACKENDS: dict[str, _SQLiteBackend] = {}
+
+
+def _backend_for(database_path: str) -> _SQLiteBackend:
+    resolved_path = str(Path(database_path).resolve())
+    backend = _BACKENDS.get(resolved_path)
+    if backend is None:
+        backend = _SQLiteBackend(resolved_path)
+        _BACKENDS[resolved_path] = backend
+    return backend
+
+
+class _SQLiteBase:
+    def __init__(self, database_path: str, *, backend: _SQLiteBackend | None = None) -> None:
+        self._backend = backend or _backend_for(database_path)
+        self._database_path = self._backend.database_path
+
+
+class SQLiteMemoryStore(_SQLiteBase):
+    """Persists memory atoms in SQLite as JSON payloads."""
+
+    def put(self, memory: MemoryAtom) -> None:
+        self.put_many((memory,))
+
+    def put_many(self, memories: tuple[MemoryAtom, ...]) -> None:
+        self._backend.put_memories(memories)
+
+    def get(self, memory_id: str) -> MemoryAtom | None:
+        return self._backend.get_memory(memory_id)
+
+    def list(self) -> tuple[MemoryAtom, ...]:
+        return self._backend.list_memories()
+
+
+class SQLiteGraphStore(_SQLiteBase):
+    """Persists graph edges and reads graph-backed memory state from SQLite."""
+
+    def upsert_memory(self, memory: MemoryAtom) -> None:
+        self._backend.put_memories((memory,))
+
+    def upsert_memories(self, memories: tuple[MemoryAtom, ...]) -> None:
+        self._backend.put_memories(memories)
+
+    def upsert_edge(self, edge: MemoryEdge) -> None:
+        self.upsert_edges((edge,))
+
+    def upsert_edges(self, edges: tuple[MemoryEdge, ...]) -> None:
+        self._backend.upsert_edges(edges)
+
+    def shares_memory_store(self, memory_store: MemoryStore) -> bool:
+        return (
+            isinstance(memory_store, SQLiteMemoryStore) and memory_store._backend is self._backend
+        )
+
+    def get_memory(self, memory_id: str) -> MemoryAtom | None:
+        return self._backend.get_memory(memory_id)
+
+    def neighbors(self, memory_id: str) -> tuple[MemoryEdge, ...]:
+        return self._backend.neighbors(memory_id)
+
+    def list_edges(self) -> tuple[MemoryEdge, ...]:
+        return self._backend.list_edges()

--- a/tests/integration/ingest/test_pipeline.py
+++ b/tests/integration/ingest/test_pipeline.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from datetime import datetime
 
 from cellin.core import Modality
 from cellin.ingest import ArtifactEnvelope, CanonicalIngestor
 from cellin.stores import InMemoryVectorIndex, SQLiteGraphStore, SQLiteMemoryStore
+from cellin.stores import sqlite as sqlite_module
 
 
 def _load_fixture() -> tuple[ArtifactEnvelope, ...]:
@@ -62,3 +64,29 @@ def test_ingestion_pipeline_persists_memories_edges_and_vectors(tmp_path) -> Non
     neighbors = graph_store.neighbors("text-1")
     assert neighbors
     assert neighbors[0].metadata["label"] == "atlas"
+
+
+def test_ingestion_pipeline_batches_sqlite_writes_for_shared_store(tmp_path, monkeypatch) -> None:
+    database_path = tmp_path / "cellin.sqlite"
+    graph_store = SQLiteGraphStore(str(database_path))
+    memory_store = SQLiteMemoryStore(str(database_path))
+    vector_index = InMemoryVectorIndex()
+    ingestor = CanonicalIngestor.with_built_in_adapters(
+        graph_store=graph_store,
+        memory_store=memory_store,
+        vector_index=vector_index,
+    )
+    connect_calls = 0
+    original_connect = sqlite3.connect
+
+    def counting_connect(*args, **kwargs):
+        nonlocal connect_calls
+        connect_calls += 1
+        return original_connect(*args, **kwargs)
+
+    monkeypatch.setattr(sqlite_module.sqlite3, "connect", counting_connect)
+
+    result = ingestor.ingest_envelopes(_load_fixture())
+
+    assert len(result.memories) == 4
+    assert connect_calls == 2


### PR DESCRIPTION
## Issue
The SQLite boundary duplicated memory persistence work on ingest and spread connection management across the graph and memory adapters.

## Cause and Impact
Ingest paid for repeated memory writes and excess SQLite connects on the hot path. The boundary also blurred ownership by having the graph adapter instantiate a fresh memory adapter for node persistence.

## Fix
Introduce a shared SQLite backend for memory and edge persistence, batch memory and edge writes on the ingest hot path, teach the ingestor to skip redundant graph-memory upserts when the graph and memory stores share backing storage, and add a regression that counts SQLite connect calls during ingest.

## Validation
- `make release-smoke`
