### PR TITLE
fix(release): harden rolling release inputs

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -42,13 +42,15 @@ jobs:
 
       - name: Validate prerelease version
         id: version
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
         shell: bash
         run: |
           python -m uv run python scripts/release/verify_version.py \
-            --tag "v${{ inputs.version }}" \
-            --expect-version "${{ inputs.version }}" \
+            --tag "v${RELEASE_VERSION}" \
+            --expect-version "${RELEASE_VERSION}" \
             --release-kind prerelease
-          echo "package_version=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          echo "package_version=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Run release smoke
         run: make release-smoke


### PR DESCRIPTION
## Issue
Fixes #52.

## Cause and impact
The prerelease workflow expanded `inputs.version` directly inside a shell `run:` block. That left the rolling release path vulnerable to command injection from workflow-dispatch input.

## Root cause
The workflow mixed GitHub expression interpolation with shell evaluation in the same multi-line step.

## Fix
This change moves the dispatch version into a step-scoped environment variable and uses the shell variable inside the validation and output-propagation commands. The workflow behavior stays the same while removing the unsafe interpolation pattern.

## Validation
- custom scan confirming `.github/workflows/rolling-release.yml` no longer interpolates `${{ inputs.version }}` inside `run:` blocks
- `make release-smoke`
