### PR TITLE
fix(release): refresh preview metadata after version stamp

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -53,6 +53,7 @@ jobs:
               --run-id "${GITHUB_RUN_ID}" \
               --run-attempt "${GITHUB_RUN_ATTEMPT}")"
             python -m uv run python scripts/release/set_version.py --version "${resolved_version}"
+            python -m uv pip install --python .venv/bin/python --reinstall -e .
             python -m uv run python scripts/release/verify_version.py \
               --expect-version "${resolved_version}" \
               --release-kind preview


### PR DESCRIPTION
## Issue

The first automatic rolling preview run on `main` failed immediately after `#82` landed.

## Cause and user impact

The workflow correctly stamped a `.devN` version into `src/cellin/__about__.py`, but the editable install metadata in `.venv` still reflected the old stable package version. That made `tests/unit/test_package.py` fail inside the preview pipeline, so no GitHub prerelease or PyPI preview was published.

## Root cause

`python -m uv sync --dev --frozen` had already installed the project before the preview version rewrite. Rewriting the version file alone does not refresh the installed metadata that `importlib.metadata.version("cellin")` reads during tests.

## Fix

After stamping the preview version, the workflow now explicitly reinstalls the editable package into `.venv` with `uv pip install --python .venv/bin/python --reinstall -e .` before running preview validation and `make release-smoke`.

## Validation

- `make release-smoke`
- local rehearsal of `set_version -> uv pip install --reinstall -e . -> pytest tests/unit/test_package.py`
- YAML parse of `.github/workflows/rolling-release.yml`
