### PR TITLE
fix(release): fetch full history for previews

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -32,6 +32,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.target_ref || github.sha }}
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
## Issue

The first successful rolling preview publish created `v0.2.1.dev...` on GitHub, but `release-please` is currently targeting `0.3.0`.

## Cause and user impact

The preview resolver infers its base version from the commit range since the latest stable tag. In CI, `actions/checkout` was still using a shallow clone, so the workflow only saw the head fix commit instead of the full commit history since `v0.2.0`. That caused preview versions to drift from the stable semver lane that `release-please` is preparing.

## Root cause

`.github/workflows/rolling-release.yml` checked out `github.sha` without `fetch-depth: 0`, which is incompatible with history-based version inference.

## Fix

Fetch the full history for the rolling preview workflow so preview version derivation can see the full range of conventional commits and tags.

## Validation

- `make release-smoke`
- local `scripts/release/resolve_preview_version.py --run-id 1 --run-attempt 1` returns `0.3.0.dev101` on full history
- YAML parse of `.github/workflows/rolling-release.yml`
