### PR TITLE
refactor(runtime): simplify plugin instantiation

### DIFF
--- a/src/cellin/runtime/registry.py
+++ b/src/cellin/runtime/registry.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from importlib import metadata
 from typing import cast
 
@@ -23,12 +23,10 @@ def _ensure_plugin(candidate: object) -> Plugin:
 
 
 def _instantiate_plugin(loaded: object) -> Plugin:
-    candidate = loaded
-
-    if isinstance(loaded, type):
-        candidate = loaded()
-    elif callable(loaded) and not hasattr(loaded, "manifest"):
-        candidate = loaded()
+    should_instantiate = isinstance(loaded, type) or (
+        callable(loaded) and not hasattr(loaded, "manifest")
+    )
+    candidate = cast(Callable[[], object], loaded)() if should_instantiate else loaded
 
     return _ensure_plugin(candidate)
 

--- a/tests/contracts/test_registry.py
+++ b/tests/contracts/test_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 import pytest
@@ -55,9 +56,10 @@ class FakeEntryPoint:
 
     name: str
     group: str
+    loaded: object = InMemoryTraceSinkPlugin
 
-    def load(self) -> type[InMemoryTraceSinkPlugin]:
-        return InMemoryTraceSinkPlugin
+    def load(self) -> object:
+        return self.loaded
 
 
 class FakeEntryPoints(list[FakeEntryPoint]):
@@ -67,9 +69,35 @@ class FakeEntryPoints(list[FakeEntryPoint]):
         return [entry_point for entry_point in self if entry_point.group == group]
 
 
-def test_registry_loads_plugins_from_entry_points(monkeypatch: pytest.MonkeyPatch) -> None:
+def _class_entry_point_target() -> object:
+    return InMemoryTraceSinkPlugin
+
+
+def _factory_entry_point_target() -> object:
+    return lambda: InMemoryTraceSinkPlugin()
+
+
+def _instance_entry_point_target() -> object:
+    return InMemoryTraceSinkPlugin()
+
+
+@pytest.mark.parametrize(
+    "target_factory",
+    (
+        _class_entry_point_target,
+        _factory_entry_point_target,
+        _instance_entry_point_target,
+    ),
+    ids=("class", "factory", "instance"),
+)
+def test_registry_loads_plugins_from_entry_points(
+    monkeypatch: pytest.MonkeyPatch, target_factory: Callable[[], object]
+) -> None:
     def fake_entry_points() -> FakeEntryPoints:
-        return FakeEntryPoints([FakeEntryPoint(name="trace", group="cellin.plugins")])
+        loaded = target_factory()
+        return FakeEntryPoints(
+            [FakeEntryPoint(name="trace", group="cellin.plugins", loaded=loaded)]
+        )
 
     monkeypatch.setattr("cellin.runtime.registry.metadata.entry_points", fake_entry_points)
 


### PR DESCRIPTION
## Issue
Fixes #58.

## Cause and impact
The runtime registry had duplicate plugin-instantiation branches that implied distinct behavior where there was none. That blurred the extension boundary in a core runtime path.

## Root cause
Class and factory-callable loading paths duplicated the same instantiation logic.

## Fix
This change collapses the duplicate branches into one instantiation decision while keeping validation and plugin-loading behavior intact. The registry contract tests now cover class, factory, and pre-instantiated plugin entry points directly.

## Validation
- `python3 -m uv run pytest tests/contracts/test_registry.py`
- `make release-smoke`
