### PR TITLE
feat(storage): add role-specific storage bundle config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,24 @@ python3 -m uv run cellin trace inspect --config "$WORKSPACE/cellin.json" --limit
 
 See `examples/starter/README.md` for the same flow in a shorter checklist form.
 
+Workspace config now supports role-specific storage backends:
+
+```json
+{
+  "runtime_id": "cellin-cli",
+  "trace_path": "traces.jsonl",
+  "profile_name": "balanced",
+  "storage": {
+    "memory": { "backend": "sqlite", "database_path": "cellin.sqlite" },
+    "graph": { "backend": "sqlite", "database_path": "cellin.sqlite" },
+    "vector": { "backend": "in_memory_vector_index" },
+    "representation": { "backend": "in_memory_vector_index" }
+  }
+}
+```
+
+Legacy workspaces that only define `database_path` continue to work and are migrated to this shape behind the scenes.
+
 ## Primary surfaces
 
 - CLI: `cellin init`, `ingest`, `retrieve`, `dream`, `plugin list`, `eval run`, `trace inspect`

--- a/examples/starter/README.md
+++ b/examples/starter/README.md
@@ -7,3 +7,6 @@ Use this local-first workflow from the repository root:
 3. `python -m cellin.cli dream --config examples/starter/cellin-starter.json --strategy abstraction`
 4. `python -m cellin.cli eval run --suite smoke --config examples/starter/cellin-starter.json --output eval-results/starter-smoke.json`
 5. `python -m cellin.cli trace inspect --config examples/starter/cellin-starter.json --limit 5`
+
+The starter config demonstrates role-specific storage (`memory`, `graph`, `vector`, `representation`)
+using SQLite for graph/memory and in-memory vector indexes by default.

--- a/examples/starter/cellin-starter.json
+++ b/examples/starter/cellin-starter.json
@@ -1,6 +1,21 @@
 {
-  "database_path": "starter.sqlite",
-  "profile_name": "balanced",
   "runtime_id": "starter-workspace",
-  "trace_path": "starter-traces.jsonl"
+  "trace_path": "starter-traces.jsonl",
+  "profile_name": "balanced",
+  "storage": {
+    "memory": {
+      "backend": "sqlite",
+      "database_path": "starter.sqlite"
+    },
+    "graph": {
+      "backend": "sqlite",
+      "database_path": "starter.sqlite"
+    },
+    "vector": {
+      "backend": "in_memory_vector_index"
+    },
+    "representation": {
+      "backend": "in_memory_vector_index"
+    }
+  }
 }

--- a/src/cellin/cli/app.py
+++ b/src/cellin/cli/app.py
@@ -9,7 +9,13 @@ from datetime import datetime
 from pathlib import Path
 
 from cellin import __version__
-from cellin.cli.config import append_trace, init_workspace, load_workspace, read_traces
+from cellin.cli.config import (
+    ResolvedWorkspace,
+    append_trace,
+    init_workspace,
+    load_workspace,
+    read_traces,
+)
 from cellin.core import Modality
 from cellin.core.models import JSONValue
 from cellin.dreaming import DreamRunner
@@ -17,8 +23,12 @@ from cellin.evals import run_evaluation_suite
 from cellin.ingest import ArtifactEnvelope, CanonicalIngestor
 from cellin.ranking import WeightedRanker, get_weight_profile
 from cellin.retrieval import RetrievalCandidateGenerator, WeightedRetriever
-from cellin.runtime import InMemoryTraceSinkPlugin, PluginRegistry
-from cellin.stores import InMemoryVectorIndex, SQLiteGraphStore, SQLiteMemoryStore
+from cellin.runtime import (
+    InMemoryTraceSinkPlugin,
+    PluginRegistry,
+    StorageBundle,
+    build_storage_bundle,
+)
 
 TRACE_INSPECT_SUCCESS_EXIT_CODE = 0
 
@@ -47,13 +57,16 @@ def _load_envelopes(input_path: Path) -> tuple[ArtifactEnvelope, ...]:
     return tuple(envelopes)
 
 
-def _retriever(config_path: Path) -> WeightedRetriever:
+def _load_bundle(config_path: Path) -> tuple[ResolvedWorkspace, StorageBundle]:
     workspace = load_workspace(config_path)
