### PR TITLE
feat(release): automate rolling dev previews

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -1,22 +1,26 @@
 name: rolling-release
 
 "on":
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       version:
-        description: "PEP 440 prerelease version without the leading v, for example 0.2.0rc1"
-        required: true
+        description: "Manual release-candidate version without the leading v, for example 0.2.1rc1"
+        required: false
       target_ref:
-        description: "Git ref to publish from when cutting a prerelease"
+        description: "Git ref to publish from when cutting a manual release candidate"
         required: false
         default: "main"
 
 concurrency:
-  group: rolling-release-${{ inputs.version }}
+  group: rolling-release-${{ github.workflow }}-${{ github.run_id }}
   cancel-in-progress: false
 
 jobs:
   build-prerelease:
+    if: "${{ github.event_name != 'push' || !startsWith(github.event.head_commit.message, 'chore(main): release ') }}"
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -27,7 +31,7 @@ jobs:
       - name: Checkout target ref
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.target_ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.target_ref || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -40,17 +44,30 @@ jobs:
       - name: Sync dependencies
         run: python -m uv sync --dev --frozen
 
-      - name: Validate prerelease version
+      - name: Resolve package version
         id: version
-        env:
-          RELEASE_VERSION: ${{ inputs.version }}
         shell: bash
         run: |
-          python -m uv run python scripts/release/verify_version.py \
-            --tag "v${RELEASE_VERSION}" \
-            --expect-version "${RELEASE_VERSION}" \
-            --release-kind prerelease
-          echo "package_version=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            resolved_version="$(python -m uv run python scripts/release/resolve_preview_version.py \
+              --run-id "${GITHUB_RUN_ID}" \
+              --run-attempt "${GITHUB_RUN_ATTEMPT}")"
+            python -m uv run python scripts/release/set_version.py --version "${resolved_version}"
+            python -m uv run python scripts/release/verify_version.py \
+              --expect-version "${resolved_version}" \
+              --release-kind preview
+          else
+            resolved_version="${{ inputs.version }}"
+            if [ -z "${resolved_version}" ]; then
+              echo "workflow_dispatch requires a release-candidate version input" >&2
+              exit 1
+            fi
+            python -m uv run python scripts/release/verify_version.py \
+              --tag "v${resolved_version}" \
+              --expect-version "${resolved_version}" \
+              --release-kind prerelease
+          fi
+          echo "package_version=${resolved_version}" >> "$GITHUB_OUTPUT"
 
       - name: Run release smoke
         run: make release-smoke
@@ -62,7 +79,7 @@ jobs:
       - name: Upload Python distributions
         uses: actions/upload-artifact@v7
         with:
