### PR TITLE
refactor(release): simplify prerelease tag validation

### DIFF
--- a/scripts/release/verify_version.py
+++ b/scripts/release/verify_version.py
@@ -87,7 +87,7 @@ def main() -> int:
     if args.tag is not None:
         if not args.tag.startswith("v"):
             raise ValueError(f"Tags must be prefixed with 'v', found {args.tag!r}")
-        if args.tag[1:] != version:
+        if args.tag.removeprefix("v") != version:
             raise ValueError(f"Tag {args.tag!r} does not match package version {version!r}")
 
     if args.print_version:


### PR DESCRIPTION
## Issue
Fixes #55.

## Cause and impact
The prerelease tag check in `verify_version.py` used an avoidable slice-based comparison. It worked, but it made the release validation path harder to read than necessary.

## Root cause
The comparison logic manually stripped the leading `v` instead of expressing the relationship more directly.

## Fix
This change rewrites the tag/version comparison in a clearer idiomatic form without changing the release validation behavior.

## Validation
- targeted `verify_version.py` command checks
- `make release-smoke`
