### PR TITLE
fix(release): align release-please tag config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "32ab53bac5c57f5b925dbe60fd414dcb6634b34f",
+  "include-component-in-tag": false,
   "skip-labeling": true,
   "packages": {
     ".": {


### PR DESCRIPTION
## Issue
Release automation was still treating this repo as if tags were component-prefixed, even though the stable publish workflow and the existing public tags use plain `vX.Y.Z` tags.

## Cause and impact
`release-please` v4 manifest mode reads advanced options from `release-please-config.json`, not from action inputs. Because the manifest config did not carry `include-component-in-tag: false`, the workflow looked for `cellin-v0.2.0`, failed to find the actual `v0.2.0` release lineage, and opened the wrong follow-up PR.

## Root cause
The tag-shape option lived only in action-level defaults instead of the manifest configuration that release-please uses for advanced settings.

## Fix
This change pins `include-component-in-tag` to `false` in `release-please-config.json` so release-please aligns with the repo's plain `vX.Y.Z` tags and the existing release workflow.

## Validation
- `make release-smoke`
- verified the release-please run log was searching for `cellin-v0.2.0` before this fix
