### PR TITLE
feat(storage): promote in-memory preset for init and runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,27 @@ Workspace config now supports role-specific storage backends:
   "trace_path": "traces.jsonl",
   "profile_name": "balanced",
   "storage": {
-    "memory": { "backend": "sqlite", "database_path": "cellin.sqlite" },
-    "graph": { "backend": "sqlite", "database_path": "cellin.sqlite" },
+    "memory": { "backend": "in_memory" },
+    "graph": { "backend": "in_memory" },
     "vector": { "backend": "in_memory_vector_index" },
     "representation": { "backend": "in_memory_vector_index" }
   }
 }
 ```
 
+`cellin init` now writes this in-memory-first preset by default.
+
 Legacy workspaces that only define `database_path` continue to work and are migrated to this shape behind the scenes.
+
+For an explicit SQLite preset, set:
+
+```json
+{
+  "memory": { "backend": "sqlite", "database_path": "cellin.sqlite" },
+  "graph": { "backend": "sqlite", "database_path": "cellin.sqlite" }
+}
+```
+
 
 ## Primary surfaces
 

--- a/examples/starter/README.md
+++ b/examples/starter/README.md
@@ -9,4 +9,4 @@ Use this local-first workflow from the repository root:
 5. `python -m cellin.cli trace inspect --config examples/starter/cellin-starter.json --limit 5`
 
 The starter config demonstrates role-specific storage (`memory`, `graph`, `vector`, `representation`)
-using SQLite for graph/memory and in-memory vector indexes by default.
+using an explicit SQLite preset for graph/memory and in-memory vector indexes.

--- a/src/cellin/cli/config.py
+++ b/src/cellin/cli/config.py
@@ -89,7 +89,9 @@ def _coerce_storage_config(raw: Mapping[str, object]) -> StorageConfig:
     )
     raw_storage = raw.get("storage")
     if raw_storage is None:
-        return StorageConfig.with_sqlite_preset(fallback_database_path)
+        if isinstance(legacy_database_path, str):
+            return StorageConfig.with_sqlite_preset(legacy_database_path)
+        return StorageConfig.with_in_memory_preset()
 
     if not isinstance(raw_storage, Mapping):
         raise ValueError("`storage` must be an object.")
@@ -98,13 +100,13 @@ def _coerce_storage_config(raw: Mapping[str, object]) -> StorageConfig:
         memory=_coerce_storage_role(
             "memory",
             raw_storage.get("memory"),
-            default_backend="sqlite",
+            default_backend="in_memory",
             fallback_database_path=fallback_database_path,
         ),
         graph=_coerce_storage_role(
             "graph",
             raw_storage.get("graph"),
-            default_backend="sqlite",
+            default_backend="in_memory",
             fallback_database_path=fallback_database_path,
         ),
         vector=_coerce_storage_role(
@@ -129,7 +131,7 @@ def init_workspace(target: Path) -> Path:
     config_path.parent.mkdir(parents=True, exist_ok=True)
     if not config_path.exists():
         defaults = WorkspaceConfig(
-            storage=StorageConfig.with_sqlite_preset(DEFAULT_DATABASE_FILENAME),
+            storage=StorageConfig.with_in_memory_preset(),
         )
         payload = asdict(defaults)
         payload.pop("database_path", None)

--- a/src/cellin/runtime/storage.py
+++ b/src/cellin/runtime/storage.py
@@ -7,7 +7,13 @@ from pathlib import Path
 from typing import Literal, Protocol, cast
 
 from cellin.core import GraphStore, MemoryStore, VectorStore
-from cellin.stores import InMemoryVectorIndex, SQLiteGraphStore, SQLiteMemoryStore
+from cellin.stores import (
+    InMemoryGraphStore,
+    InMemoryMemoryStore,
+    InMemoryVectorIndex,
+    SQLiteGraphStore,
+    SQLiteMemoryStore,
+)
 
 StorageRole = Literal["graph", "memory", "representation", "vector"]
 
@@ -35,13 +41,26 @@ class StorageConfig:
 
     @classmethod
     def with_sqlite_preset(cls, database_path: str) -> StorageConfig:
-        """Return a config that keeps SQLite for graph/memory and in-memory vector roles."""
+        """Return an explicit, sqlite-backed storage preset."""
 
         sqlite_backend = StorageBackendConfig("sqlite", database_path)
         vector_backend = StorageBackendConfig("in_memory_vector_index")
         return cls(
             memory=sqlite_backend,
             graph=sqlite_backend,
+            vector=vector_backend,
+            representation=vector_backend,
+        )
+
+    @classmethod
+    def with_in_memory_preset(cls) -> StorageConfig:
+        """Return the batteries-included in-memory storage preset."""
+
+        in_memory_backend = StorageBackendConfig("in_memory")
+        vector_backend = StorageBackendConfig("in_memory_vector_index")
+        return cls(
+            memory=in_memory_backend,
+            graph=in_memory_backend,
             vector=vector_backend,
             representation=vector_backend,
         )
@@ -108,6 +127,24 @@ def _build_sqlite_graph_store(
     return SQLiteGraphStore(database_path)
 
 
+def _build_in_memory_memory_store(
+    config: StorageBackendConfig,
+    *,
+    workspace_root: Path,
+) -> MemoryStore:
+    del config, workspace_root
+    return InMemoryMemoryStore()
+
+
+def _build_in_memory_graph_store(
+    config: StorageBackendConfig,
+    *,
+    workspace_root: Path,
+) -> GraphStore:
+    del config, workspace_root
+    return InMemoryGraphStore()
+
+
 def _build_vector_store(
     config: StorageBackendConfig,
     *,
@@ -121,11 +158,13 @@ def _build_vector_store(
 
 _MEMORY_BACKEND_REGISTRY: dict[str, BackendBuilder] = {
     "sqlite": _build_sqlite_memory_store,
+    "in_memory": _build_in_memory_memory_store,
 }
 
 
 _GRAPH_BACKEND_REGISTRY: dict[str, BackendBuilder] = {
     "sqlite": _build_sqlite_graph_store,
+    "in_memory": _build_in_memory_graph_store,
 }
 
 

--- a/src/cellin/stores/__init__.py
+++ b/src/cellin/stores/__init__.py
@@ -1,6 +1,14 @@
 """Local persistence primitives for Cellin."""
 
+from cellin.stores.in_memory import InMemoryGraphStore, InMemoryMemoryStore
 from cellin.stores.sqlite import SQLiteGraphStore, SQLiteMemoryStore
 from cellin.stores.vector_index import InMemoryVectorIndex, SearchResult
 
-__all__ = ["InMemoryVectorIndex", "SQLiteGraphStore", "SQLiteMemoryStore", "SearchResult"]
+__all__ = [
+    "InMemoryGraphStore",
+    "InMemoryMemoryStore",
+    "InMemoryVectorIndex",
+    "SearchResult",
+    "SQLiteGraphStore",
+    "SQLiteMemoryStore",
+]

--- a/src/cellin/stores/in_memory.py
+++ b/src/cellin/stores/in_memory.py
@@ -1,0 +1,79 @@
+"""In-memory runtime stores for memory and graph state."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from cellin.core import MemoryAtom, MemoryEdge, MemoryStore
+
+
+def _edge_archived(edge: MemoryEdge) -> bool:
+    archived = edge.metadata.get("archived")
+    return bool(archived) if isinstance(archived, bool) else False
+
+
+class InMemoryMemoryStore:
+    """In-memory memory store used by default CLI and eval runtime presets."""
+
+    def __init__(self, memories: Sequence[MemoryAtom] = ()) -> None:
+        self._memories: dict[str, MemoryAtom] = {}
+        self.put_many(tuple(memories))
+
+    def put(self, memory: MemoryAtom) -> None:
+        self.put_many((memory,))
+
+    def put_many(self, memories: Sequence[MemoryAtom]) -> None:
+        for memory in memories:
+            self._memories[memory.memory_id] = memory
+
+    def get(self, memory_id: str) -> MemoryAtom | None:
+        return self._memories.get(memory_id)
+
+    def list(self) -> tuple[MemoryAtom, ...]:
+        return tuple(self._memories.values())
+
+
+class InMemoryGraphStore:
+    """In-memory graph store used by default CLI and eval runtime presets."""
+
+    def __init__(
+        self,
+        memories: Sequence[MemoryAtom] = (),
+        edges: Sequence[MemoryEdge] = (),
+    ) -> None:
+        self._memory_store: MemoryStore | None = None
+        self._memories: dict[str, MemoryAtom] = {}
+        self._edges: dict[str, MemoryEdge] = {}
+        self.upsert_memories(tuple(memories))
+        self.upsert_edges(tuple(edges))
+
+    def upsert_memory(self, memory: MemoryAtom) -> None:
+        self._memories[memory.memory_id] = memory
+
+    def upsert_memories(self, memories: Sequence[MemoryAtom]) -> None:
+        for memory in memories:
+            self.upsert_memory(memory)
+
+    def upsert_edge(self, edge: MemoryEdge) -> None:
+        self._edges[edge.edge_id] = edge
+
+    def upsert_edges(self, edges: Sequence[MemoryEdge]) -> None:
+        for edge in edges:
+            self.upsert_edge(edge)
+
+    def shares_memory_store(self, memory_store: MemoryStore) -> bool:
+        return self._memory_store is memory_store
+
+    def get_memory(self, memory_id: str) -> MemoryAtom | None:
+        return self._memories.get(memory_id)
+
+    def neighbors(self, memory_id: str) -> tuple[MemoryEdge, ...]:
+        return tuple(
+            edge
+            for edge in self._edges.values()
+            if edge.source_id == memory_id or edge.target_id == memory_id
+            if not _edge_archived(edge)
+        )
+
+    def list_edges(self) -> tuple[MemoryEdge, ...]:
+        return tuple(edge for edge in self._edges.values() if not _edge_archived(edge))

--- a/tests/contracts/test_storage.py
+++ b/tests/contracts/test_storage.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from cellin.cli.config import DEFAULT_DATABASE_FILENAME, load_workspace
+from cellin.cli.config import load_workspace
 from cellin.runtime.storage import (
     StorageBackendConfig,
     StorageBackendError,
@@ -89,8 +89,16 @@ def test_load_workspace_defaults_role_specific_graph_memory_path_when_missing(
     )
     workspace = load_workspace(config_path)
 
-    assert workspace.storage == StorageConfig.with_sqlite_preset(DEFAULT_DATABASE_FILENAME)
-    assert workspace.storage.vector.backend == "in_memory_vector_index"
+    assert workspace.storage == StorageConfig.with_in_memory_preset()
+
+
+def test_load_workspace_defaults_to_in_memory_preset_when_storage_omitted(tmp_path: Path) -> None:
+    config_path = tmp_path / "minimal.json"
+    config_path.write_text(json.dumps({}), encoding="utf-8")
+
+    workspace = load_workspace(config_path)
+
+    assert workspace.storage == StorageConfig.with_in_memory_preset()
 
 
 def test_build_storage_bundle_resolves_sqlite_path_in_workspace(tmp_path: Path) -> None:

--- a/tests/integration/cli/test_cli.py
+++ b/tests/integration/cli/test_cli.py
@@ -30,6 +30,18 @@ def test_cli_end_to_end_flow(tmp_path: Path, capsys: CaptureFixture[str]) -> Non
     init_output = capsys.readouterr().out
     assert "initialized workspace" in init_output
 
+    sqlite_storage = {
+        "storage": {
+            "memory": {"backend": "sqlite", "database_path": "cellin.sqlite"},
+            "graph": {"backend": "sqlite", "database_path": "cellin.sqlite"},
+            "vector": {"backend": "in_memory_vector_index", "database_path": None},
+            "representation": {"backend": "in_memory_vector_index", "database_path": None},
+        }
+    }
+    config_payload = json.loads(config_path.read_text(encoding="utf-8"))
+    config_payload.update(sqlite_storage)
+    config_path.write_text(json.dumps(config_payload, sort_keys=True), encoding="utf-8")
+
     assert main(["ingest", "--config", str(config_path), "--input", str(input_path)]) == 0
     ingest_output = capsys.readouterr().out
     assert "memories=4" in ingest_output

--- a/tests/integration/stores/test_in_memory.py
+++ b/tests/integration/stores/test_in_memory.py
@@ -1,0 +1,86 @@
+"""Coverage for production in-memory stores."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from cellin.core import (
+    DecayState,
+    EdgeKind,
+    MemoryAtom,
+    MemoryEdge,
+    MemoryKind,
+    Modality,
+    Provenance,
+    RetrievalStats,
+)
+from cellin.stores import InMemoryGraphStore, InMemoryMemoryStore
+
+
+def _memory(memory_id: str, text: str) -> MemoryAtom:
+    return MemoryAtom(
+        memory_id=memory_id,
+        kind=MemoryKind.ATOM,
+        text=text,
+        provenance=Provenance(source_id=memory_id, source_type="fixture"),
+        modality=Modality.TEXT,
+        created_at=datetime(2026, 4, 5, tzinfo=UTC),
+        observed_at=datetime(2026, 4, 5, tzinfo=UTC),
+        decay=DecayState(half_life_days=14.0),
+        retrieval=RetrievalStats(),
+    )
+
+
+def _edge(edge_id: str, source_id: str, target_id: str, archived: bool) -> MemoryEdge:
+    return MemoryEdge(
+        edge_id=edge_id,
+        source_id=source_id,
+        target_id=target_id,
+        kind=EdgeKind.SUPPORTS,
+        provenance=Provenance(source_id=edge_id, source_type="fixture"),
+        created_at=datetime(2026, 4, 5, tzinfo=UTC),
+        metadata={"archived": archived},
+    )
+
+
+def test_in_memory_memory_store_preserves_order_and_updates_entries() -> None:
+    first = _memory("atlas-1", "Atlas one")
+    duplicate = _memory("atlas-1", "Atlas one revised")
+    second = _memory("atlas-2", "Atlas two")
+
+    store = InMemoryMemoryStore()
+    store.put_many((first, second))
+    store.put(duplicate)
+
+    assert store.get("atlas-1") == duplicate
+    assert store.list() == (duplicate, second)
+
+
+def test_in_memory_graph_store_handles_memories_edges_and_archived_filtering() -> None:
+    active = _edge("edge-active", "atlas-1", "atlas-2", archived=False)
+    archived = _edge("edge-archived", "atlas-1", "atlas-3", archived=True)
+
+    graph_store = InMemoryGraphStore(
+        memories=(_memory("atlas-1", "Atlas one"), _memory("atlas-2", "Atlas two")),
+        edges=(active, archived),
+    )
+
+    assert graph_store.get_memory("atlas-1").memory_id == "atlas-1"
+    assert graph_store.neighbors("atlas-1") == (active,)
+    assert graph_store.list_edges() == (active,)
+
+    graph_store.upsert_edges(())
+    graph_store.upsert_edge(_edge("edge-revision", "atlas-2", "atlas-3", archived=False))
+
+    assert {edge.edge_id for edge in graph_store.neighbors("atlas-2")} == {
+        "edge-revision",
+        "edge-active",
+    }
+
+
+def test_in_memory_graph_store_detects_shared_memory_store_reference() -> None:
+    memory_store = InMemoryMemoryStore((_memory("atlas-1", "Atlas one"),))
+    graph_store = InMemoryGraphStore(memories=(memory_store.list()[0],))
+    graph_store._memory_store = memory_store
+
+    assert graph_store.shares_memory_store(memory_store) is True

--- a/tests/unit/test_cli_config.py
+++ b/tests/unit/test_cli_config.py
@@ -7,7 +7,8 @@ from pathlib import Path
 
 import pytest
 
-from cellin.cli.config import load_workspace
+from cellin.cli.config import init_workspace, load_workspace
+from cellin.runtime.storage import StorageConfig
 
 
 def _write_config(path: Path, payload: object) -> Path:
@@ -72,3 +73,20 @@ def test_load_workspace_treats_empty_sqlite_database_path_as_legacy_fallback(
 
     assert workspace.storage.memory.database_path == "legacy.sqlite"
     assert workspace.storage.graph.database_path == "legacy.sqlite"
+
+
+def test_init_workspace_defaults_to_in_memory_preset(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    config_path = init_workspace(workspace)
+
+    workspace_config = load_workspace(config_path)
+    assert workspace_config.storage == StorageConfig.with_in_memory_preset()
+
+    payload = json.loads(config_path.read_text(encoding="utf-8"))
+
+    assert payload["storage"] == {
+        "memory": {"backend": "in_memory", "database_path": None},
+        "graph": {"backend": "in_memory", "database_path": None},
+        "vector": {"backend": "in_memory_vector_index", "database_path": None},
+        "representation": {"backend": "in_memory_vector_index", "database_path": None},
+    }


### PR DESCRIPTION
## Issue
- https://github.com/ben-ranford/cellin/issues/73

## Root cause
- In-memory memory/graph stores existed only in test-only/eval-local scaffolding and were not wired as production backends.
- `cellin init` and storage role defaults were still SQLite-first, so new workspaces always assumed a file-backed database path.
- SQLite was effectively the default path even when no explicit backend was provided.

## Fix
- Added first-class production in-memory storage backends in `src/cellin/stores/in_memory.py`:
  - `InMemoryMemoryStore`
  - `InMemoryGraphStore`
- Registered both in `src/cellin/runtime/storage.py` and added `StorageConfig.with_in_memory_preset()` while keeping `with_sqlite_preset()` as an explicit compatibility preset.
- Changed storage defaulting in `src/cellin/cli/config.py` so missing `storage` resolves to `in_memory` preset; role defaults for missing memory/graph now use `in_memory`.
- Updated `cellin init` to write the in-memory preset.
- Kept SQLite available via explicit `sqlite` backend + `database_path`.
- Updated README, starter docs, CLI and contract/unit tests and added in-memory store integration coverage.

## Validation
- `make release-smoke`
- Full validation run includes:
  - ruff format/check
  - mypy
  - pytest + coverage gates
  - mkdocs build
  - release smoke (`cellin.evals smoke`)
  - package build + twine checks

Closes #73
