### PR TITLE
fix(release): label release prs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,4 +34,3 @@ jobs:
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          skip-labeling: true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "bootstrap-sha": "32ab53bac5c57f5b925dbe60fd414dcb6634b34f",
   "include-component-in-tag": false,
-  "skip-labeling": true,
+  "release-label": "release",
   "packages": {
     ".": {
       "release-type": "python",


### PR DESCRIPTION
## Issue
Release PRs were not receiving any dedicated release label.

## Cause and impact
The repo had disabled release-please labeling globally, so automated release PRs like `#68` opened without a release-specific tag and needed manual cleanup.

## Root cause
Both the workflow input and manifest config were opting into `skip-labeling`, which bypassed release-please's release-PR label support entirely.

## Fix
This change removes the global skip-labeling opt-out and configures release-please to apply the `release` label to release PRs. It also adds the `release` label on GitHub and applies it to the already-open release PR `#68`.

## Validation
- `python3 -m json.tool release-please-config.json`
- YAML parse for `.github/workflows/release-please.yml`
- `make release-smoke`
