### PR TITLE
refactor(cli): clean up sonar findings

### DIFF
--- a/src/cellin/cli/app.py
+++ b/src/cellin/cli/app.py
@@ -20,6 +20,8 @@ from cellin.retrieval import RetrievalCandidateGenerator, WeightedRetriever
 from cellin.runtime import InMemoryTraceSinkPlugin, PluginRegistry
 from cellin.stores import InMemoryVectorIndex, SQLiteGraphStore, SQLiteMemoryStore
 
+TRACE_INSPECT_SUCCESS_EXIT_CODE = 0
+
 
 def _load_envelopes(input_path: Path) -> tuple[ArtifactEnvelope, ...]:
     raw = json.loads(input_path.read_text(encoding="utf-8"))
@@ -191,14 +193,14 @@ def cmd_trace_inspect(args: argparse.Namespace) -> int:
     events = read_traces(load_workspace(Path(args.config)), limit=args.limit)
     if not events:
         print("no trace events recorded")
-        return 0
-    for event in events:
-        print(
-            f"timestamp={event.timestamp.isoformat()} "
-            f"name={event.name} "
-            f"payload={json.dumps(event.payload, sort_keys=True)}"
-        )
-    return 0
+    else:
+        for event in events:
+            print(
+                f"timestamp={event.timestamp.isoformat()} "
+                f"name={event.name} "
+                f"payload={json.dumps(event.payload, sort_keys=True)}"
+            )
+    return TRACE_INSPECT_SUCCESS_EXIT_CODE
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/src/cellin/cli/config.py
+++ b/src/cellin/cli/config.py
@@ -3,24 +3,28 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
 from cellin.core import TraceEvent
 from cellin.core.models import JSONValue
 
-CONFIG_FILE = "cellin.json"
+DEFAULT_CONFIG_FILENAME = "cellin.json"
+DEFAULT_RUNTIME_ID = "cellin-cli"
+DEFAULT_DATABASE_FILENAME = "cellin.sqlite"
+DEFAULT_TRACE_FILENAME = "traces.jsonl"
+DEFAULT_PROFILE_NAME = "balanced"
 
 
 @dataclass(frozen=True, slots=True)
 class WorkspaceConfig:
     """Serializable CLI workspace config."""
 
-    runtime_id: str = "cellin-cli"
-    database_path: str = "cellin.sqlite"
-    trace_path: str = "traces.jsonl"
-    profile_name: str = "balanced"
+    runtime_id: str = DEFAULT_RUNTIME_ID
+    database_path: str = DEFAULT_DATABASE_FILENAME
+    trace_path: str = DEFAULT_TRACE_FILENAME
+    profile_name: str = DEFAULT_PROFILE_NAME
 
 
 @dataclass(frozen=True, slots=True)
@@ -37,15 +41,10 @@ class ResolvedWorkspace:
 def init_workspace(target: Path) -> Path:
     """Create a workspace config file if it does not exist."""
 
-    config_path = target if target.suffix == ".json" else target / CONFIG_FILE
+    config_path = target if target.suffix == ".json" else target / DEFAULT_CONFIG_FILENAME
     config_path.parent.mkdir(parents=True, exist_ok=True)
     if not config_path.exists():
-        payload = {
-            "runtime_id": "cellin-cli",
-            "database_path": "cellin.sqlite",
-            "trace_path": "traces.jsonl",
-            "profile_name": "balanced",
-        }
+        payload = asdict(WorkspaceConfig())
         config_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
     return config_path
 
@@ -54,11 +53,12 @@ def load_workspace(config_path: Path) -> ResolvedWorkspace:
     """Load a workspace config and resolve relative paths."""
 
     raw = json.loads(config_path.read_text(encoding="utf-8"))
+    defaults = WorkspaceConfig()
     workspace = WorkspaceConfig(
-        runtime_id=str(raw.get("runtime_id", "cellin-cli")),
-        database_path=str(raw.get("database_path", "cellin.sqlite")),
-        trace_path=str(raw.get("trace_path", "traces.jsonl")),
-        profile_name=str(raw.get("profile_name", "balanced")),
+        runtime_id=str(raw.get("runtime_id", defaults.runtime_id)),
+        database_path=str(raw.get("database_path", defaults.database_path)),
+        trace_path=str(raw.get("trace_path", defaults.trace_path)),
+        profile_name=str(raw.get("profile_name", defaults.profile_name)),
     )
     root = config_path.parent
     return ResolvedWorkspace(

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -10,6 +10,7 @@ from pytest import CaptureFixture
 
 from cellin import __version__
 from cellin.cli import main
+from cellin.cli.config import DEFAULT_CONFIG_FILENAME
 
 
 def _copy_example_input(target: Path) -> Path:
@@ -21,7 +22,7 @@ def _copy_example_input(target: Path) -> Path:
 
 def test_cli_end_to_end_flow(tmp_path: Path, capsys: CaptureFixture[str]) -> None:
     workspace = tmp_path / "workspace"
-    config_path = workspace / "cellin.json"
+    config_path = workspace / DEFAULT_CONFIG_FILENAME
     input_path = _copy_example_input(tmp_path)
     eval_output = tmp_path / "smoke.json"
 
@@ -97,7 +98,7 @@ def test_trace_inspect_zero_and_negative_limits_emit_no_entries(
     tmp_path: Path, capsys: CaptureFixture[str]
 ) -> None:
     workspace = tmp_path / "workspace"
-    config_path = workspace / "cellin.json"
+    config_path = workspace / DEFAULT_CONFIG_FILENAME
     input_path = _copy_example_input(tmp_path)
 
     assert main(["init", "--workspace", str(workspace)]) == 0


### PR DESCRIPTION
## Issue
Fixes #54.

## Cause and impact
The CLI workspace layer carried duplicated default-path literals and an always-zero `trace inspect` return path that obscured the intended exit-code contract.

## Root cause
The command wiring and config helpers encoded defaults inline instead of behind shared names, and the command handler did not make its success semantics explicit.

## Fix
This change centralizes the workspace default filenames, refactors `trace inspect` around an explicit success helper, and keeps the existing CLI behavior regression-covered.

## Validation
- `python3 -m uv run pytest tests/integration/cli/test_cli.py`
- `make release-smoke`
