### PR TITLE
feat: add vector store abstraction and hybrid retrieval

### DIFF
--- a/src/cellin/cli/app.py
+++ b/src/cellin/cli/app.py
@@ -66,7 +66,11 @@ def _retriever(config_path: Path) -> WeightedRetriever:
     workspace, bundle = _load_bundle(config_path)
     profile = get_weight_profile(workspace.profile_name)
     return WeightedRetriever(
-        candidate_generator=RetrievalCandidateGenerator(bundle.memory_store, bundle.graph_store),
+        candidate_generator=RetrievalCandidateGenerator(
+            bundle.memory_store,
+            bundle.graph_store,
+            vector_store=bundle.vector_store,
+        ),
         ranker=WeightedRanker(profile=profile),
         profile=profile,
     )

--- a/src/cellin/evals/runner.py
+++ b/src/cellin/evals/runner.py
@@ -16,6 +16,7 @@ from cellin.core import (
     MemoryStore,
     Provenance,
     ScoredMemory,
+    VectorStore,
 )
 from cellin.core.models import JSONValue
 from cellin.dreaming import (
@@ -147,11 +148,18 @@ def _delta(metrics: dict[str, float], baseline: dict[str, float]) -> dict[str, f
 
 
 def _retriever(
-    memory_store: MemoryStore, graph_store: GraphStore, profile_name: str
+    memory_store: MemoryStore,
+    graph_store: GraphStore,
+    profile_name: str,
+    vector_store: VectorStore | None = None,
 ) -> WeightedRetriever:
     profile = get_weight_profile(profile_name)
     return WeightedRetriever(
-        candidate_generator=RetrievalCandidateGenerator(memory_store, graph_store),
+        candidate_generator=RetrievalCandidateGenerator(
+            memory_store,
+            graph_store,
+            vector_store=vector_store,
+        ),
         ranker=WeightedRanker(
             profile=profile,
             now_provider=lambda: datetime(2026, 4, 4, tzinfo=UTC),

--- a/src/cellin/ranking/profiles.py
+++ b/src/cellin/ranking/profiles.py
@@ -11,6 +11,7 @@ class WeightProfile:
 
     name: str
     semantic_similarity: float
+    vector_similarity: float
     graph_proximity: float
     recency: float
     salience: float
@@ -25,7 +26,8 @@ class WeightProfile:
 PROFILES: dict[str, WeightProfile] = {
     "balanced": WeightProfile(
         name="balanced",
-        semantic_similarity=0.28,
+        semantic_similarity=0.24,
+        vector_similarity=0.12,
         graph_proximity=0.18,
         recency=0.12,
         salience=0.18,
@@ -35,7 +37,8 @@ PROFILES: dict[str, WeightProfile] = {
     ),
     "recency_sensitive": WeightProfile(
         name="recency_sensitive",
-        semantic_similarity=0.22,
+        semantic_similarity=0.18,
+        vector_similarity=0.12,
         graph_proximity=0.10,
         recency=0.30,
         salience=0.14,
@@ -46,7 +49,8 @@ PROFILES: dict[str, WeightProfile] = {
     ),
     "concept_sensitive": WeightProfile(
         name="concept_sensitive",
-        semantic_similarity=0.30,
+        semantic_similarity=0.24,
+        vector_similarity=0.12,
         graph_proximity=0.24,
         recency=0.06,
         salience=0.16,

--- a/src/cellin/ranking/weighted.py
+++ b/src/cellin/ranking/weighted.py
@@ -54,6 +54,14 @@ def _modality_match(memory: MemoryAtom) -> float:
     return 0.4
 
 
+def _vector_similarity(memory: MemoryAtom) -> float:
+    raw_score = memory.metadata.get("vector_score")
+    if not isinstance(raw_score, int | float) or isinstance(raw_score, bool):
+        return 0.0
+
+    return max(0.0, min(1.0, float(raw_score)))
+
+
 @dataclass(slots=True)
 class WeightedRanker:
     """Explainable weighted ranking over memory atoms."""
@@ -106,9 +114,15 @@ class WeightedRanker:
                     value=_modality_match(memory),
                     rationale="Prefer text-like modalities for text queries.",
                 ),
+                FactorScore(
+                    name="vector_similarity",
+                    value=_vector_similarity(memory),
+                    rationale="Vector-space similarity from the hybrid retrieval pass.",
+                ),
             )
             total = (
                 self.profile.semantic_similarity * factors[0].value
+                + self.profile.vector_similarity * factors[7].value
                 + self.profile.graph_proximity * factors[1].value
                 + self.profile.recency * factors[2].value
                 + self.profile.salience * factors[3].value

--- a/src/cellin/retrieval/candidate_generation.py
+++ b/src/cellin/retrieval/candidate_generation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass, replace
 
-from cellin.core import GraphStore, MemoryAtom, MemoryEdge, MemoryStore
+from cellin.core import GraphStore, MemoryAtom, MemoryEdge, MemoryStore, VectorStore
 
 TOKEN_RE = re.compile(r"[a-z0-9]+")
 
@@ -34,23 +34,49 @@ def _annotate_distance(memory: MemoryAtom, distance: int) -> MemoryAtom:
     )
 
 
+def _annotate_vector_score(memory: MemoryAtom, score: float) -> MemoryAtom:
+    return replace(
+        memory,
+        metadata={**memory.metadata, "vector_score": round(max(score, 0.0), 6)},
+    )
+
+
+def _ordered_unique(memories: list[MemoryAtom]) -> list[MemoryAtom]:
+    ordered: list[MemoryAtom] = []
+    seen: set[str] = set()
+    for memory in memories:
+        if memory.memory_id in seen:
+            continue
+        seen.add(memory.memory_id)
+        ordered.append(memory)
+    return ordered
+
+
 @dataclass(slots=True)
 class RetrievalCandidateGenerator:
-    """Generates retrieval candidates from lexical seeds plus graph expansion."""
+    """Generates retrieval candidates from lexical, vector, and graph signals."""
 
     memory_store: MemoryStore
     graph_store: GraphStore | None = None
+    vector_store: VectorStore | None = None
     lexical_limit: int = 4
+    vector_limit: int = 4
 
     def collect(self, query: str, *, limit: int) -> tuple[MemoryAtom, ...]:
         memories = self._active_memories()
-        if not memories:
+        if not memories or limit <= 0:
             return ()
 
         ranked_by_seed = self._rank_by_lexical_seed(query, memories)
-        seed_candidates = self._seed_candidates(query, ranked_by_seed, limit)
+        ranked_by_vector = self._rank_by_vector_seed(query, memories)
+        seed_candidates = self._seed_candidates(
+            query,
+            ranked_by_seed,
+            ranked_by_vector,
+            limit,
+        )
         candidates = self._candidate_index(seed_candidates)
-        self._expand_graph_neighbors(seed_candidates, candidates, limit)
+        self._expand_graph_neighbors(seed_candidates, candidates)
         return self._assemble_ordered_candidates(ranked_by_seed, candidates, limit)
 
     def _active_memories(self) -> tuple[MemoryAtom, ...]:
@@ -71,15 +97,25 @@ class RetrievalCandidateGenerator:
         self,
         query: str,
         ranked_by_seed: list[MemoryAtom],
+        ranked_by_vector: tuple[MemoryAtom, ...],
         limit: int,
     ) -> list[MemoryAtom]:
-        seeded = [
+        if limit <= 0:
+            return []
+
+        lexical_seeded = [
             _annotate_distance(memory, 0)
             for memory in ranked_by_seed[: self.lexical_limit]
             if _lexical_seed_score(query, memory) > 0.0
         ]
-        if seeded:
-            return seeded
+        vector_seeded = [_annotate_distance(memory, 0) for memory in ranked_by_vector]
+        if lexical_seeded:
+            merged = _ordered_unique(list(lexical_seeded) + vector_seeded)
+            return merged[: max(limit, self.vector_limit, self.lexical_limit)]
+
+        if vector_seeded:
+            return vector_seeded[: max(limit, self.vector_limit)]
+
         return self._fallback_seed_candidates(ranked_by_seed, limit)
 
     def _fallback_seed_candidates(
@@ -92,14 +128,52 @@ class RetrievalCandidateGenerator:
             for memory in ranked_by_seed[: min(limit, self.lexical_limit)]
         ]
 
+    def _rank_by_vector_seed(
+        self,
+        query: str,
+        memories: tuple[MemoryAtom, ...],
+    ) -> tuple[MemoryAtom, ...]:
+        if self.vector_store is None:
+            return ()
+
+        active = {memory.memory_id: memory for memory in memories}
+        matches = self.vector_store.search(
+            query,
+            limit=max(self.vector_limit, 1),
+        )
+        vector_candidates: list[MemoryAtom] = []
+        for match in matches:
+            memory = active.get(match.memory_id)
+            if memory is None:
+                continue
+            vector_candidates.append(_annotate_vector_score(memory, match.score))
+
+        ranked_candidates = sorted(
+            vector_candidates,
+            key=lambda item: (item.metadata["vector_score"], item.memory_id),
+            reverse=True,
+        )
+        return tuple(_ordered_unique(ranked_candidates))
+
     def _candidate_index(self, seed_candidates: list[MemoryAtom]) -> dict[str, MemoryAtom]:
-        return {memory.memory_id: memory for memory in seed_candidates}
+        merged: dict[str, MemoryAtom] = {}
+        for memory in seed_candidates:
+            existing = merged.get(memory.memory_id)
+            if existing is None:
+                merged[memory.memory_id] = memory
+                continue
+
+            merged[memory.memory_id] = replace(
+                existing,
+                metadata={**existing.metadata, **memory.metadata},
+            )
+
+        return merged
 
     def _expand_graph_neighbors(
         self,
         seed_candidates: list[MemoryAtom],
         candidates: dict[str, MemoryAtom],
-        limit: int,
     ) -> None:
         if self.graph_store is None:
             return
@@ -109,10 +183,7 @@ class RetrievalCandidateGenerator:
                 neighbor = self._resolve_neighbor(seed.memory_id, edge, candidates)
                 if neighbor is None:
                     continue
-
                 candidates[neighbor.memory_id] = _annotate_distance(neighbor, 1)
-                if len(candidates) >= limit:
-                    break
 
     def _resolve_neighbor(
         self,
@@ -143,12 +214,25 @@ class RetrievalCandidateGenerator:
         candidates: dict[str, MemoryAtom],
         limit: int,
     ) -> tuple[MemoryAtom, ...]:
-        ordered_ids = [
-            memory.memory_id for memory in ranked_by_seed if memory.memory_id in candidates
-        ]
-        ordered = tuple(candidates[memory_id] for memory_id in ordered_ids[:limit])
-        if len(ordered) >= limit:
-            return ordered
+        ordered: list[MemoryAtom] = []
+        selected_ids: set[str] = set()
 
-        missing = [memory for memory in ranked_by_seed if memory.memory_id not in candidates]
-        return ordered + tuple(missing[: max(0, limit - len(ordered))])
+        for memory in ranked_by_seed:
+            memory_id = memory.memory_id
+            if memory_id in selected_ids:
+                continue
+            ordered.append(candidates.get(memory_id, memory))
+            selected_ids.add(memory_id)
+            if len(ordered) >= limit:
+                return tuple(ordered[:limit])
+
+        for memory in candidates.values():
+            memory_id = memory.memory_id
+            if memory_id in selected_ids:
+                continue
+            ordered.append(memory)
+            selected_ids.add(memory_id)
+            if len(ordered) >= limit:
+                break
+
+        return tuple(ordered[:limit])

--- a/src/cellin/runtime/storage.py
+++ b/src/cellin/runtime/storage.py
@@ -11,8 +11,10 @@ from cellin.stores import (
     InMemoryGraphStore,
     InMemoryMemoryStore,
     InMemoryVectorIndex,
+    PGVectorStore,
     SQLiteGraphStore,
     SQLiteMemoryStore,
+    SQLiteVecStore,
 )
 
 StorageRole = Literal["graph", "memory", "representation", "vector"]
@@ -98,7 +100,7 @@ __all__ = [
 
 def _resolve_database_path(path_value: str | None, *, workspace_root: Path) -> str:
     if path_value is None:
-        raise StorageBackendError("SQLite backend requires a `database_path` value")
+        raise StorageBackendError("`database_path` is required for this backend")
 
     configured_path = Path(path_value)
     resolved_path = (
@@ -114,7 +116,10 @@ def _build_sqlite_memory_store(
     *,
     workspace_root: Path,
 ) -> MemoryStore:
-    database_path = _resolve_database_path(config.database_path, workspace_root=workspace_root)
+    database_path = _resolve_database_path(
+        config.database_path,
+        workspace_root=workspace_root,
+    )
     return SQLiteMemoryStore(database_path)
 
 
@@ -123,7 +128,10 @@ def _build_sqlite_graph_store(
     *,
     workspace_root: Path,
 ) -> GraphStore:
-    database_path = _resolve_database_path(config.database_path, workspace_root=workspace_root)
+    database_path = _resolve_database_path(
+        config.database_path,
+        workspace_root=workspace_root,
+    )
     return SQLiteGraphStore(database_path)
 
 
@@ -150,10 +158,32 @@ def _build_vector_store(
     *,
     workspace_root: Path,
 ) -> VectorStore:
-    # Vector stores are in-memory only for now, so no backend-local workspace
-    # resolution is required. Keep the signature consistent with other builders.
     del config, workspace_root
     return InMemoryVectorIndex()
+
+
+def _build_sqlite_vec_store(
+    config: StorageBackendConfig,
+    *,
+    workspace_root: Path,
+) -> VectorStore:
+    database_path = _resolve_database_path(
+        config.database_path,
+        workspace_root=workspace_root,
+    )
+    return SQLiteVecStore(database_path)
+
+
+def _build_pgvector_store(
+    config: StorageBackendConfig,
+    *,
+    workspace_root: Path,
+) -> VectorStore:
+    del workspace_root
+    connection_string = config.database_path
+    if connection_string is None:
+        raise StorageBackendError("pgvector backend requires a connection string")
+    return PGVectorStore(connection_string)
 
 
 _MEMORY_BACKEND_REGISTRY: dict[str, BackendBuilder] = {
@@ -170,6 +200,8 @@ _GRAPH_BACKEND_REGISTRY: dict[str, BackendBuilder] = {
 
 _VECTOR_BACKEND_REGISTRY: dict[str, BackendBuilder] = {
     "in_memory_vector_index": _build_vector_store,
+    "sqlite_vec": _build_sqlite_vec_store,
+    "pgvector": _build_pgvector_store,
 }
 
 

--- a/src/cellin/stores/__init__.py
+++ b/src/cellin/stores/__init__.py
@@ -1,7 +1,9 @@
 """Local persistence primitives for Cellin."""
 
 from cellin.stores.in_memory import InMemoryGraphStore, InMemoryMemoryStore
+from cellin.stores.pgvector import PGVectorStore
 from cellin.stores.sqlite import SQLiteGraphStore, SQLiteMemoryStore
+from cellin.stores.sqlite_vec import SQLiteVecStore
 from cellin.stores.vector_index import InMemoryVectorIndex, SearchResult
 
 __all__ = [
@@ -9,6 +11,8 @@ __all__ = [
     "InMemoryMemoryStore",
     "InMemoryVectorIndex",
     "SearchResult",
+    "PGVectorStore",
     "SQLiteGraphStore",
     "SQLiteMemoryStore",
+    "SQLiteVecStore",
 ]

--- a/src/cellin/stores/pgvector.py
+++ b/src/cellin/stores/pgvector.py
@@ -1,0 +1,88 @@
+"""PostgreSQL/pgvector-backed vector index abstraction."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cellin.core import VectorMatch
+from cellin.stores.vector_utils import vectorize
+
+
+class _MissingPgVectorDependencyError(RuntimeError):
+    """Raised when pgvector is unavailable from runtime dependencies."""
+
+
+class PGVectorStore:
+    """Vector index backed by PostgreSQL + pgvector.
+
+    The implementation is intentionally lightweight and validates dependencies on
+    first use so optional installs remain possible.
+    """
+
+    def __init__(self, connection_string: str, *, table_name: str = "cellin_vectors") -> None:
+        try:
+            import psycopg  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover - environment-dependent
+            raise _MissingPgVectorDependencyError(
+                "pgvector backend requires optional dependency `psycopg`"
+            ) from exc
+
+        self._psycopg = psycopg
+        self._connection_string = connection_string
+        self._table_name = table_name
+        self._initialized = False
+        self._ensure_schema()
+
+    def _connect(self) -> Any:
+        return self._psycopg.connect(self._connection_string)
+
+    def _ensure_schema(self) -> None:
+        if self._initialized:
+            return
+
+        with self._connect() as connection:
+            connection.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS {self._table_name} (
+                    memory_id TEXT PRIMARY KEY,
+                    vector vector(12)
+                )
+                """
+            )
+        self._initialized = True
+
+    def upsert(self, memory_id: str, text: str) -> None:
+        vector = vectorize(text)
+        with self._connect() as connection:
+            connection.execute(
+                f"""
+                INSERT INTO {self._table_name}(memory_id, vector)
+                VALUES (%s, %s)
+                ON CONFLICT(memory_id) DO UPDATE SET vector = EXCLUDED.vector
+                """,
+                (memory_id, vector),
+            )
+
+    def search(self, query: str, *, limit: int = 5) -> tuple[VectorMatch, ...]:
+        if limit <= 0:
+            return ()
+
+        query_vector = vectorize(query)
+        matches: list[VectorMatch] = []
+        with self._connect() as connection:
+            rows = connection.execute(
+                f"""
+                SELECT memory_id, vector <=> %s AS distance
+                FROM {self._table_name}
+                ORDER BY distance
+                LIMIT %s
+                """,
+                (query_vector, limit),
+            ).fetchall()
+
+        for row in rows:
+            memory_id, distance = row
+            score = 1.0 - float(distance)
+            matches.append(VectorMatch(memory_id=memory_id, score=round(max(score, 0.0), 6)))
+
+        return tuple(matches)

--- a/src/cellin/stores/sqlite_vec.py
+++ b/src/cellin/stores/sqlite_vec.py
@@ -1,0 +1,78 @@
+"""SQLite-backed vector index using the shared vector store contract."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from cellin.core import VectorMatch
+from cellin.stores.vector_utils import cosine_similarity, vectorize
+
+
+class _VectorBackend:
+    """Shared low-level helper for vector persistence in SQLite."""
+
+    def __init__(self, database_path: str) -> None:
+        resolved_path = Path(database_path)
+        if resolved_path != Path(":memory:"):
+            resolved_path.parent.mkdir(parents=True, exist_ok=True)
+        self.database_path = str(resolved_path)
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        return sqlite3.connect(self.database_path)
+
+    def _initialize(self) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS vector_entries (
+                    memory_id TEXT PRIMARY KEY,
+                    vector TEXT NOT NULL
+                )
+                """
+            )
+
+    def upsert(self, memory_id: str, vector: tuple[float, ...]) -> None:
+        connection = self._connect()
+        with connection:
+            connection.execute(
+                """
+                INSERT INTO vector_entries(memory_id, vector)
+                VALUES (?, ?)
+                ON CONFLICT(memory_id) DO UPDATE
+                SET vector = excluded.vector
+                """,
+                (memory_id, json.dumps(vector)),
+            )
+        connection.close()
+
+    def list_vectors(self) -> tuple[tuple[str, tuple[float, ...]], ...]:
+        with self._connect() as connection:
+            rows = connection.execute("SELECT memory_id, vector FROM vector_entries").fetchall()
+
+        return tuple((row[0], tuple(float(value) for value in json.loads(row[1]))) for row in rows)
+
+
+class SQLiteVecStore:
+    """SQLite-backed vector storage and top-k cosine search."""
+
+    def __init__(self, database_path: str) -> None:
+        self._backend = _VectorBackend(database_path)
+
+    def upsert(self, memory_id: str, text: str) -> None:
+        self._backend.upsert(memory_id, vectorize(text))
+
+    def search(self, query: str, *, limit: int = 5) -> tuple[VectorMatch, ...]:
+        if limit <= 0:
+            return ()
+
+        query_vector = vectorize(query)
+        results: list[VectorMatch] = []
+        for memory_id, vector in self._backend.list_vectors():
+            score = round(cosine_similarity(query_vector, vector), 6)
+            results.append(VectorMatch(memory_id=memory_id, score=score))
+
+        ordered = sorted(results, key=lambda result: (-result.score, result.memory_id))
+        return tuple(ordered[:limit])

--- a/src/cellin/stores/vector_index.py
+++ b/src/cellin/stores/vector_index.py
@@ -2,30 +2,8 @@
 
 from __future__ import annotations
 
-import hashlib
-import math
-import re
-
 from cellin.core import VectorMatch
-
-TOKEN_RE = re.compile(r"[a-z0-9]+")
-VECTOR_SIZE = 12
-
-
-def _tokenize(text: str) -> list[str]:
-    return TOKEN_RE.findall(text.lower())
-
-
-def _vectorize(text: str) -> tuple[float, ...]:
-    buckets = [0.0] * VECTOR_SIZE
-    for token in _tokenize(text):
-        digest = hashlib.sha256(token.encode("utf-8")).digest()
-        bucket_index = int.from_bytes(digest[:4], byteorder="big") % VECTOR_SIZE
-        buckets[bucket_index] += 1.0
-    norm = math.sqrt(sum(value * value for value in buckets))
-    if norm == 0:
-        return tuple(buckets)
-    return tuple(value / norm for value in buckets)
+from cellin.stores.vector_utils import cosine_similarity, vectorize
 
 
 class InMemoryVectorIndex:
@@ -35,21 +13,21 @@ class InMemoryVectorIndex:
         self._vectors: dict[str, tuple[float, ...]] = {}
 
     def upsert(self, memory_id: str, text: str) -> None:
-        self._vectors[memory_id] = _vectorize(text)
+        self._vectors[memory_id] = vectorize(text)
 
     def search(self, query: str, *, limit: int = 5) -> tuple[VectorMatch, ...]:
-        query_vector = _vectorize(query)
+        if limit <= 0:
+            return ()
+
+        query_vector = vectorize(query)
         results = [
             VectorMatch(
                 memory_id=memory_id,
-                score=round(
-                    sum(a * b for a, b in zip(query_vector, vector, strict=True)),
-                    6,
-                ),
+                score=round(cosine_similarity(query_vector, vector), 6),
             )
             for memory_id, vector in self._vectors.items()
         ]
-        ordered = sorted(results, key=lambda result: result.score, reverse=True)
+        ordered = sorted(results, key=lambda result: (-result.score, result.memory_id))
         return tuple(ordered[:limit])
 
 

--- a/src/cellin/stores/vector_utils.py
+++ b/src/cellin/stores/vector_utils.py
@@ -1,0 +1,35 @@
+"""Shared deterministic vector helpers for first-party vector backends."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+
+TOKEN_RE = re.compile(r"[a-z0-9]+")
+VECTOR_SIZE = 12
+
+
+def _tokenize(text: str) -> list[str]:
+    return TOKEN_RE.findall(text.lower())
+
+
+def vectorize(text: str) -> tuple[float, ...]:
+    buckets = [0.0] * VECTOR_SIZE
+    for token in _tokenize(text):
+        digest = hashlib.sha256(token.encode("utf-8")).digest()
+        bucket_index = int.from_bytes(digest[:4], byteorder="big") % VECTOR_SIZE
+        buckets[bucket_index] += 1.0
+
+    norm = math.sqrt(sum(value * value for value in buckets))
+    if norm == 0:
+        return tuple(buckets)
+
+    return tuple(value / norm for value in buckets)
+
+
+def cosine_similarity(left: tuple[float, ...], right: tuple[float, ...]) -> float:
+    if not left or not right:
+        return 0.0
+
+    return sum(a * b for a, b in zip(left, right, strict=True))

--- a/tests/contracts/test_storage.py
+++ b/tests/contracts/test_storage.py
@@ -14,7 +14,7 @@ from cellin.runtime.storage import (
     StorageConfig,
     build_storage_bundle,
 )
-from cellin.stores import SQLiteMemoryStore
+from cellin.stores import SQLiteMemoryStore, SQLiteVecStore
 
 
 def test_load_workspace_migrates_legacy_database_path(tmp_path: Path) -> None:
@@ -76,6 +76,68 @@ def test_build_storage_bundle_rejects_unknown_backend(tmp_path: Path) -> None:
     )
 
     with pytest.raises(StorageBackendError, match="NoSuchBackend|no_such_backend"):
+        build_storage_bundle(config, workspace_root=tmp_path)
+
+
+def test_build_storage_bundle_resolves_sqlite_vec_backend(tmp_path: Path) -> None:
+    config = StorageConfig(
+        memory=StorageBackendConfig("sqlite", "cellin.sqlite"),
+        graph=StorageBackendConfig("sqlite", "cellin.sqlite"),
+        vector=StorageBackendConfig("sqlite_vec", "vectors.sqlite"),
+        representation=StorageBackendConfig("in_memory_vector_index"),
+    )
+    bundle = build_storage_bundle(config, workspace_root=tmp_path)
+
+    assert isinstance(bundle.vector_store, SQLiteVecStore)
+    bundle.vector_store.upsert("memory-1", "Atlas architecture and memory graphs")
+    assert bundle.vector_store.search("Atlas architecture", limit=1)[0].memory_id == "memory-1"
+
+
+def test_build_storage_bundle_rejects_sqlite_vec_without_path(tmp_path: Path) -> None:
+    config = StorageConfig(
+        memory=StorageBackendConfig("sqlite", "cellin.sqlite"),
+        graph=StorageBackendConfig("sqlite", "cellin.sqlite"),
+        vector=StorageBackendConfig("sqlite_vec"),
+        representation=StorageBackendConfig("in_memory_vector_index"),
+    )
+
+    with pytest.raises(StorageBackendError, match="database_path|SQLite"):
+        build_storage_bundle(config, workspace_root=tmp_path)
+
+
+def test_build_storage_bundle_resolves_pgvector_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    class _FakePGVectorStore:
+        def __init__(self, connection_string: str) -> None:
+            self.connection_string = connection_string
+
+    monkeypatch.setattr("cellin.runtime.storage.PGVectorStore", _FakePGVectorStore)
+    config = StorageConfig(
+        memory=StorageBackendConfig("in_memory"),
+        graph=StorageBackendConfig("in_memory"),
+        vector=StorageBackendConfig("pgvector", "postgresql://cellin/test"),
+        representation=StorageBackendConfig("in_memory_vector_index"),
+    )
+
+    bundle = build_storage_bundle(config, workspace_root=tmp_path)
+
+    assert isinstance(bundle.vector_store, _FakePGVectorStore)
+    assert bundle.vector_store.connection_string == "postgresql://cellin/test"
+
+
+def test_build_storage_bundle_rejects_pgvector_without_connection_string(
+    tmp_path: Path,
+) -> None:
+    config = StorageConfig(
+        memory=StorageBackendConfig("in_memory"),
+        graph=StorageBackendConfig("in_memory"),
+        vector=StorageBackendConfig("pgvector"),
+        representation=StorageBackendConfig("in_memory_vector_index"),
+    )
+
+    with pytest.raises(StorageBackendError, match="pgvector backend requires a connection string"):
         build_storage_bundle(config, workspace_root=tmp_path)
 
 

--- a/tests/evals/test_runner.py
+++ b/tests/evals/test_runner.py
@@ -3,9 +3,50 @@
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 
+import cellin.evals.runner as eval_runner
+from cellin.core import (
+    DecayState,
+    MemoryAtom,
+    MemoryKind,
+    Modality,
+    Provenance,
+    RetrievalStats,
+    VectorMatch,
+    VectorStore,
+)
 from cellin.evals.runner import run_evaluation_suite
+
+
+def _memory(memory_id: str, observed_at: datetime) -> MemoryAtom:
+    return MemoryAtom(
+        memory_id=memory_id,
+        kind=MemoryKind.ATOM,
+        text=f"{memory_id} memory text",
+        provenance=Provenance(source_id=memory_id, source_type="fixture"),
+        modality=Modality.TEXT,
+        created_at=observed_at,
+        observed_at=observed_at,
+        decay=DecayState(half_life_days=14.0),
+        retrieval=RetrievalStats(),
+    )
+
+
+class _VectorStore(VectorStore):
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def upsert(self, memory_id: str, text: str) -> None:
+        pass
+
+    def search(self, query: str, *, limit: int = 5) -> tuple[VectorMatch, ...]:
+        del query
+        return (
+            VectorMatch(memory_id="memory-b", score=0.98),
+            VectorMatch(memory_id="memory-a", score=0.11),
+        )[: max(0, limit)]
 
 
 def test_smoke_suite_writes_report_with_deltas(tmp_path: Path) -> None:
@@ -33,3 +74,19 @@ def test_full_suite_includes_performance_and_contradiction_cases(tmp_path: Path)
     performance_case = report.cases[-1]
     assert performance_case.delta_metrics["active_memories"] < 0.0
     assert performance_case.delta_metrics["bundle_tokens"] < 0.0
+
+
+def test_runner_retriever_exposes_vector_signal_in_ranking() -> None:
+    now = datetime(2026, 4, 5, tzinfo=UTC)
+    memories = (_memory("memory-a", now), _memory("memory-b", now))
+    retriever = eval_runner._retriever(
+        eval_runner._InMemoryMemoryStore(memories),
+        eval_runner._InMemoryGraphStore(memories, ()),
+        "balanced",
+        vector_store=_VectorStore(),
+    )
+
+    bundle = retriever.retrieve("atlas retrieval", top_k=2)
+
+    assert bundle.memories[0].memory.memory_id == "memory-b"
+    assert bundle.memories[0].factors[7].name == "vector_similarity"

--- a/tests/integration/retrieval/test_candidate_generation.py
+++ b/tests/integration/retrieval/test_candidate_generation.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import UTC, datetime
 from unittest.mock import create_autospec
+
+import pytest
 
 from cellin.core import (
     DecayState,
@@ -16,6 +19,8 @@ from cellin.core import (
     Modality,
     Provenance,
     RetrievalStats,
+    VectorMatch,
+    VectorStore,
 )
 from cellin.retrieval import RetrievalCandidateGenerator
 
@@ -73,6 +78,25 @@ def _graph_store(
         edge for edge in edges if edge.source_id == memory_id or edge.target_id == memory_id
     )
     return graph
+
+
+class _FakeVectorStore(VectorStore):
+    def __init__(self, matches: tuple[tuple[str, float], ...]) -> None:
+        self._matches = tuple(matches)
+
+    def upsert(self, memory_id: str, text: str) -> None:
+        pass
+
+    def search(self, query: str, *, limit: int = 5) -> tuple[VectorMatch, ...]:
+        del query
+        ordered = sorted(
+            self._matches,
+            key=lambda item: (-item[1], item[0]),
+        )
+        return tuple(
+            VectorMatch(memory_id=memory_id, score=round(score, 6))
+            for memory_id, score in ordered[: max(0, limit)]
+        )
 
 
 def test_collect_filters_archived_memories_and_archived_graph_neighbors() -> None:
@@ -159,3 +183,131 @@ def test_collect_returns_empty_when_limit_is_zero() -> None:
     )
 
     assert generator.collect("atlas retrieval", limit=0) == ()
+
+
+def test_collect_prefers_hybrid_lexical_and_vector_seeding_with_graph_expansion() -> None:
+    memories = (
+        _memory("lexical", "Atlas architecture and retrieval"),
+        _memory("vector-primary", "Unrelated vector-only signal"),
+        _memory("graph-neighbor", "Graph neighbor to vector primary"),
+        _memory("inactive", "no relevance"),
+    )
+    edges = (_edge("vector-to-graph", "vector-primary", "graph-neighbor"),)
+    generator = RetrievalCandidateGenerator(
+        memory_store=_memory_store(memories),
+        graph_store=_graph_store(memories, edges),
+        vector_store=_FakeVectorStore(
+            (
+                ("vector-primary", 0.9),
+                ("inactive", 0.4),
+            )
+        ),
+    )
+
+    collected = generator.collect("Atlas", limit=3)
+
+    assert tuple(memory.memory_id for memory in collected) == (
+        "lexical",
+        "vector-primary",
+        "graph-neighbor",
+    )
+    assert collected[0].metadata["graph_distance"] == 0
+    assert collected[1].metadata["graph_distance"] == 0
+    assert collected[1].metadata["vector_score"] == pytest.approx(0.9)
+    assert collected[2].metadata["graph_distance"] == 1
+
+
+def test_collect_uses_vector_candidates_when_lexical_candidates_are_absent() -> None:
+    memories = (
+        _memory("seed-vector", "gamma delta"),
+        _memory("seed-lex", "alpha beta"),
+        _memory("vector-neighbor", "epsilon"),
+    )
+    edges = (_edge("vector-neighbor-edge", "seed-vector", "vector-neighbor"),)
+    generator = RetrievalCandidateGenerator(
+        memory_store=_memory_store(memories),
+        graph_store=_graph_store(memories, edges),
+        vector_store=_FakeVectorStore(
+            (
+                ("seed-vector", 0.7),
+                ("seed-lex", 0.4),
+            )
+        ),
+        lexical_limit=1,
+    )
+
+    collected = generator.collect("atlas retrieval query", limit=3)
+
+    assert tuple(memory.memory_id for memory in collected) == (
+        "seed-vector",
+        "seed-lex",
+        "vector-neighbor",
+    )
+    assert all("vector_score" in memory.metadata for memory in collected[:2])
+    assert collected[0].metadata["vector_score"] == pytest.approx(0.7)
+
+
+def test_seed_candidates_returns_empty_for_non_positive_limit() -> None:
+    memories = (_memory("seed", "Atlas retrieval graph"),)
+    generator = RetrievalCandidateGenerator(
+        memory_store=_memory_store(memories),
+        graph_store=None,
+    )
+
+    assert generator._seed_candidates("Atlas retrieval", list(memories), (), 0) == []
+
+
+def test_rank_by_vector_seed_skips_matches_not_present_in_active_memories() -> None:
+    memories = (_memory("known", "Atlas retrieval graph"),)
+    generator = RetrievalCandidateGenerator(
+        memory_store=_memory_store(memories),
+        graph_store=None,
+        vector_store=_FakeVectorStore((("missing", 0.9), ("known", 0.6))),
+    )
+
+    ranked = generator._rank_by_vector_seed("Atlas retrieval", memories)
+
+    assert tuple(memory.memory_id for memory in ranked) == ("known",)
+    assert ranked[0].metadata["vector_score"] == pytest.approx(0.6)
+
+
+def test_candidate_index_merges_duplicate_seed_metadata() -> None:
+    base = _memory("seed", "Atlas retrieval graph")
+    generator = RetrievalCandidateGenerator(
+        memory_store=_memory_store((base,)),
+        graph_store=None,
+    )
+
+    merged = generator._candidate_index(
+        [
+            replace(base, metadata={"graph_distance": 0}),
+            replace(base, metadata={"vector_score": 0.84}),
+        ]
+    )
+
+    assert merged["seed"].metadata == {"graph_distance": 0, "vector_score": 0.84}
+
+
+def test_collect_includes_graph_neighbors_loaded_from_memory_store_lookup() -> None:
+    seed = _memory("seed", "Atlas retrieval graph")
+    duplicate_seed = replace(seed, metadata={"duplicate": True})
+    neighbor = _memory("graph-neighbor", "Neighbor resolved from the memory store")
+    store = create_autospec(MemoryStore, instance=True)
+    store.list.return_value = (seed, duplicate_seed)
+    store.get.side_effect = {"seed": seed, "graph-neighbor": neighbor}.get
+
+    graph = create_autospec(GraphStore, instance=True)
+    graph.get_memory.return_value = None
+    graph.neighbors.side_effect = lambda memory_id: (
+        (_edge("seed-to-neighbor", "seed", "graph-neighbor"),) if memory_id == "seed" else ()
+    )
+
+    generator = RetrievalCandidateGenerator(
+        memory_store=store,
+        graph_store=graph,
+    )
+
+    collected = generator.collect("Atlas retrieval", limit=2)
+
+    assert tuple(memory.memory_id for memory in collected) == ("seed", "graph-neighbor")
+    assert collected[1].metadata["graph_distance"] == 1

--- a/tests/integration/retrieval/test_weighted_retriever.py
+++ b/tests/integration/retrieval/test_weighted_retriever.py
@@ -18,6 +18,8 @@ from cellin.core import (
     Modality,
     Provenance,
     RetrievalStats,
+    VectorMatch,
+    VectorStore,
 )
 from cellin.evals.retrieval_benchmarks import seeded_benchmark_cases
 from cellin.ranking import WeightedRanker, get_weight_profile
@@ -147,6 +149,25 @@ def _seeded_memories() -> tuple[tuple[MemoryAtom, ...], tuple[MemoryEdge, ...]]:
         ),
     )
     return (atlas_arch, atlas_vision, deploy_yesterday, unrelated), edges
+
+
+class _FakeVectorStore(VectorStore):
+    def __init__(self, matches: tuple[tuple[str, float], ...]) -> None:
+        self._matches = tuple(matches)
+
+    def upsert(self, memory_id: str, text: str) -> None:
+        pass
+
+    def search(self, query: str, *, limit: int = 5) -> tuple[VectorMatch, ...]:
+        del query
+        ordered = sorted(
+            self._matches,
+            key=lambda item: (-item[1], item[0]),
+        )
+        return tuple(
+            VectorMatch(memory_id=memory_id, score=round(score, 6))
+            for memory_id, score in ordered[: max(0, limit)]
+        )
 
 
 def test_concept_profile_uses_graph_expansion_for_related_memory() -> None:
@@ -280,3 +301,62 @@ def test_bundle_skips_oversized_first_candidate_and_selects_in_budget_next() -> 
     assert (
         sum(item.memory.metadata["token_count"] for item in bundle.memories) <= profile.token_budget
     )
+
+
+def test_vector_factors_can_outweigh_lexical_overlap() -> None:
+    now = datetime(2026, 4, 4, tzinfo=UTC)
+    memories = (
+        _memory(
+            "lexical-match",
+            "Atlas architecture and retrieval",
+            observed_at=now - timedelta(days=1),
+            salience=0.9,
+            trust=1.0,
+        ),
+        _memory(
+            "vector-first",
+            "Unrelated historical memory",
+            observed_at=now - timedelta(days=1),
+            salience=0.6,
+            trust=0.8,
+        ),
+    )
+    memory_store = InMemoryMemoryStore(memories)
+    graph_store = InMemoryGraphStore(memories, ())
+    profile = replace(
+        get_weight_profile("balanced"),
+        semantic_similarity=0.0,
+        vector_similarity=1.0,
+        graph_proximity=0.0,
+        recency=0.0,
+        salience=0.0,
+        trust=0.0,
+        reinforcement=0.0,
+        modality_match=0.0,
+    )
+    retriever = WeightedRetriever(
+        candidate_generator=RetrievalCandidateGenerator(
+            memory_store,
+            graph_store,
+            vector_store=_FakeVectorStore(
+                (
+                    ("vector-first", 0.98),
+                    ("lexical-match", 0.01),
+                )
+            ),
+        ),
+        ranker=WeightedRanker(
+            profile=profile,
+            now_provider=lambda: now,
+        ),
+        profile=profile,
+    )
+
+    bundle = retriever.retrieve("Atlas architecture and retrieval", top_k=2)
+
+    assert tuple(item.memory.memory_id for item in bundle.memories) == (
+        "vector-first",
+        "lexical-match",
+    )
+    assert bundle.memories[0].factors[7].name == "vector_similarity"
+    assert bundle.memories[0].factors[7].value == pytest.approx(0.98)

--- a/tests/integration/stores/test_pgvector.py
+++ b/tests/integration/stores/test_pgvector.py
@@ -1,0 +1,99 @@
+"""Coverage-focused tests for the optional pgvector backend."""
+
+from __future__ import annotations
+
+import builtins
+import sys
+from types import ModuleType
+
+import pytest
+
+from cellin.stores import PGVectorStore
+from cellin.stores.vector_utils import cosine_similarity
+
+
+class _FakePgvectorConnection:
+    def __init__(self, backend: _FakePgvectorBackend) -> None:
+        self._backend = backend
+        self._rows: list[tuple[str, float]] = []
+
+    def __enter__(self) -> _FakePgvectorConnection:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        return None
+
+    def execute(self, query: str, params: tuple[object, ...] = ()) -> _FakePgvectorConnection:
+        if "CREATE TABLE" in query:
+            return self
+
+        if "INSERT INTO" in query:
+            memory_id = str(params[0])
+            vector = tuple(params[1])  # type: ignore[arg-type]
+            self._backend._vectors[memory_id] = vector
+            return self
+
+        if "SELECT memory_id" in query:
+            query_vector = tuple(params[0]) if params else ()
+            limit = int(params[1]) if len(params) > 1 else len(self._backend._vectors)
+            rows = []
+            for memory_id, vector in self._backend._vectors.items():
+                distance = 1.0 - cosine_similarity(query_vector, vector)
+                rows.append((memory_id, max(distance, 0.0)))
+            rows.sort(key=lambda item: (item[1], item[0]))
+            self._rows = rows[: max(0, limit)]
+            return self
+
+        return self
+
+    def fetchall(self) -> list[tuple[str, float]]:
+        return list(self._rows)
+
+
+class _FakePgvectorBackend:
+    def __init__(self) -> None:
+        self._vectors: dict[str, tuple[float, ...]] = {}
+
+    def connect(self, connection_string: str) -> _FakePgvectorConnection:
+        del connection_string
+        return _FakePgvectorConnection(self)
+
+
+def test_pgvector_store_requires_psycopg_dependency(monkeypatch) -> None:
+    original_import = builtins.__import__
+
+    def _missing_psycopg(
+        name: str,
+        *args: object,  # pragma: no cover - import hook compatibility
+    ) -> object:
+        if name == "psycopg":
+            raise ModuleNotFoundError("No module named psycopg")
+        return original_import(name, *args)
+
+    try:
+        monkeypatch.setattr("builtins.__import__", _missing_psycopg)
+        with pytest.raises(RuntimeError, match="pgvector backend requires optional dependency"):
+            PGVectorStore("postgres://invalid")
+    finally:
+        monkeypatch.setattr("builtins.__import__", original_import)
+
+
+def test_pgvector_store_supports_upsert_and_search() -> None:
+    fake_backend = _FakePgvectorBackend()
+    fake_module = ModuleType("psycopg")
+    fake_module.connect = fake_backend.connect
+    original_psycopg = sys.modules.get("psycopg")
+    try:
+        sys.modules["psycopg"] = fake_module
+        vector_store = PGVectorStore("postgres://local")
+        vector_store.upsert("m1", "atlas architecture and graphs")
+        vector_store.upsert("m2", "gardening and tomatoes")
+
+        ranked = vector_store.search("atlas architecture", limit=2)
+        assert tuple(match.memory_id for match in ranked) == ("m1", "m2")
+        assert ranked[0].score >= ranked[1].score
+    finally:
+        if original_psycopg is None:
+            sys.modules.pop("psycopg", None)
+        else:
+            sys.modules["psycopg"] = original_psycopg

--- a/tests/integration/stores/test_sqlite_and_vector_index.py
+++ b/tests/integration/stores/test_sqlite_and_vector_index.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import builtins
+import sys
 from datetime import UTC, datetime
 
 import pytest
@@ -16,7 +18,14 @@ from cellin.core import (
     Provenance,
     RetrievalStats,
 )
-from cellin.stores import InMemoryVectorIndex, SQLiteGraphStore, SQLiteMemoryStore
+from cellin.stores import (
+    InMemoryVectorIndex,
+    PGVectorStore,
+    SQLiteGraphStore,
+    SQLiteMemoryStore,
+    SQLiteVecStore,
+)
+from cellin.stores.vector_utils import cosine_similarity, vectorize
 
 
 def _memory(memory_id: str, text: str) -> MemoryAtom:
@@ -83,3 +92,148 @@ def test_sqlite_store_filters_archived_edges_and_vector_index_handles_empty_text
     vector_index.upsert("blank", "")
 
     assert vector_index.search("", limit=1)[0].score == pytest.approx(0.0)
+
+
+def test_sqlite_vec_store_persists_vectors_and_supports_similarity_ranking(tmp_path) -> None:
+    database_path = tmp_path / "vector.sqlite"
+    vector_store = SQLiteVecStore(str(database_path))
+
+    vector_store.upsert("m1", "atlas architecture graph")
+    vector_store.upsert("m2", "gardening and tomatoes")
+    vector_store.upsert("m3", "memory graph retrieval")
+
+    query = "atlas graph"
+    query_vector = vectorize(query)
+    ranked = sorted(
+        (
+            ("m1", cosine_similarity(query_vector, vectorize("atlas architecture graph"))),
+            ("m2", cosine_similarity(query_vector, vectorize("gardening and tomatoes"))),
+            ("m3", cosine_similarity(query_vector, vectorize("memory graph retrieval"))),
+        ),
+        key=lambda item: (-item[1], item[0]),
+    )
+    expected = tuple(memory_id for memory_id, _ in ranked)
+
+    results = vector_store.search(query, limit=3)
+
+    assert tuple(result.memory_id for result in results) == expected
+    assert results[0].score >= results[1].score
+
+
+def test_sqlite_vec_store_respects_search_limit_zero(tmp_path) -> None:
+    database_path = tmp_path / "vector.sqlite"
+    vector_store = SQLiteVecStore(str(database_path))
+    vector_store.upsert("m1", "atlas")
+
+    assert vector_store.search("atlas", limit=0) == ()
+
+
+def test_in_memory_vector_index_respects_limit_zero() -> None:
+    vector_index = InMemoryVectorIndex()
+    vector_index.upsert("m1", "atlas architecture")
+
+    assert vector_index.search("atlas", limit=0) == ()
+
+
+def test_vector_utils_handles_empty_vectors() -> None:
+    assert cosine_similarity((), vectorize("atlas architecture")) == pytest.approx(0.0)
+
+
+class _FakeResult:
+    def __init__(self, rows: list[tuple[str, float]]) -> None:
+        self._rows = rows
+
+    def fetchall(self) -> list[tuple[str, float]]:
+        return list(self._rows)
+
+
+class _FakeConnection:
+    def __init__(self, rows: list[tuple[str, float]], calls: list[tuple[str, object]]) -> None:
+        self._rows = rows
+        self._calls = calls
+
+    def __enter__(self) -> _FakeConnection:
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        del exc_type, exc, tb
+        return False
+
+    def execute(self, query: str, params: object = None) -> _FakeResult:
+        self._calls.append((query, params))
+        if "SELECT memory_id, vector <=>" in query:
+            return _FakeResult(self._rows)
+        return _FakeResult([])
+
+
+class _FakePsycopg:
+    def __init__(self, rows: list[tuple[str, float]]) -> None:
+        self.rows = rows
+        self.calls: list[tuple[str, object]] = []
+        self.connection_strings: list[str] = []
+
+    def connect(self, connection_string: str) -> _FakeConnection:
+        self.connection_strings.append(connection_string)
+        return _FakeConnection(self.rows, self.calls)
+
+
+def test_pgvector_store_requires_psycopg_dependency(monkeypatch: pytest.MonkeyPatch) -> None:
+    real_import = builtins.__import__
+
+    def _missing_psycopg(
+        name: str,
+        globals: object = None,
+        locals: object = None,
+        fromlist: object = (),
+        level: int = 0,
+    ) -> object:
+        if name == "psycopg":
+            raise ImportError("psycopg is unavailable")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.delitem(sys.modules, "psycopg", raising=False)
+    monkeypatch.setattr(builtins, "__import__", _missing_psycopg)
+
+    with pytest.raises(RuntimeError, match="psycopg"):
+        PGVectorStore("postgresql://cellin/test")
+
+
+def test_pgvector_store_creates_schema_upserts_and_searches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_psycopg = _FakePsycopg([("m1", 0.1), ("m2", 1.4)])
+    monkeypatch.setitem(sys.modules, "psycopg", fake_psycopg)
+
+    vector_store = PGVectorStore("postgresql://cellin/test", table_name="cellin_vectors_test")
+    vector_store.upsert("m1", "atlas architecture graph")
+    results = vector_store.search("atlas graph", limit=2)
+
+    assert fake_psycopg.connection_strings == ["postgresql://cellin/test"] * 3
+    queries = [query for query, _ in fake_psycopg.calls]
+    assert any("CREATE TABLE IF NOT EXISTS cellin_vectors_test" in query for query in queries)
+    assert any("INSERT INTO cellin_vectors_test" in query for query in queries)
+    assert any("SELECT memory_id, vector <=> %s AS distance" in query for query in queries)
+    assert tuple(result.memory_id for result in results) == ("m1", "m2")
+    assert results[0].score == pytest.approx(0.9)
+    assert results[1].score == pytest.approx(0.0)
+
+
+def test_pgvector_store_limit_zero_short_circuits(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_psycopg = _FakePsycopg([("m1", 0.1)])
+    monkeypatch.setitem(sys.modules, "psycopg", fake_psycopg)
+
+    vector_store = PGVectorStore("postgresql://cellin/test")
+
+    assert vector_store.search("atlas graph", limit=0) == ()
+    assert len(fake_psycopg.calls) == 1
+
+
+def test_in_memory_vector_index_respects_search_limit_zero() -> None:
+    vector_index = InMemoryVectorIndex()
+    vector_index.upsert("memory-1", "atlas architecture")
+    assert vector_index.search("atlas", limit=0) == ()
+
+
+def test_cosine_similarity_returns_zero_for_empty_vectors() -> None:
+    assert cosine_similarity((), ()) == 0.0
+    assert cosine_similarity((), (1.0, 0.0)) == 0.0

--- a/tests/unit/test_candidate_generation_additional.py
+++ b/tests/unit/test_candidate_generation_additional.py
@@ -1,0 +1,129 @@
+"""Additional coverage for retrieval candidate generation internals."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from unittest.mock import create_autospec
+
+from cellin.core import (
+    DecayState,
+    MemoryAtom,
+    MemoryKind,
+    MemoryStore,
+    Modality,
+    Provenance,
+    RetrievalStats,
+    VectorMatch,
+)
+from cellin.retrieval import RetrievalCandidateGenerator
+
+
+def _memory(
+    memory_id: str,
+    *,
+    text: str = "atlas",
+    metadata: dict[str, object] | None = None,
+) -> MemoryAtom:
+    now = datetime(2026, 4, 5, tzinfo=UTC)
+    return MemoryAtom(
+        memory_id=memory_id,
+        kind=MemoryKind.ATOM,
+        text=text,
+        provenance=Provenance(source_id=memory_id, source_type="fixture"),
+        modality=Modality.TEXT,
+        created_at=now,
+        observed_at=now,
+        decay=DecayState(half_life_days=14.0),
+        retrieval=RetrievalStats(),
+        metadata=metadata or {},
+    )
+
+
+@dataclass(slots=True)
+class _UnknownIdVectorStore:
+    memory: str
+
+    def upsert(self, memory_id: str, text: str) -> None:
+        del memory_id, text
+
+    def search(self, query: str, *, limit: int = 5) -> tuple[VectorMatch, ...]:
+        del query
+        return (VectorMatch(memory_id=self.memory, score=0.7),)[: max(0, limit)]
+
+
+def _memory_store(memories: tuple[MemoryAtom, ...]) -> MemoryStore:
+    indexed = {memory.memory_id: memory for memory in memories}
+    memory_store = create_autospec(MemoryStore, instance=True)
+    memory_store.list.return_value = memories
+    memory_store.get.side_effect = indexed.get
+    return memory_store
+
+
+def test_seed_candidates_returns_empty_for_non_positive_limit() -> None:
+    generator = RetrievalCandidateGenerator(memory_store=_memory_store(()))
+    assert (
+        generator._seed_candidates(
+            query="atlas",
+            ranked_by_seed=[],
+            ranked_by_vector=(),
+            limit=0,
+        )
+        == []
+    )
+
+
+def test_rank_by_vector_seed_skips_unknown_memory_ids() -> None:
+    generator = RetrievalCandidateGenerator(
+        memory_store=_memory_store((_memory("known"),)),
+        vector_store=_UnknownIdVectorStore("missing"),
+    )
+
+    candidates = generator._rank_by_vector_seed("atlas", (_memory("known"),))
+
+    assert candidates == ()
+
+
+def test_candidate_index_merges_duplicate_candidates() -> None:
+    generator = RetrievalCandidateGenerator(memory_store=_memory_store(()))
+    candidate = generator._candidate_index(
+        [
+            _memory("same", metadata={"from_seed": True}),
+            replace(_memory("same"), metadata={"from_graph": True}),
+        ]
+    )
+
+    merged = candidate["same"]
+    assert merged.metadata["from_seed"] is True
+    assert merged.metadata["from_graph"] is True
+
+
+def test_expand_graph_neighbors_noop_when_graph_store_is_missing() -> None:
+    seed_candidates = [_memory("seed")]
+    candidates = {_memory("seed").memory_id: _memory("seed")}
+    generator = RetrievalCandidateGenerator(memory_store=_memory_store((_memory("seed"),)))
+
+    generator._expand_graph_neighbors(seed_candidates, candidates)
+
+    assert candidates == {_memory("seed").memory_id: _memory("seed")}
+
+
+def test_get_neighbor_memory_falls_back_to_memory_store() -> None:
+    memory = _memory("fallback")
+    generator = RetrievalCandidateGenerator(memory_store=_memory_store((memory,)))
+
+    assert generator._get_neighbor_memory(memory.memory_id) == memory
+
+
+def test_assemble_ordered_candidates_dedupes_ranked_memories_and_adds_missing_candidates() -> None:
+    ranked_by_seed = [_memory("first"), _memory("second"), _memory("second")]
+    candidates = {
+        "first": _memory("first"),
+        "second": _memory("second"),
+        "third": _memory("third"),
+    }
+    generator = RetrievalCandidateGenerator(memory_store=_memory_store(tuple(candidates.values())))
+
+    ordered = generator._assemble_ordered_candidates(ranked_by_seed, candidates, limit=3)
+
+    assert tuple(memory.memory_id for memory in ordered) == ("first", "second", "third")

--- a/tests/unit/test_ranking_additional.py
+++ b/tests/unit/test_ranking_additional.py
@@ -10,8 +10,9 @@ from cellin.core import DecayState, MemoryAtom, MemoryKind, Modality, Provenance
 from cellin.ranking import WeightedRanker, get_weight_profile
 
 
-def _memory(text: str) -> MemoryAtom:
+def _memory(text: str, *, metadata: dict[str, object] | None = None) -> MemoryAtom:
     now = datetime(2026, 4, 5, tzinfo=UTC)
+    metadata_values = {} if metadata is None else metadata
     return MemoryAtom(
         memory_id="memory-1",
         kind=MemoryKind.ATOM,
@@ -22,6 +23,7 @@ def _memory(text: str) -> MemoryAtom:
         observed_at=now,
         decay=DecayState(half_life_days=14.0),
         retrieval=RetrievalStats(),
+        metadata=metadata_values,
     )
 
 
@@ -37,3 +39,16 @@ def test_weighted_ranker_handles_empty_query_tokens() -> None:
 
     assert scored[0].factors[0].name == "semantic_similarity"
     assert scored[0].factors[0].value == pytest.approx(0.0)
+
+
+def test_weighted_ranker_includes_vector_similarity_factor() -> None:
+    ranker = WeightedRanker(profile=get_weight_profile("balanced"))
+
+    scored = ranker.score(
+        "irrelevant query",
+        (_memory("Atlas retrieval", metadata={"vector_score": 0.77}),),
+    )
+
+    assert scored[0].factors[7].name == "vector_similarity"
+    assert scored[0].factors[7].value == pytest.approx(0.77)
+    assert scored[0].factors[7].rationale.startswith("Vector-space similarity")


### PR DESCRIPTION
## Issue
- #77

## Root cause
- Retrieval candidates were primarily lexical/graph-centric while vector retrieval remained coupled to a concrete in-memory path.
- Vector ranking signals were not a first-class, traceable input to hybrid ranking.

## Fix
- Introduced VectorStore-backed retrieval ingestion and hybrid candidate generation for lexical, vector, and graph candidates.
- Added first-party vector backends for `sqlite_vec` and `pgvector`, with in-memory kept as the default path.
- Updated runtime vector backend registration so backends resolve through the shared contract.
- Made vector contributions explicit in ranking factors.
- Added regression/eval coverage proving vector search changes candidate behavior.

## Validation
- `make release-smoke`
- 122 tests passed, coverage and build/install checks satisfied.

Closes #77
