### PR TITLE
fix(release): ignore prerelease tags in preview base

### DIFF
--- a/scripts/release/_versioning.py
+++ b/scripts/release/_versioning.py
@@ -78,6 +78,21 @@ def validate_release_kind(version: str, release_kind: ReleaseKind) -> None:
         raise ValueError("Preview releases must use PEP 440 development versions like X.Y.Z.devN")
 
 
+def is_stable_tag(tag: str) -> bool:
+    """Return whether a Git tag matches Cellin's stable tag shape."""
+
+    return tag.startswith("v") and STABLE_PATTERN.fullmatch(tag.removeprefix("v")) is not None
+
+
+def select_latest_stable_tag(tags: Iterable[str]) -> str | None:
+    """Pick the most recent stable tag from an already sorted tag list."""
+
+    for tag in tags:
+        if is_stable_tag(tag):
+            return tag
+    return None
+
+
 def stable_base_version(version: str) -> str:
     """Return the stable base triple for any supported version string."""
 

--- a/scripts/release/resolve_preview_version.py
+++ b/scripts/release/resolve_preview_version.py
@@ -12,6 +12,7 @@ from _versioning import (
     build_preview_version,
     derive_preview_base_version,
     load_assigned_version,
+    select_latest_stable_tag,
     stable_base_version,
 )
 
@@ -27,10 +28,8 @@ def _git(*args: str) -> str:
 
 
 def _latest_stable_tag(ref: str) -> str | None:
-    tags = _git("tag", "--merged", ref, "--sort=-v:refname", "--list", "v[0-9]*.[0-9]*.[0-9]*")
-    if not tags:
-        return None
-    return tags.splitlines()[0]
+    tags = _git("tag", "--merged", ref, "--sort=-v:refname")
+    return select_latest_stable_tag(tags.splitlines())
 
 
 def _commit_messages(revision_range: str) -> list[CommitMessage]:

--- a/tests/unit/test_release_versioning.py
+++ b/tests/unit/test_release_versioning.py
@@ -70,3 +70,9 @@ def test_build_preview_version_uses_numeric_build_identifier() -> None:
 def test_build_preview_version_rejects_non_numeric_build_identifier() -> None:
     with pytest.raises(ValueError, match="numeric"):
         release_versioning.build_preview_version("0.2.1", "run-42")
+
+
+def test_select_latest_stable_tag_ignores_preview_and_candidate_tags() -> None:
+    tags = ["v0.2.1.dev2399631184001", "v0.2.1rc1", "v0.2.0", "v0.1.1"]
+
+    assert release_versioning.select_latest_stable_tag(tags) == "v0.2.0"


### PR DESCRIPTION
## Issue

Once the first preview tag existed, the rolling resolver started treating `v0.2.1.dev...` as if it were the latest stable anchor.

## Cause and user impact

The resolver asked Git for tags sorted by version and then took the first matching `v[0-9]*.[0-9]*.[0-9]*` tag. That pattern also matches preview and candidate tags, so later preview runs anchored on prerelease tags instead of the last true stable tag. In practice, that broke version derivation entirely once a preview tag was present.

## Root cause

Stable-tag selection was not filtering tags to the strict `vX.Y.Z` shape before deriving the next preview base.

## Fix

Add stable-tag helpers in the shared release versioning module, use them when selecting the latest stable tag, and add a regression test that proves preview and candidate tags are ignored.

## Validation

- `make release-smoke`
- `python3 -m uv run python scripts/release/resolve_preview_version.py --run-id 1 --run-attempt 1`
- `python3 -m uv run pytest tests/unit/test_release_versioning.py`