-          name: python-dist-v${{ inputs.version }}
+          name: python-dist-v${{ steps.version.outputs.package_version }}
           path: |
             dist/*.tar.gz
             dist/*.whl
@@ -70,7 +87,7 @@ jobs:
       - name: Upload rolling release bundle
         uses: actions/upload-artifact@v7
         with:
-          name: rolling-release-v${{ inputs.version }}
+          name: rolling-release-v${{ steps.version.outputs.package_version }}
           path: dist/*
 
   publish-github-prerelease:
@@ -82,16 +99,22 @@ jobs:
       - name: Download rolling release bundle
         uses: actions/download-artifact@v8
         with:
-          name: rolling-release-v${{ inputs.version }}
+          name: rolling-release-v${{ needs.build-prerelease.outputs.package_version }}
           path: dist
 
       - name: Publish rolling prerelease
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: v${{ inputs.version }}
-          TARGET_REF: ${{ inputs.target_ref }}
+          REPO: ${{ github.repository }}
+          TAG: v${{ needs.build-prerelease.outputs.package_version }}
+          TARGET_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.target_ref || github.sha }}
         shell: bash
-        run: gh release create "$TAG" dist/* --title "$TAG" --generate-notes --target "$TARGET_REF" --prerelease
+        run: |
+          if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
+            gh release upload "$TAG" dist/* --repo "$REPO" --clobber
+          else
+            gh release create "$TAG" dist/* --repo "$REPO" --title "$TAG" --generate-notes --target "$TARGET_REF" --prerelease
+          fi
 
   publish-pypi-prerelease:
     needs: build-prerelease
@@ -105,7 +128,7 @@ jobs:
       - name: Download Python distributions
         uses: actions/download-artifact@v8
         with:
-          name: python-dist-v${{ inputs.version }}
+          name: python-dist-v${{ needs.build-prerelease.outputs.package_version }}
           path: dist
 
       - name: Publish prerelease distributions to PyPI

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,8 +36,9 @@ Generated artifacts such as `eval-results/`, `dist/`, and `site/` should not be 
 3. Add or update tests, eval fixtures, docs, and starter examples when behavior changes.
 4. Use Conventional Commits for commit messages and PR titles. Stable release automation derives semver bumps from `fix:`, `feat:`, and `BREAKING CHANGE` markers.
 5. When squashing or merging, keep the final commit title in Conventional Commit form. `release-please` builds release PR notes from merged commit titles on `main`, not from GitHub labels, and non-conventional titles may be dropped from the generated changelog.
-6. Run `make release-smoke` before pushing.
-7. Open a draft PR until the stream is ready for review.
+6. Every push to `main` publishes a rolling preview build from `.github/workflows/rolling-release.yml`. If a merge should not create a preview version, it should not land on `main`.
+7. Run `make release-smoke` before pushing.
+8. Open a draft PR until the stream is ready for review.
 
 ## Quality Gates
 
@@ -65,10 +66,12 @@ python3 -m uv run lefthook run pre-commit
 ## Release Workflow
 
 - Stable releases are initiated by `release-please` from merged conventional commits on `main`.
+- Pushes to `main` automatically publish `.devN` preview builds from the next inferred stable version.
 - Release PRs carry the version bump, changelog update, and tag metadata for the next stable cut.
 - Release PR summaries are grouped from parsed Conventional Commit types such as `feat`, `fix`, `docs`, `refactor`, and `perf`. Issue labels like `bug`, `retrieval`, or `release-candidate` do not drive those sections.
-- Prerelease versions use PEP 440 syntax such as `0.2.0rc1`.
-- Manual prereleases are created through the GitHub Actions `rolling-release` workflow.
+- Preview versions use PEP 440 development syntax such as `0.2.1.dev123456701`.
+- Release-candidate versions use PEP 440 syntax such as `0.2.1rc1`.
+- Manual release candidates are created through the GitHub Actions `rolling-release` workflow.
 - Run `make version-check` when you change the package version or prepare a release branch.
 - Run `make release-smoke` before you cut or approve a release-related change.
 - Use `RELEASING.md` for the stable release PR flow, trusted publishing setup, token requirements, and artifact expectations.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,11 +1,11 @@
 # Releasing
 
-Cellin uses a semver library release model with an automated stable channel and a manual prerelease channel.
+Cellin uses a semver library release model with an automated stable channel, an automated rolling preview channel, and a manual release-candidate channel.
 
 ## Planning
 
 - Delivery planning stays on the calendar milestone train, for example `2026-04`.
-- Git tags use `vX.Y.Z` for stable releases and `vX.Y.ZrcN`, `vX.Y.ZbN`, or `vX.Y.ZaN` for prereleases.
+- Git tags use `vX.Y.Z` for stable releases, `vX.Y.Z.devN` for rolling previews, and `vX.Y.ZrcN` for manual release candidates.
 - Python package versions use the same value without the leading `v`.
 - Use `release-candidate` for work intended for the next cut and `release-blocker` for issues that must land before a stable release.
 - Stable semver increments are inferred from Conventional Commit types in merged PR titles and commits:
@@ -37,14 +37,25 @@ Stable library releases are managed by `release-please` and publish to both GitH
 
 If `v0.1.1` has not been published yet, cut that bootstrap release manually before relying on `release-please` for the next stable version.
 
-## Prerelease Path
+## Rolling Preview Path
 
-Prereleases are workflow-dispatch driven through `.github/workflows/rolling-release.yml`.
+Rolling previews are triggered automatically by pushes to `main` through `.github/workflows/rolling-release.yml`.
 
-1. Commit a prerelease package version such as `0.2.0rc1` on the target branch or release branch.
+1. Merge a change to `main`.
+2. The rolling-release workflow skips stable release commits from `release-please`, then resolves the latest stable tag plus the merged commit history into the next preview base version.
+3. The workflow stamps a unique PEP 440 development version such as `0.2.1.dev123456701` into the checkout for that run only.
+4. It runs `make release-smoke`, publishes a GitHub prerelease tagged `vX.Y.Z.devN`, and uploads the package to PyPI through the `pypi-prerelease` environment.
+
+Rolling previews intentionally do not change `src/cellin/__about__.py` on `main`; the committed version remains the stable line that `release-please` manages.
+
+## Release-Candidate Path
+
+Release candidates are workflow-dispatch driven through `.github/workflows/rolling-release.yml`.
+
+1. Commit a release-candidate package version such as `0.2.1rc1` on a release branch or other target ref.
 2. Open the `rolling-release` workflow in GitHub Actions.
-3. Provide the same prerelease version without the leading `v`, for example `0.2.0rc1`.
-4. Provide the `target_ref` to release from, usually `main` or a release branch.
+3. Provide the same candidate version without the leading `v`, for example `0.2.1rc1`.
+4. Provide the `target_ref` to release from.
 5. The workflow validates that the input matches the committed package version, then publishes a GitHub prerelease and the package distributions to PyPI.
 
 ## Trusted Publishing Setup
@@ -70,7 +81,7 @@ Configure these trusted publishers on PyPI before the first live publish:
   - repository: `ben-ranford/cellin`
   - workflow: `.github/workflows/release.yml`
   - environment: `pypi`
-- prerelease publisher:
+- preview and release-candidate publisher:
   - repository: `ben-ranford/cellin`
   - workflow: `.github/workflows/rolling-release.yml`
   - environment: `pypi-prerelease`

--- a/scripts/release/_versioning.py
+++ b/scripts/release/_versioning.py
@@ -1,0 +1,132 @@
+"""Shared release versioning helpers for CI scripts."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Literal
+
+VERSION_VALUE_PATTERN = r"\d+\.\d+\.\d+(?:(?:a|b|rc)\d+|\.dev\d+)?"
+VERSION_ASSIGNMENT_PATTERN = re.compile(
+    rf'^(?P<prefix>__version__\s*=\s*")(?P<version>{VERSION_VALUE_PATTERN})(?P<suffix>"(?:\s*#.*)?)$',
+    re.MULTILINE,
+)
+VERSION_BASE_PATTERN = re.compile(r"^(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)")
+STABLE_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
+PRERELEASE_PATTERN = re.compile(r"^\d+\.\d+\.\d+(?:a|b|rc)\d+$")
+PREVIEW_PATTERN = re.compile(r"^\d+\.\d+\.\d+\.dev\d+$")
+CONVENTIONAL_PATTERN = re.compile(r"^(?P<type>[a-z]+)(?:\([^)]+\))?(?P<breaking>!)?:")
+
+Bump = Literal["patch", "minor", "major"]
+ReleaseKind = Literal["stable", "prerelease", "preview"]
+
+
+@dataclass(frozen=True)
+class CommitMessage:
+    """Minimal commit message payload used for version inference."""
+
+    subject: str
+    body: str = ""
+
+
+def load_assigned_version(text: str) -> str:
+    """Extract the package version from a module source string."""
+
+    match = VERSION_ASSIGNMENT_PATTERN.search(text)
+    if match is None:
+        raise ValueError("Unable to locate __version__ assignment")
+    return match.group("version")
+
+
+def replace_assigned_version(text: str, version: str) -> str:
+    """Replace the package version while preserving inline comments."""
+
+    validate_version(version)
+    match = VERSION_ASSIGNMENT_PATTERN.search(text)
+    if match is None:
+        raise ValueError("Unable to locate __version__ assignment")
+    return VERSION_ASSIGNMENT_PATTERN.sub(
+        f"{match.group('prefix')}{version}{match.group('suffix')}",
+        text,
+        count=1,
+    )
+
+
+def validate_version(version: str) -> None:
+    """Reject version strings that are outside the supported release model."""
+
+    if not (
+        STABLE_PATTERN.fullmatch(version)
+        or PRERELEASE_PATTERN.fullmatch(version)
+        or PREVIEW_PATTERN.fullmatch(version)
+    ):
+        raise ValueError("Versions must use X.Y.Z, X.Y.ZrcN/X.Y.ZbN/X.Y.ZaN, or X.Y.Z.devN")
+
+
+def validate_release_kind(version: str, release_kind: ReleaseKind) -> None:
+    """Validate a version against one of Cellin's release channels."""
+
+    validate_version(version)
+    if release_kind == "stable" and STABLE_PATTERN.fullmatch(version) is None:
+        raise ValueError(f"Stable releases must use X.Y.Z, found {version!r}")
+    if release_kind == "prerelease" and PRERELEASE_PATTERN.fullmatch(version) is None:
+        raise ValueError(
+            "Prereleases must use PEP 440 prerelease versions like X.Y.ZrcN, X.Y.ZbN, or X.Y.ZaN"
+        )
+    if release_kind == "preview" and PREVIEW_PATTERN.fullmatch(version) is None:
+        raise ValueError("Preview releases must use PEP 440 development versions like X.Y.Z.devN")
+
+
+def stable_base_version(version: str) -> str:
+    """Return the stable base triple for any supported version string."""
+
+    validate_version(version)
+    match = VERSION_BASE_PATTERN.match(version)
+    if match is None:
+        raise ValueError(f"Unable to derive a stable base from {version!r}")
+    return ".".join((match.group("major"), match.group("minor"), match.group("patch")))
+
+
+def bump_stable_version(version: str, bump: Bump) -> str:
+    """Increment a stable semver triple by the requested bump type."""
+
+    if STABLE_PATTERN.fullmatch(version) is None:
+        raise ValueError(f"Expected a stable version, found {version!r}")
+    major, minor, patch = (int(part) for part in version.split("."))
+    if bump == "major":
+        return f"{major + 1}.0.0"
+    if bump == "minor":
+        return f"{major}.{minor + 1}.0"
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def infer_semver_bump(commits: Iterable[CommitMessage]) -> Bump:
+    """Mirror the repo's release-please bump policy for preview builds."""
+
+    highest: Bump = "patch"
+    for commit in commits:
+        subject = commit.subject.strip()
+        body = commit.body
+        match = CONVENTIONAL_PATTERN.match(subject)
+        if "BREAKING CHANGE:" in body or (match is not None and match.group("breaking") == "!"):
+            return "major"
+        if match is not None and match.group("type") == "feat":
+            highest = "minor"
+    return highest
+
+
+def derive_preview_base_version(stable_version: str, commits: Iterable[CommitMessage]) -> str:
+    """Return the next preview base version after the latest stable cut."""
+
+    return bump_stable_version(stable_version, infer_semver_bump(commits))
+
+
+def build_preview_version(base_version: str, build_id: str) -> str:
+    """Render a unique development release version."""
+
+    if STABLE_PATTERN.fullmatch(base_version) is None:
+        raise ValueError(f"Expected a stable preview base version, found {base_version!r}")
+    if not build_id.isdigit():
+        raise ValueError(f"Preview build ids must be numeric, found {build_id!r}")
+    return f"{base_version}.dev{build_id}"

--- a/scripts/release/resolve_preview_version.py
+++ b/scripts/release/resolve_preview_version.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Resolve the next rolling preview version for the current Git ref."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+from _versioning import (
+    CommitMessage,
+    build_preview_version,
+    derive_preview_base_version,
+    load_assigned_version,
+    stable_base_version,
+)
+
+
+def _git(*args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _latest_stable_tag(ref: str) -> str | None:
+    tags = _git("tag", "--merged", ref, "--sort=-v:refname", "--list", "v[0-9]*.[0-9]*.[0-9]*")
+    if not tags:
+        return None
+    return tags.splitlines()[0]
+
+
+def _commit_messages(revision_range: str) -> list[CommitMessage]:
+    raw_log = _git("log", "--format=%s%x1f%b%x1e", revision_range)
+    messages: list[CommitMessage] = []
+    for record in raw_log.split("\x1e"):
+        if not record.strip():
+            continue
+        subject, _, body = record.partition("\x1f")
+        messages.append(CommitMessage(subject=subject.strip(), body=body.strip()))
+    return messages
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Resolve Cellin's rolling preview version.")
+    parser.add_argument(
+        "--run-id", required=True, help="GitHub run id or other numeric build identifier"
+    )
+    parser.add_argument(
+        "--run-attempt", default="1", help="GitHub run attempt for rerun uniqueness"
+    )
+    parser.add_argument("--ref", default="HEAD", help="Git ref to resolve from")
+    parser.add_argument(
+        "--version-path",
+        default="src/cellin/__about__.py",
+        help="Path to the checked-in version source file",
+    )
+    args = parser.parse_args()
+
+    build_id = f"{args.run_id}{int(args.run_attempt):02d}"
+    stable_tag = _latest_stable_tag(args.ref)
+    if stable_tag is None:
+        current_version = load_assigned_version(Path(args.version_path).read_text(encoding="utf-8"))
+        stable_version = stable_base_version(current_version)
+        commits = _commit_messages(args.ref)
+    else:
+        stable_version = stable_tag.removeprefix("v")
+        commits = _commit_messages(f"{stable_tag}..{args.ref}")
+
+    preview_base = derive_preview_base_version(stable_version, commits)
+    print(build_preview_version(preview_base, build_id))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/set_version.py
+++ b/scripts/release/set_version.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Rewrite Cellin's single-source version file."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from _versioning import replace_assigned_version
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Set the Cellin package version in-place.")
+    parser.add_argument("--version", required=True, help="Target version string")
+    parser.add_argument(
+        "--version-path",
+        default="src/cellin/__about__.py",
+        help="Path to the version source file",
+    )
+    args = parser.parse_args()
+
+    version_path = Path(args.version_path)
+    updated = replace_assigned_version(version_path.read_text(encoding="utf-8"), args.version)
+    version_path.write_text(updated, encoding="utf-8")
+    print(f"version={args.version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/release/verify_version.py
+++ b/scripts/release/verify_version.py
@@ -4,24 +4,15 @@
 from __future__ import annotations
 
 import argparse
-import re
 import sys
 import tomllib
 from pathlib import Path
 
-VERSION_PATTERN = re.compile(
-    r'^__version__\s*=\s*"(?P<version>\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?)"(?:\s*#.*)?\s*$',
-    re.MULTILINE,
-)
-STABLE_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
-PRERELEASE_PATTERN = re.compile(r"^\d+\.\d+\.\d+(?:a|b|rc)\d+$")
+from _versioning import load_assigned_version, validate_release_kind
 
 
 def load_version(version_path: Path) -> str:
-    match = VERSION_PATTERN.search(version_path.read_text(encoding="utf-8"))
-    if match is None:
-        raise ValueError(f"Unable to locate __version__ in {version_path}")
-    return match.group("version")
+    return load_assigned_version(version_path.read_text(encoding="utf-8"))
 
 
 def validate_pyproject(pyproject_path: Path, version_path: str) -> None:
@@ -38,24 +29,15 @@ def validate_pyproject(pyproject_path: Path, version_path: str) -> None:
         )
 
 
-def validate_release_kind(version: str, release_kind: str) -> None:
-    if release_kind == "stable" and STABLE_PATTERN.fullmatch(version) is None:
-        raise ValueError(f"Stable releases must use X.Y.Z, found {version!r}")
-    if release_kind == "prerelease" and PRERELEASE_PATTERN.fullmatch(version) is None:
-        raise ValueError(
-            "Prereleases must use PEP 440 prerelease versions like X.Y.ZrcN, X.Y.ZbN, or X.Y.ZaN"
-        )
-
-
 def main() -> int:
     parser = argparse.ArgumentParser(description="Validate the Cellin package version surface.")
     parser.add_argument("--tag", help="Git tag to compare against, for example v0.1.0")
     parser.add_argument("--expect-version", help="Expected package version")
     parser.add_argument(
         "--release-kind",
-        choices=("any", "stable", "prerelease"),
+        choices=("any", "stable", "prerelease", "preview"),
         default="any",
-        help="Validate stable or prerelease policy",
+        help="Validate stable, prerelease, or preview release policy",
     )
     parser.add_argument(
         "--version-path",

--- a/tests/unit/test_release_versioning.py
+++ b/tests/unit/test_release_versioning.py
@@ -1,0 +1,72 @@
+"""Unit tests for release version derivation helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _load_module():
+    module_path = Path(__file__).resolve().parents[2] / "scripts" / "release" / "_versioning.py"
+    spec = importlib.util.spec_from_file_location("cellin_release_versioning", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load release versioning helpers")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+release_versioning = _load_module()
+CommitMessage = release_versioning.CommitMessage
+
+
+def test_replace_assigned_version_preserves_inline_comment() -> None:
+    source = '__version__ = "0.2.0"  # x-release-please-version\n'
+
+    updated = release_versioning.replace_assigned_version(source, "0.2.1.dev42")
+
+    assert updated == '__version__ = "0.2.1.dev42"  # x-release-please-version\n'
+
+
+@pytest.mark.parametrize(
+    ("commits", "expected"),
+    (
+        ([CommitMessage(subject="fix(retrieval): enforce token budget")], "0.2.1"),
+        ([CommitMessage(subject="feat(runtime): add preview lane")], "0.3.0"),
+        (
+            [
+                CommitMessage(subject="fix(retrieval): enforce token budget"),
+                CommitMessage(subject="feat(runtime): add preview lane"),
+            ],
+            "0.3.0",
+        ),
+        ([CommitMessage(subject="feat(runtime)!: break plugin API")], "1.0.0"),
+        ([CommitMessage(subject="docs(readme): refresh install docs")], "0.2.1"),
+    ),
+)
+def test_derive_preview_base_version_matches_repo_bump_policy(
+    commits: list[object], expected: str
+) -> None:
+    assert release_versioning.derive_preview_base_version("0.2.0", commits) == expected
+
+
+def test_infer_semver_bump_recognizes_breaking_change_in_body() -> None:
+    commit = CommitMessage(
+        subject="refactor(runtime): simplify plugin API",
+        body="BREAKING CHANGE: plugin constructors now require settings",
+    )
+
+    assert release_versioning.infer_semver_bump([commit]) == "major"
+
+
+def test_build_preview_version_uses_numeric_build_identifier() -> None:
+    assert release_versioning.build_preview_version("0.2.1", "1234501") == "0.2.1.dev1234501"
+
+
+def test_build_preview_version_rejects_non_numeric_build_identifier() -> None:
+    with pytest.raises(ValueError, match="numeric"):
+        release_versioning.build_preview_version("0.2.1", "run-42")


### PR DESCRIPTION
## Issue

`rolling-release` only ran on manual dispatch, so `main` had no continuous preview channel between stable `release-please` cuts.

## Cause and user impact

The workflow assumed a prerelease version was already committed and supplied manually. That meant normal merges to `main` never produced preview artifacts on GitHub Releases or PyPI, even when the branch had moved ahead of the last stable tag.

## Root cause

The release model coupled prerelease publishing to the checked-in package version in `src/cellin/__about__.py`, which stays pinned to the latest stable version until `release-please` lands the next stable bump. Without a derived preview version, push-triggered prereleases would either collide on version numbers or publish the wrong series.

## Fix

This change adds a shared release-versioning helper, a preview-version resolver, and an in-place CI version stamper. `rolling-release` now triggers on every push to `main`, skips stable `release-please` merge commits, derives the next preview base from commits since the latest stable tag, stamps a unique `.devN` version for that run, validates it, and publishes the preview artifacts. Manual workflow dispatch remains available for deliberate release-candidate cuts from a branch that already carries an `rc` version.

The docs in `RELEASING.md` and `CONTRIBUTING.md` are updated to reflect the stable vs preview vs manual release-candidate split, and a new unit test file covers the preview version inference helpers.

## Validation

- `make release-smoke`
- `python3 -m uv run python scripts/release/resolve_preview_version.py --run-id 1234567 --run-attempt 2`
- `python3 -m uv run python - <<'PY' ... set_version + verify_version preview rehearsal ... PY`
- YAML parse of `.github/workflows/rolling-release.yml`
