### PR TITLE
docs(readme): show release status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cellin
 
-[![PyPI](https://img.shields.io/pypi/v/cellin)](https://pypi.org/project/cellin/)
-[![Release](https://img.shields.io/github/v/release/ben-ranford/cellin)](https://github.com/ben-ranford/cellin/releases)
+[![PyPI Version](https://img.shields.io/pypi/v/cellin)](https://pypi.org/project/cellin/)
+[![Release Passing](https://github.com/ben-ranford/cellin/actions/workflows/release.yml/badge.svg)](https://github.com/ben-ranford/cellin/actions/workflows/release.yml)
 
 Cellin builds long-lived multimodal memory, dreams over it to consolidate ideas, and
 retrieves context with transparent weighted ranking.


### PR DESCRIPTION
## Issue
The README already showed the package version, but it did not show whether the stable release workflow was currently healthy.

## Cause and impact
The badge block used a GitHub release-version badge instead of the release workflow status, so readers could see the latest tag but not whether release automation was currently passing.

## Fix
This change keeps the PyPI version badge and swaps the release-version badge for the stable release workflow status badge.

## Validation
- `make release-smoke`
