### PR TITLE
docs(contributing): explain release-please changelog inputs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,9 @@ Generated artifacts such as `eval-results/`, `dist/`, and `site/` should not be 
 2. Keep work scoped to one issue stream.
 3. Add or update tests, eval fixtures, docs, and starter examples when behavior changes.
 4. Use Conventional Commits for commit messages and PR titles. Stable release automation derives semver bumps from `fix:`, `feat:`, and `BREAKING CHANGE` markers.
-5. Run `make release-smoke` before pushing.
-6. Open a draft PR until the stream is ready for review.
+5. When squashing or merging, keep the final commit title in Conventional Commit form. `release-please` builds release PR notes from merged commit titles on `main`, not from GitHub labels, and non-conventional titles may be dropped from the generated changelog.
+6. Run `make release-smoke` before pushing.
+7. Open a draft PR until the stream is ready for review.
 
 ## Quality Gates
 
@@ -65,6 +66,7 @@ python3 -m uv run lefthook run pre-commit
 
 - Stable releases are initiated by `release-please` from merged conventional commits on `main`.
 - Release PRs carry the version bump, changelog update, and tag metadata for the next stable cut.
+- Release PR summaries are grouped from parsed Conventional Commit types such as `feat`, `fix`, `docs`, `refactor`, and `perf`. Issue labels like `bug`, `retrieval`, or `release-candidate` do not drive those sections.
 - Prerelease versions use PEP 440 syntax such as `0.2.0rc1`.
 - Manual prereleases are created through the GitHub Actions `rolling-release` workflow.
 - Run `make version-check` when you change the package version or prepare a release branch.


### PR DESCRIPTION
## Issue
Contributors did not have clear guidance on why release-please sometimes omits work from generated release PR summaries.

## Cause and impact
The docs explained that Conventional Commits drive semver bumps, but they did not make it explicit that release-please builds changelog sections from merged commit titles on `main`, not from GitHub labels. That made the generated release PR body look arbitrary when non-conventional squash titles were used.

## Fix
This change updates `CONTRIBUTING.md` to explain:
- the final squash or merge title must stay in Conventional Commit form
- release-please derives release PR summaries from parsed commit types on `main`
- GitHub labels do not drive those changelog sections

## Validation
- `make release-smoke`
