### PR TITLE
fix(cli): respect zero trace limit

### DIFF
--- a/src/cellin/cli/config.py
+++ b/src/cellin/cli/config.py
@@ -91,6 +91,8 @@ def append_trace(
 def read_traces(workspace: ResolvedWorkspace, *, limit: int) -> tuple[TraceEvent, ...]:
     """Read the last N trace events from the workspace trace log."""
 
+    if limit <= 0:
+        return ()
     if not workspace.trace_path.exists():
         return ()
 

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -91,3 +91,24 @@ def test_cli_version_flag(capsys: CaptureFixture[str]) -> None:
     assert excinfo.value.code == 0
     version_output = capsys.readouterr().out.strip()
     assert version_output.endswith(__version__)
+
+
+def test_trace_inspect_zero_and_negative_limits_emit_no_entries(
+    tmp_path: Path, capsys: CaptureFixture[str]
+) -> None:
+    workspace = tmp_path / "workspace"
+    config_path = workspace / "cellin.json"
+    input_path = _copy_example_input(tmp_path)
+
+    assert main(["init", "--workspace", str(workspace)]) == 0
+    capsys.readouterr()
+    assert main(["ingest", "--config", str(config_path), "--input", str(input_path)]) == 0
+    capsys.readouterr()
+
+    assert main(["trace", "inspect", "--config", str(config_path), "--limit", "0"]) == 0
+    zero_limit_output = capsys.readouterr().out
+    assert zero_limit_output.strip() == "no trace events recorded"
+
+    assert main(["trace", "inspect", "--config", str(config_path), "--limit", "-1"]) == 0
+    negative_limit_output = capsys.readouterr().out
+    assert negative_limit_output.strip() == "no trace events recorded"


### PR DESCRIPTION
## Issue
`trace inspect --limit 0` returned trace entries instead of none because the trace reader sliced with `lines[-0:]`, which is the full list.

## Cause and Impact
The CLI leaked more trace output than the caller requested. Negative values were also undefined and happened to behave like broad slices instead of an explicit empty result.

## Fix
Treat non-positive limits as a request for zero entries at the trace helper boundary and add CLI regression coverage for both `0` and negative limits.

## Validation
- `make release-smoke`