-    memory_store = SQLiteMemoryStore(str(workspace.database_path))
-    graph_store = SQLiteGraphStore(str(workspace.database_path))
+    return workspace, build_storage_bundle(workspace.storage, workspace_root=config_path.parent)
+
+
+def _retriever(config_path: Path) -> WeightedRetriever:
+    workspace, bundle = _load_bundle(config_path)
     profile = get_weight_profile(workspace.profile_name)
     return WeightedRetriever(
-        candidate_generator=RetrievalCandidateGenerator(memory_store, graph_store),
+        candidate_generator=RetrievalCandidateGenerator(bundle.memory_store, bundle.graph_store),
         ranker=WeightedRanker(profile=profile),
         profile=profile,
     )
@@ -72,12 +85,11 @@ def cmd_init(args: argparse.Namespace) -> int:
 def cmd_ingest(args: argparse.Namespace) -> int:
     config_path = Path(args.config)
     workspace = load_workspace(config_path)
-    graph_store = SQLiteGraphStore(str(workspace.database_path))
-    memory_store = SQLiteMemoryStore(str(workspace.database_path))
+    bundle = build_storage_bundle(workspace.storage, workspace_root=config_path.parent)
     ingestor = CanonicalIngestor.with_built_in_adapters(
-        graph_store=graph_store,
-        memory_store=memory_store,
-        vector_index=InMemoryVectorIndex(),
+        graph_store=bundle.graph_store,
+        memory_store=bundle.memory_store,
+        vector_store=bundle.vector_store,
     )
     result = ingestor.ingest_envelopes(_load_envelopes(Path(args.input)))
     _record(
@@ -125,9 +137,10 @@ def cmd_retrieve(args: argparse.Namespace) -> int:
 def cmd_dream(args: argparse.Namespace) -> int:
     config_path = Path(args.config)
     workspace = load_workspace(config_path)
+    bundle = build_storage_bundle(workspace.storage, workspace_root=config_path.parent)
     runner = DreamRunner(
-        graph_store=SQLiteGraphStore(str(workspace.database_path)),
-        memory_store=SQLiteMemoryStore(str(workspace.database_path)),
+        graph_store=bundle.graph_store,
+        memory_store=bundle.memory_store,
     )
     results = (
         (runner.run_strategy(args.strategy),) if args.strategy is not None else runner.run_pending()

--- a/src/cellin/cli/config.py
+++ b/src/cellin/cli/config.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
 from cellin.core import TraceEvent
 from cellin.core.models import JSONValue
+from cellin.runtime.storage import StorageBackendConfig, StorageConfig
 
 DEFAULT_CONFIG_FILENAME = "cellin.json"
 DEFAULT_RUNTIME_ID = "cellin-cli"
@@ -22,9 +24,10 @@ class WorkspaceConfig:
     """Serializable CLI workspace config."""
 
     runtime_id: str = DEFAULT_RUNTIME_ID
-    database_path: str = DEFAULT_DATABASE_FILENAME
     trace_path: str = DEFAULT_TRACE_FILENAME
     profile_name: str = DEFAULT_PROFILE_NAME
+    database_path: str | None = None
+    storage: StorageConfig | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -33,9 +36,90 @@ class ResolvedWorkspace:
 
     config_path: Path
     runtime_id: str
-    database_path: Path
+    storage: StorageConfig
     trace_path: Path
     profile_name: str
+
+
+def _as_str(value: object, default: str) -> str:
+    return value if isinstance(value, str) else default
+
+
+def _coerce_storage_role(
+    role: str,
+    raw_config: object,
+    *,
+    default_backend: str,
+    fallback_database_path: str,
+) -> StorageBackendConfig:
+    if raw_config is None:
+        if default_backend == "sqlite":
+            return StorageBackendConfig(default_backend, fallback_database_path)
+        return StorageBackendConfig(default_backend)
+
+    if not isinstance(raw_config, Mapping):
+        raise ValueError(f"`{role}` storage config must be an object.")
+
+    backend_raw = raw_config.get("backend")
+    if backend_raw is not None and not isinstance(backend_raw, str):
+        raise ValueError(f"`{role}` storage backend must be a string.")
+
+    backend = backend_raw if isinstance(backend_raw, str) else default_backend
+    database_path_raw = raw_config.get("database_path")
+    if database_path_raw is not None and not isinstance(database_path_raw, str):
+        raise ValueError(f"`{role}` storage database_path must be a string.")
+
+    if backend == "sqlite":
+        resolved_path: str | None = database_path_raw or fallback_database_path
+    else:
+        resolved_path = database_path_raw
+    if backend == "sqlite" and resolved_path == "":
+        resolved_path = fallback_database_path
+
+    return StorageBackendConfig(
+        backend=backend,
+        database_path=resolved_path,
+    )
+
+
+def _coerce_storage_config(raw: Mapping[str, object]) -> StorageConfig:
+    legacy_database_path = raw.get("database_path")
+    fallback_database_path = (
+        legacy_database_path if isinstance(legacy_database_path, str) else DEFAULT_DATABASE_FILENAME
+    )
+    raw_storage = raw.get("storage")
+    if raw_storage is None:
+        return StorageConfig.with_sqlite_preset(fallback_database_path)
+
+    if not isinstance(raw_storage, Mapping):
+        raise ValueError("`storage` must be an object.")
+
+    return StorageConfig(
+        memory=_coerce_storage_role(
+            "memory",
+            raw_storage.get("memory"),
+            default_backend="sqlite",
+            fallback_database_path=fallback_database_path,
+        ),
+        graph=_coerce_storage_role(
+            "graph",
+            raw_storage.get("graph"),
+            default_backend="sqlite",
+            fallback_database_path=fallback_database_path,
+        ),
+        vector=_coerce_storage_role(
+            "vector",
+            raw_storage.get("vector"),
+            default_backend="in_memory_vector_index",
+            fallback_database_path=fallback_database_path,
+        ),
+        representation=_coerce_storage_role(
+            "representation",
+            raw_storage.get("representation"),
+            default_backend="in_memory_vector_index",
+            fallback_database_path=fallback_database_path,
+        ),
+    )
 
 
 def init_workspace(target: Path) -> Path:
@@ -44,7 +128,11 @@ def init_workspace(target: Path) -> Path:
     config_path = target if target.suffix == ".json" else target / DEFAULT_CONFIG_FILENAME
     config_path.parent.mkdir(parents=True, exist_ok=True)
     if not config_path.exists():
-        payload = asdict(WorkspaceConfig())
+        defaults = WorkspaceConfig(
+            storage=StorageConfig.with_sqlite_preset(DEFAULT_DATABASE_FILENAME),
+        )
+        payload = asdict(defaults)
+        payload.pop("database_path", None)
         config_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
     return config_path
 
@@ -53,20 +141,19 @@ def load_workspace(config_path: Path) -> ResolvedWorkspace:
     """Load a workspace config and resolve relative paths."""
 
     raw = json.loads(config_path.read_text(encoding="utf-8"))
-    defaults = WorkspaceConfig()
-    workspace = WorkspaceConfig(
-        runtime_id=str(raw.get("runtime_id", defaults.runtime_id)),
-        database_path=str(raw.get("database_path", defaults.database_path)),
-        trace_path=str(raw.get("trace_path", defaults.trace_path)),
-        profile_name=str(raw.get("profile_name", defaults.profile_name)),
-    )
-    root = config_path.parent
+    if not isinstance(raw, Mapping):
+        raise ValueError("Workspace config must be a JSON object.")
+
+    storage = _coerce_storage_config(raw)
+
     return ResolvedWorkspace(
         config_path=config_path,
-        runtime_id=workspace.runtime_id,
-        database_path=(root / workspace.database_path).resolve(),
-        trace_path=(root / workspace.trace_path).resolve(),
-        profile_name=workspace.profile_name,
+        runtime_id=_as_str(raw.get("runtime_id"), default=DEFAULT_RUNTIME_ID),
+        storage=storage,
+        trace_path=(
+            config_path.parent / _as_str(raw.get("trace_path"), default=DEFAULT_TRACE_FILENAME)
+        ).resolve(),
+        profile_name=_as_str(raw.get("profile_name"), default=DEFAULT_PROFILE_NAME),
     )
 
 

--- a/src/cellin/core/__init__.py
+++ b/src/cellin/core/__init__.py
@@ -21,6 +21,7 @@ from cellin.core.contracts import (
     Retriever,
     RuntimeConfig,
     TraceSink,
+    VectorStore,
 )
 from cellin.core.models import (
     Artifact,
@@ -43,6 +44,7 @@ from cellin.core.models import (
     ScheduledDreamRun,
     ScoredMemory,
     TraceEvent,
+    VectorMatch,
 )
 
 __all__ = [
@@ -86,4 +88,6 @@ __all__ = [
     "ScoredMemory",
     "TraceEvent",
     "TraceSink",
+    "VectorMatch",
+    "VectorStore",
 ]

--- a/src/cellin/core/contracts.py
+++ b/src/cellin/core/contracts.py
@@ -22,6 +22,7 @@ from cellin.core.models import (
     ScheduledDreamRun,
     ScoredMemory,
     TraceEvent,
+    VectorMatch,
 )
 
 
@@ -220,3 +221,13 @@ class TraceSink(Protocol):
 
     def record(self, event: TraceEvent) -> None:
         """Record a trace event."""
+
+
+class VectorStore(Protocol):
+    """Vector indexing primitives for memory and representation retrieval."""
+
+    def upsert(self, memory_id: str, text: str) -> None:
+        """Add or update an indexed vector for a memory id."""
+
+    def search(self, query: str, *, limit: int = 5) -> Sequence[VectorMatch]:
+        """Return matching memory ids and scores."""

--- a/src/cellin/core/models.py
+++ b/src/cellin/core/models.py
@@ -215,6 +215,14 @@ class MemoryBundle:
 
 
 @dataclass(slots=True)
+class VectorMatch:
+    """A single vector retrieval match."""
+
+    memory_id: str
+    score: float
+
+
+@dataclass(slots=True)
 class TraceEvent:
     """Structured runtime trace data."""
 

--- a/src/cellin/evals/runner.py
+++ b/src/cellin/evals/runner.py
@@ -30,7 +30,7 @@ from cellin.evals.retrieval_benchmarks import seeded_benchmark_cases
 from cellin.ingest import CanonicalIngestor
 from cellin.ranking import WeightedRanker, get_weight_profile
 from cellin.retrieval import RetrievalCandidateGenerator, WeightedRetriever
-from cellin.stores import InMemoryVectorIndex, SQLiteGraphStore, SQLiteMemoryStore
+from cellin.runtime.storage import StorageConfig, build_storage_bundle
 
 
 def _json_float_map(values: dict[str, float]) -> dict[str, JSONValue]:
@@ -177,16 +177,15 @@ def _project_edges() -> tuple[MemoryEdge, ...]:
 def _run_ingest_case() -> EvaluationCaseResult:
     with TemporaryDirectory() as directory:
         database_path = Path(directory) / "cellin.sqlite"
-        graph_store = SQLiteGraphStore(str(database_path))
-        memory_store = SQLiteMemoryStore(str(database_path))
-        vector_index = InMemoryVectorIndex()
+        storage = StorageConfig.with_sqlite_preset(str(database_path))
+        bundle = build_storage_bundle(storage, workspace_root=Path(directory))
         ingestor = CanonicalIngestor.with_built_in_adapters(
-            graph_store=graph_store,
-            memory_store=memory_store,
-            vector_index=vector_index,
+            graph_store=bundle.graph_store,
+            memory_store=bundle.memory_store,
+            vector_store=bundle.vector_store,
         )
         result = ingestor.ingest_envelopes(load_envelope_corpus("multimodal_artifacts"))
-        vector_results = vector_index.search("memory graph retrieval pipeline", limit=1)
+        vector_results = bundle.vector_store.search("memory graph retrieval pipeline", limit=1)
         memory_count = len(result.memories)
         edge_count = len(result.edges)
         metrics = {

--- a/src/cellin/ingest/pipeline.py
+++ b/src/cellin/ingest/pipeline.py
@@ -16,10 +16,10 @@ from cellin.core import (
     MemoryStore,
     Modality,
     Provenance,
+    VectorStore,
 )
 from cellin.ingest.adapters import EnvelopeAdapter, built_in_adapters
 from cellin.ingest.envelope import ArtifactEnvelope, IngestionBatchResult
-from cellin.stores.vector_index import InMemoryVectorIndex
 
 
 @dataclass(slots=True)
@@ -28,7 +28,7 @@ class CanonicalIngestor:
 
     graph_store: GraphStore
     memory_store: MemoryStore
-    vector_index: InMemoryVectorIndex
+    vector_store: VectorStore
     adapters: Mapping[Modality, EnvelopeAdapter]
 
     @classmethod
@@ -37,8 +37,15 @@ class CanonicalIngestor:
         *,
         graph_store: GraphStore,
         memory_store: MemoryStore,
-        vector_index: InMemoryVectorIndex,
+        vector_store: VectorStore | None = None,
+        vector_index: VectorStore | None = None,
     ) -> CanonicalIngestor:
+        resolved_vector_store = vector_store if vector_store is not None else vector_index
+        if resolved_vector_store is None:
+            raise TypeError(
+                "CanonicalIngestor.with_built_in_adapters requires "
+                "`vector_store` or legacy `vector_index`."
+            )
         adapters = built_in_adapters()
         adapter_map = {
             Modality.TEXT: adapters[0],
@@ -50,7 +57,7 @@ class CanonicalIngestor:
         return cls(
             graph_store=graph_store,
             memory_store=memory_store,
-            vector_index=vector_index,
+            vector_store=resolved_vector_store,
             adapters=adapter_map,
         )
 
@@ -60,7 +67,7 @@ class CanonicalIngestor:
         memories = tuple(self._artifact_to_memory(artifact) for artifact in artifacts)
         self._persist_memories(memories)
         for memory in memories:
-            self.vector_index.upsert(memory.memory_id, memory.text)
+            self.vector_store.upsert(memory.memory_id, memory.text)
         return memories
 
     def ingest_envelopes(self, envelopes: Sequence[ArtifactEnvelope]) -> IngestionBatchResult:

--- a/src/cellin/runtime/__init__.py
+++ b/src/cellin/runtime/__init__.py
@@ -2,5 +2,20 @@
 
 from cellin.runtime.builtins import InMemoryTraceSinkPlugin
 from cellin.runtime.registry import PluginRegistry
+from cellin.runtime.storage import (
+    StorageBackendConfig,
+    StorageBackendError,
+    StorageBundle,
+    StorageConfig,
+    build_storage_bundle,
+)
 
-__all__ = ["InMemoryTraceSinkPlugin", "PluginRegistry"]
+__all__ = [
+    "InMemoryTraceSinkPlugin",
+    "PluginRegistry",
+    "StorageBackendConfig",
+    "StorageBackendError",
+    "StorageBundle",
+    "StorageConfig",
+    "build_storage_bundle",
+]

--- a/src/cellin/runtime/storage.py
+++ b/src/cellin/runtime/storage.py
@@ -1,0 +1,199 @@
+"""Storage composition layer for resolved runtime storage backends."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, Protocol, cast
+
+from cellin.core import GraphStore, MemoryStore, VectorStore
+from cellin.stores import InMemoryVectorIndex, SQLiteGraphStore, SQLiteMemoryStore
+
+StorageRole = Literal["graph", "memory", "representation", "vector"]
+
+
+class StorageBackendError(ValueError):
+    """Raised when a storage role uses an unknown backend family."""
+
+
+@dataclass(frozen=True, slots=True)
+class StorageBackendConfig:
+    """Backend selector and minimal role-specific options."""
+
+    backend: str
+    database_path: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class StorageConfig:
+    """Role-specific storage composition for runtime initialization."""
+
+    memory: StorageBackendConfig
+    graph: StorageBackendConfig
+    vector: StorageBackendConfig
+    representation: StorageBackendConfig
+
+    @classmethod
+    def with_sqlite_preset(cls, database_path: str) -> StorageConfig:
+        """Return a config that keeps SQLite for graph/memory and in-memory vector roles."""
+
+        sqlite_backend = StorageBackendConfig("sqlite", database_path)
+        vector_backend = StorageBackendConfig("in_memory_vector_index")
+        return cls(
+            memory=sqlite_backend,
+            graph=sqlite_backend,
+            vector=vector_backend,
+            representation=vector_backend,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class StorageBundle:
+    """Concrete storage objects produced by backend resolution."""
+
+    memory_store: MemoryStore
+    graph_store: GraphStore
+    vector_store: VectorStore
+    representation_store: VectorStore
+
+
+class BackendBuilder(Protocol):
+    """Callable that resolves one storage backend configuration."""
+
+    def __call__(
+        self,
+        config: StorageBackendConfig,
+        *,
+        workspace_root: Path,
+    ) -> object: ...
+
+
+__all__ = [
+    "StorageBackendConfig",
+    "StorageBackendError",
+    "StorageConfig",
+    "StorageBundle",
+    "build_storage_bundle",
+]
+
+
+def _resolve_database_path(path_value: str | None, *, workspace_root: Path) -> str:
+    if path_value is None:
+        raise StorageBackendError("SQLite backend requires a `database_path` value")
+
+    configured_path = Path(path_value)
+    resolved_path = (
+        configured_path
+        if configured_path.is_absolute()
+        else (workspace_root / configured_path).resolve()
+    )
+    return str(resolved_path)
+
+
+def _build_sqlite_memory_store(
+    config: StorageBackendConfig,
+    *,
+    workspace_root: Path,
+) -> MemoryStore:
+    database_path = _resolve_database_path(config.database_path, workspace_root=workspace_root)
+    return SQLiteMemoryStore(database_path)
+
+
+def _build_sqlite_graph_store(
+    config: StorageBackendConfig,
+    *,
+    workspace_root: Path,
+) -> GraphStore:
+    database_path = _resolve_database_path(config.database_path, workspace_root=workspace_root)
+    return SQLiteGraphStore(database_path)
+
+
+def _build_vector_store(
+    config: StorageBackendConfig,
+    *,
+    workspace_root: Path,
+) -> VectorStore:
+    # Vector stores are in-memory only for now, so no backend-local workspace
+    # resolution is required. Keep the signature consistent with other builders.
+    del config, workspace_root
+    return InMemoryVectorIndex()
+
+
+_MEMORY_BACKEND_REGISTRY: dict[str, BackendBuilder] = {
+    "sqlite": _build_sqlite_memory_store,
+}
+
+
+_GRAPH_BACKEND_REGISTRY: dict[str, BackendBuilder] = {
+    "sqlite": _build_sqlite_graph_store,
+}
+
+
+_VECTOR_BACKEND_REGISTRY: dict[str, BackendBuilder] = {
+    "in_memory_vector_index": _build_vector_store,
+}
+
+
+def _resolve_backend(
+    role: StorageRole,
+    config: StorageBackendConfig,
+    *,
+    backend_registry: dict[str, BackendBuilder],
+    workspace_root: Path,
+) -> object:
+    builder = backend_registry.get(config.backend)
+    if builder is None:
+        raise StorageBackendError(f"Unknown backend `{config.backend}` for role `{role}`")
+    return builder(config, workspace_root=workspace_root)
+
+
+def build_storage_bundle(
+    storage: StorageConfig,
+    *,
+    workspace_root: Path,
+) -> StorageBundle:
+    """Resolve role configs to concrete storage objects."""
+
+    memory_store = cast(
+        MemoryStore,
+        _resolve_backend(
+            "memory",
+            storage.memory,
+            backend_registry=_MEMORY_BACKEND_REGISTRY,
+            workspace_root=workspace_root,
+        ),
+    )
+    graph_store = cast(
+        GraphStore,
+        _resolve_backend(
+            "graph",
+            storage.graph,
+            backend_registry=_GRAPH_BACKEND_REGISTRY,
+            workspace_root=workspace_root,
+        ),
+    )
+    vector_store = cast(
+        VectorStore,
+        _resolve_backend(
+            "vector",
+            storage.vector,
+            backend_registry=_VECTOR_BACKEND_REGISTRY,
+            workspace_root=workspace_root,
+        ),
+    )
+    representation_store = cast(
+        VectorStore,
+        _resolve_backend(
+            "representation",
+            storage.representation,
+            backend_registry=_VECTOR_BACKEND_REGISTRY,
+            workspace_root=workspace_root,
+        ),
+    )
+
+    return StorageBundle(
+        memory_store=memory_store,
+        graph_store=graph_store,
+        vector_store=vector_store,
+        representation_store=representation_store,
+    )

--- a/src/cellin/stores/sqlite.py
+++ b/src/cellin/stores/sqlite.py
@@ -144,10 +144,16 @@ class _SQLiteBackend:
 
     def __init__(self, database_path: str) -> None:
         self.database_path = database_path
+        self._ensure_parent_directory()
         self._initialize()
 
     def _connect(self) -> sqlite3.Connection:
         return sqlite3.connect(self.database_path)
+
+    def _ensure_parent_directory(self) -> None:
+        if self.database_path == ":memory:":
+            return
+        Path(self.database_path).parent.mkdir(parents=True, exist_ok=True)
 
     def _initialize(self) -> None:
         with closing(self._connect()) as connection, connection:

--- a/src/cellin/stores/vector_index.py
+++ b/src/cellin/stores/vector_index.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import hashlib
 import math
 import re
-from dataclasses import dataclass
+
+from cellin.core import VectorMatch
 
 TOKEN_RE = re.compile(r"[a-z0-9]+")
 VECTOR_SIZE = 12
@@ -27,14 +28,6 @@ def _vectorize(text: str) -> tuple[float, ...]:
     return tuple(value / norm for value in buckets)
 
 
-@dataclass(frozen=True, slots=True)
-class SearchResult:
-    """A deterministic vector-index search match."""
-
-    memory_id: str
-    score: float
-
-
 class InMemoryVectorIndex:
     """A simple in-memory cosine-similarity index."""
 
@@ -44,10 +37,10 @@ class InMemoryVectorIndex:
     def upsert(self, memory_id: str, text: str) -> None:
         self._vectors[memory_id] = _vectorize(text)
 
-    def search(self, query: str, *, limit: int = 5) -> tuple[SearchResult, ...]:
+    def search(self, query: str, *, limit: int = 5) -> tuple[VectorMatch, ...]:
         query_vector = _vectorize(query)
         results = [
-            SearchResult(
+            VectorMatch(
                 memory_id=memory_id,
                 score=round(
                     sum(a * b for a, b in zip(query_vector, vector, strict=True)),
@@ -58,3 +51,6 @@ class InMemoryVectorIndex:
         ]
         ordered = sorted(results, key=lambda result: result.score, reverse=True)
         return tuple(ordered[:limit])
+
+
+SearchResult = VectorMatch

--- a/tests/contracts/test_storage.py
+++ b/tests/contracts/test_storage.py
@@ -1,0 +1,103 @@
+"""Tests for workspace storage configuration migration and backend resolution."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cellin.cli.config import DEFAULT_DATABASE_FILENAME, load_workspace
+from cellin.runtime.storage import (
+    StorageBackendConfig,
+    StorageBackendError,
+    StorageConfig,
+    build_storage_bundle,
+)
+from cellin.stores import SQLiteMemoryStore
+
+
+def test_load_workspace_migrates_legacy_database_path(tmp_path: Path) -> None:
+    config_path = tmp_path / "legacy.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "runtime_id": "legacy-workspace",
+                "database_path": "legacy.sqlite",
+                "trace_path": "legacy-traces.jsonl",
+                "profile_name": "balanced",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    workspace = load_workspace(config_path)
+
+    assert workspace.runtime_id == "legacy-workspace"
+    assert workspace.storage == StorageConfig.with_sqlite_preset("legacy.sqlite")
+    assert workspace.trace_path == (tmp_path / "legacy-traces.jsonl").resolve()
+
+
+def test_load_workspace_uses_role_specific_storage_definition(tmp_path: Path) -> None:
+    config_path = tmp_path / "role-specific.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "runtime_id": "role-workspace",
+                "trace_path": "trace.jsonl",
+                "storage": {
+                    "memory": {"backend": "sqlite", "database_path": "memory.sqlite"},
+                    "graph": {"backend": "sqlite", "database_path": "graph.sqlite"},
+                    "vector": {"backend": "in_memory_vector_index"},
+                    "representation": {"backend": "in_memory_vector_index"},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    workspace = load_workspace(config_path)
+
+    assert workspace.runtime_id == "role-workspace"
+    assert workspace.storage == StorageConfig(
+        memory=StorageBackendConfig("sqlite", "memory.sqlite"),
+        graph=StorageBackendConfig("sqlite", "graph.sqlite"),
+        vector=StorageBackendConfig("in_memory_vector_index"),
+        representation=StorageBackendConfig("in_memory_vector_index"),
+    )
+
+
+def test_build_storage_bundle_rejects_unknown_backend(tmp_path: Path) -> None:
+    config = StorageConfig(
+        memory=StorageBackendConfig("sqlite", "cellin.sqlite"),
+        graph=StorageBackendConfig("sqlite", "cellin.sqlite"),
+        vector=StorageBackendConfig("no_such_backend"),
+        representation=StorageBackendConfig("in_memory_vector_index"),
+    )
+
+    with pytest.raises(StorageBackendError, match="NoSuchBackend|no_such_backend"):
+        build_storage_bundle(config, workspace_root=tmp_path)
+
+
+def test_load_workspace_defaults_role_specific_graph_memory_path_when_missing(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "legacy-defaults.json"
+    config_path.write_text(
+        json.dumps({"storage": {"vector": {"backend": "in_memory_vector_index"}}}),
+        encoding="utf-8",
+    )
+    workspace = load_workspace(config_path)
+
+    assert workspace.storage == StorageConfig.with_sqlite_preset(DEFAULT_DATABASE_FILENAME)
+    assert workspace.storage.vector.backend == "in_memory_vector_index"
+
+
+def test_build_storage_bundle_resolves_sqlite_path_in_workspace(tmp_path: Path) -> None:
+    bundle = build_storage_bundle(
+        StorageConfig.with_sqlite_preset("subdir/cellin.sqlite"),
+        workspace_root=tmp_path,
+    )
+    memory_store = bundle.memory_store
+    assert isinstance(memory_store, SQLiteMemoryStore)
+    assert memory_store._database_path == str((tmp_path / "subdir" / "cellin.sqlite").resolve())

--- a/tests/integration/ingest/test_pipeline.py
+++ b/tests/integration/ingest/test_pipeline.py
@@ -38,7 +38,7 @@ def test_ingestion_pipeline_persists_memories_edges_and_vectors(tmp_path) -> Non
     ingestor = CanonicalIngestor.with_built_in_adapters(
         graph_store=graph_store,
         memory_store=memory_store,
-        vector_index=vector_index,
+        vector_store=vector_index,
     )
 
     result = ingestor.ingest_envelopes(_load_fixture())
@@ -74,7 +74,7 @@ def test_ingestion_pipeline_batches_sqlite_writes_for_shared_store(tmp_path, mon
     ingestor = CanonicalIngestor.with_built_in_adapters(
         graph_store=graph_store,
         memory_store=memory_store,
-        vector_index=vector_index,
+        vector_store=vector_index,
     )
     connect_calls = 0
     original_connect = sqlite3.connect

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -1,0 +1,74 @@
+"""Unit coverage for CLI workspace storage config parsing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cellin.cli.config import load_workspace
+
+
+def _write_config(path: Path, payload: object) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_load_workspace_rejects_non_object_json(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path / "invalid.json", ["not", "an", "object"])
+
+    with pytest.raises(ValueError, match="JSON object"):
+        load_workspace(config_path)
+
+
+def test_load_workspace_rejects_non_object_storage(tmp_path: Path) -> None:
+    config_path = _write_config(tmp_path / "invalid-storage.json", {"storage": []})
+
+    with pytest.raises(ValueError, match="`storage` must be an object"):
+        load_workspace(config_path)
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    (
+        ({"storage": {"memory": []}}, "`memory` storage config must be an object"),
+        (
+            {"storage": {"graph": {"backend": 3}}},
+            "`graph` storage backend must be a string",
+        ),
+        (
+            {"storage": {"memory": {"backend": "sqlite", "database_path": 7}}},
+            "`memory` storage database_path must be a string",
+        ),
+    ),
+)
+def test_load_workspace_rejects_invalid_role_shapes(
+    tmp_path: Path,
+    payload: object,
+    message: str,
+) -> None:
+    config_path = _write_config(tmp_path / "invalid-role.json", payload)
+
+    with pytest.raises(ValueError, match=message):
+        load_workspace(config_path)
+
+
+def test_load_workspace_treats_empty_sqlite_database_path_as_legacy_fallback(
+    tmp_path: Path,
+) -> None:
+    config_path = _write_config(
+        tmp_path / "fallback.json",
+        {
+            "database_path": "legacy.sqlite",
+            "storage": {
+                "memory": {"backend": "sqlite", "database_path": ""},
+                "graph": {"backend": "sqlite"},
+            },
+        },
+    )
+
+    workspace = load_workspace(config_path)
+
+    assert workspace.storage.memory.database_path == "legacy.sqlite"
+    assert workspace.storage.graph.database_path == "legacy.sqlite"


### PR DESCRIPTION
## Summary

Introduce a first-class storage composition layer so Cellin stops hard-wiring SQLite constructors in the CLI and eval runner.

## Issue

Cellin only understood a single `database_path`, which scattered SQLite assumptions through the CLI and eval flow and left no runtime abstraction for vector-backed roles.

## Root Cause

Workspace config parsing, ingest wiring, and eval setup all resolved concrete store implementations directly instead of resolving a role-based storage bundle.

## Fix

- add `StorageConfig`, `StorageBackendConfig`, and `StorageBundle` runtime resolution in `cellin.runtime.storage`
- add `VectorStore` and `VectorMatch` core contracts and route the in-memory vector index through them
- migrate CLI config loading to support role-specific `storage` config while preserving legacy `database_path` compatibility
- wire CLI ingest/retrieve/dream flows and eval ingest setup through `build_storage_bundle`
- document the new config shape in the starter example and README
- add config migration, backend resolution, and defensive parsing coverage

## Validation

```bash
make release-smoke
```

Closes #72
