### PR TITLE
feat(storage): add first-party SQL memory and graph backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,38 @@ For an explicit SQLite preset, set:
 }
 ```
 
+For additional SQL-backed presets, install optional dependencies as needed:
+
+```bash
+python3 -m pip install cellin[duckdb]
+python3 -m pip install cellin[postgresql]
+python3 -m pip install cellin[mysql]
+python3 -m pip install cellin[sql-backends]
+```
+
+Use `duckdb` to point both roles at a local DB file:
+
+```json
+{
+  "memory": { "backend": "duckdb", "database_path": "cellin.duckdb" },
+  "graph": { "backend": "duckdb", "database_path": "cellin.duckdb" }
+}
+```
+
+Use `postgresql` and `mysql` with connection strings:
+
+```json
+{
+  "memory": { "backend": "postgresql", "database_path": "postgresql://user:pass@host:5432/db" },
+  "graph": { "backend": "postgresql", "database_path": "postgresql://user:pass@host:5432/db" }
+}
+
+{
+  "memory": { "backend": "mysql", "database_path": "mysql://user:pass@host:3306/db" },
+  "graph": { "backend": "mysql", "database_path": "mysql://user:pass@host:3306/db" }
+}
+```
+
 
 ## Primary surfaces
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,12 @@ dev = [
   "twine>=6.1.0",
 ]
 
+[project.optional-dependencies]
+duckdb = ["duckdb"]
+mysql = ["mysql-connector-python"]
+postgresql = ["psycopg"]
+sql-backends = ["duckdb", "psycopg", "mysql-connector-python"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/cellin"]
 

--- a/src/cellin/runtime/storage.py
+++ b/src/cellin/runtime/storage.py
@@ -8,10 +8,16 @@ from typing import Literal, Protocol, cast
 
 from cellin.core import GraphStore, MemoryStore, VectorStore
 from cellin.stores import (
+    DuckDBGraphStore,
+    DuckDBMemoryStore,
     InMemoryGraphStore,
     InMemoryMemoryStore,
     InMemoryVectorIndex,
+    MySQLGraphStore,
+    MySQLMemoryStore,
     PGVectorStore,
+    PostgreSQLGraphStore,
+    PostgreSQLMemoryStore,
     SQLiteGraphStore,
     SQLiteMemoryStore,
     SQLiteVecStore,
@@ -135,6 +141,78 @@ def _build_sqlite_graph_store(
     return SQLiteGraphStore(database_path)
 
 
+def _build_duckdb_memory_store(
+    config: StorageBackendConfig,
+    *,
+    workspace_root: Path,
+) -> MemoryStore:
+    database_path = _resolve_database_path(
+        config.database_path,
+        workspace_root=workspace_root,
+    )
+    return DuckDBMemoryStore(database_path)
+
+
+def _build_duckdb_graph_store(
+    config: StorageBackendConfig,
+    *,
+    workspace_root: Path,
+) -> GraphStore:
+    database_path = _resolve_database_path(
+        config.database_path,
+        workspace_root=workspace_root,
+    )
+    return DuckDBGraphStore(database_path)
+
+
+def _build_postgresql_memory_store(
+    config: StorageBackendConfig,
+    *,
+    workspace_root: Path,
+) -> MemoryStore:
+    del workspace_root
+    connection_string = config.database_path
+    if not connection_string:
+        raise StorageBackendError("postgresql backend requires a connection string")
+    return PostgreSQLMemoryStore(connection_string)
+
+
+def _build_postgresql_graph_store(
+    config: StorageBackendConfig,
+    *,
+    workspace_root: Path,
+) -> GraphStore:
+    del workspace_root
+    connection_string = config.database_path
+    if not connection_string:
+        raise StorageBackendError("postgresql backend requires a connection string")
+    return PostgreSQLGraphStore(connection_string)
+
+
+def _build_mysql_memory_store(
+    config: StorageBackendConfig,
+    *,
+    workspace_root: Path,
+) -> MemoryStore:
+    del workspace_root
+    connection_string = config.database_path
+    if not connection_string:
+        raise StorageBackendError("mysql backend requires a connection string")
+    return MySQLMemoryStore(connection_string)
+
+
+def _build_mysql_graph_store(
+    config: StorageBackendConfig,
+    *,
+    workspace_root: Path,
+) -> GraphStore:
+    del workspace_root
+    connection_string = config.database_path
+    if not connection_string:
+        raise StorageBackendError("mysql backend requires a connection string")
+    return MySQLGraphStore(connection_string)
+
+
 def _build_in_memory_memory_store(
     config: StorageBackendConfig,
     *,
@@ -187,13 +265,19 @@ def _build_pgvector_store(
 
 
 _MEMORY_BACKEND_REGISTRY: dict[str, BackendBuilder] = {
+    "duckdb": _build_duckdb_memory_store,
+    "mysql": _build_mysql_memory_store,
     "sqlite": _build_sqlite_memory_store,
+    "postgresql": _build_postgresql_memory_store,
     "in_memory": _build_in_memory_memory_store,
 }
 
 
 _GRAPH_BACKEND_REGISTRY: dict[str, BackendBuilder] = {
+    "duckdb": _build_duckdb_graph_store,
+    "mysql": _build_mysql_graph_store,
     "sqlite": _build_sqlite_graph_store,
+    "postgresql": _build_postgresql_graph_store,
     "in_memory": _build_in_memory_graph_store,
 }
 

--- a/src/cellin/stores/__init__.py
+++ b/src/cellin/stores/__init__.py
@@ -2,6 +2,14 @@
 
 from cellin.stores.in_memory import InMemoryGraphStore, InMemoryMemoryStore
 from cellin.stores.pgvector import PGVectorStore
+from cellin.stores.sql_backends import (
+    DuckDBGraphStore,
+    DuckDBMemoryStore,
+    MySQLGraphStore,
+    MySQLMemoryStore,
+    PostgreSQLGraphStore,
+    PostgreSQLMemoryStore,
+)
 from cellin.stores.sqlite import SQLiteGraphStore, SQLiteMemoryStore
 from cellin.stores.sqlite_vec import SQLiteVecStore
 from cellin.stores.vector_index import InMemoryVectorIndex, SearchResult
@@ -10,6 +18,12 @@ __all__ = [
     "InMemoryGraphStore",
     "InMemoryMemoryStore",
     "InMemoryVectorIndex",
+    "DuckDBGraphStore",
+    "DuckDBMemoryStore",
+    "MySQLGraphStore",
+    "MySQLMemoryStore",
+    "PostgreSQLGraphStore",
+    "PostgreSQLMemoryStore",
     "SearchResult",
     "PGVectorStore",
     "SQLiteGraphStore",

--- a/src/cellin/stores/sql_backends.py
+++ b/src/cellin/stores/sql_backends.py
@@ -1,0 +1,601 @@
+"""Shared SQL-backed memory and graph stores for first-party relational backends."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol, cast
+from urllib.parse import unquote, urlparse
+
+from cellin.core import MemoryAtom, MemoryEdge, MemoryStore
+from cellin.stores.sqlite import _dump_edge, _dump_memory, _edge_archived, _load_edge, _load_memory
+
+
+class _MissingDuckDBDependencyError(RuntimeError):
+    """Raised when DuckDB is unavailable from runtime dependencies."""
+
+
+class _MissingPostgreSQLDependencyError(RuntimeError):
+    """Raised when psycopg is unavailable from runtime dependencies."""
+
+
+class _MissingMySQLDependencyError(RuntimeError):
+    """Raised when a MySQL driver is unavailable from runtime dependencies."""
+
+
+class _QueryResult(Protocol):
+    def fetchall(self) -> list[tuple[Any, ...]]: ...
+
+
+class _ExecutableConnection(Protocol):
+    def execute(self, query: str, parameters: Sequence[object] | None = None) -> _QueryResult: ...
+
+    def __enter__(self) -> _ExecutableConnection: ...
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None: ...
+
+
+@dataclass(frozen=True)
+class _BackendSpec:
+    parameter_style: str
+    upsert_memory_sql: str
+    upsert_edge_sql: str
+
+
+class _RelationalBackend:
+    _MEMORY_GET_SQL = "SELECT payload FROM memories WHERE memory_id = ?"
+    _MEMORY_LIST_SQL = "SELECT payload FROM memories ORDER BY memory_id"
+    _NEIGHBORS_SQL = """
+    SELECT payload
+    FROM edges
+    WHERE source_id = ? OR target_id = ?
+    ORDER BY edge_id
+    """
+    _EDGES_LIST_SQL = "SELECT payload FROM edges ORDER BY edge_id"
+
+    def __init__(
+        self,
+        connection_key: str,
+        connect: Callable[[], _ExecutableConnection],
+        *,
+        spec: _BackendSpec,
+    ) -> None:
+        self._connection_key = connection_key
+        self._connect = connect
+        self._spec = spec
+        self._initialized = False
+        self._ensure_schema()
+
+    @staticmethod
+    def _consume_result(result: _QueryResult) -> None:
+        result.fetchall()
+
+    @staticmethod
+    def _parametrize(query: str, parameter_style: str) -> str:
+        return query.replace("?", parameter_style)
+
+    def _execute(
+        self,
+        connection: _ExecutableConnection,
+        query: str,
+        parameters: Sequence[object] = (),
+    ) -> _QueryResult | None:
+        return connection.execute(query, tuple(parameters) if parameters else ())
+
+    def _fetch_one(
+        self,
+        query: str,
+        parameters: Sequence[object] = (),
+    ) -> tuple[Any, ...] | None:
+        with self._connect() as connection:
+            result = self._execute(
+                connection,
+                self._parametrize(query, self._spec.parameter_style),
+                parameters,
+            )
+            if result is None:
+                return None
+            rows = tuple(result.fetchall())
+        return rows[0] if rows else None
+
+    def _fetch_all(
+        self,
+        query: str,
+        parameters: Sequence[object] = (),
+    ) -> tuple[tuple[Any, ...], ...]:
+        with self._connect() as connection:
+            result = self._execute(
+                connection,
+                self._parametrize(query, self._spec.parameter_style),
+                parameters,
+            )
+            if result is None:
+                return ()
+            return tuple(result.fetchall())
+
+    def _execute_many(self, query: str, rows: Sequence[tuple[object, ...]]) -> None:
+        if not rows:
+            return
+
+        with self._connect() as connection:
+            for row in rows:
+                result = self._execute(connection, query, row)
+                if result is not None:
+                    self._consume_result(result)
+
+    def _ensure_schema(self) -> None:
+        """Initialize schema exactly once per backend key."""
+        if self._initialized:
+            return
+
+        schema_statements = (
+            """
+            CREATE TABLE IF NOT EXISTS memories (
+                memory_id TEXT PRIMARY KEY,
+                payload TEXT NOT NULL
+            )
+            """,
+            """
+            CREATE TABLE IF NOT EXISTS edges (
+                edge_id TEXT PRIMARY KEY,
+                source_id TEXT NOT NULL,
+                target_id TEXT NOT NULL,
+                payload TEXT NOT NULL
+            )
+            """,
+        )
+
+        with self._connect() as connection:
+            for statement in schema_statements:
+                result = self._execute(connection, statement)
+                if result is not None:
+                    self._consume_result(result)
+
+        self._initialized = True
+
+    def put_memories(self, memories: Sequence[MemoryAtom]) -> None:
+        if not memories:
+            return
+
+        rows = tuple((memory.memory_id, _dump_memory(memory)) for memory in memories)
+        self._execute_many(
+            self._parametrize(self._spec.upsert_memory_sql, self._spec.parameter_style),
+            rows,
+        )
+
+    def get_memory(self, memory_id: str) -> MemoryAtom | None:
+        row = self._fetch_one(self._MEMORY_GET_SQL, (memory_id,))
+        if row is None:
+            return None
+        return _load_memory(row[0])
+
+    def list_memories(self) -> tuple[MemoryAtom, ...]:
+        rows = self._fetch_all(self._MEMORY_LIST_SQL)
+        return tuple(_load_memory(row[0]) for row in rows)
+
+    def upsert_edges(self, edges: Sequence[MemoryEdge]) -> None:
+        if not edges:
+            return
+
+        rows = tuple(
+            (edge.edge_id, edge.source_id, edge.target_id, _dump_edge(edge)) for edge in edges
+        )
+        self._execute_many(
+            self._parametrize(self._spec.upsert_edge_sql, self._spec.parameter_style),
+            rows,
+        )
+
+    def get_neighbors(self, memory_id: str) -> tuple[MemoryEdge, ...]:
+        rows = self._fetch_all(self._NEIGHBORS_SQL, (memory_id, memory_id))
+        return tuple(
+            edge
+            for row in rows
+            if not _edge_archived(
+                edge := _load_edge(row[0]),
+            )
+        )
+
+    def list_edges(self) -> tuple[MemoryEdge, ...]:
+        rows = self._fetch_all(self._EDGES_LIST_SQL)
+        return tuple(
+            edge
+            for row in rows
+            if not _edge_archived(
+                edge := _load_edge(row[0]),
+            )
+        )
+
+
+_BACKENDS: dict[tuple[str, str], _RelationalBackend] = {}
+
+
+def _backend_for(
+    label: str,
+    connection_key: str,
+    connect: Callable[[], _ExecutableConnection],
+    *,
+    parameter_style: str,
+    upsert_memory_sql: str,
+    upsert_edge_sql: str,
+) -> _RelationalBackend:
+    backend_key = (label, connection_key)
+    backend = _BACKENDS.get(backend_key)
+    if backend is None:
+        backend = _RelationalBackend(
+            connection_key,
+            connect,
+            spec=_BackendSpec(
+                parameter_style=parameter_style,
+                upsert_memory_sql=upsert_memory_sql,
+                upsert_edge_sql=upsert_edge_sql,
+            ),
+        )
+        _BACKENDS[backend_key] = backend
+    return backend
+
+
+def _build_duckdb_connection(database_path: str) -> Callable[[], _ExecutableConnection]:
+    def connect() -> _ExecutableConnection:
+        try:
+            import duckdb  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise _MissingDuckDBDependencyError(
+                "duckdb backend requires optional dependency `duckdb`"
+            ) from exc
+
+        return cast(_ExecutableConnection, duckdb.connect(database_path))
+
+    return connect
+
+
+def _build_postgresql_connection(connection_string: str) -> Callable[[], _ExecutableConnection]:
+    def connect() -> _ExecutableConnection:
+        try:
+            import psycopg  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise _MissingPostgreSQLDependencyError(
+                "postgresql backend requires optional dependency `psycopg`"
+            ) from exc
+
+        return cast(_ExecutableConnection, psycopg.connect(connection_string))
+
+    return connect
+
+
+def _resolve_file_path(database_path: str) -> str:
+    if database_path == ":memory:":
+        return database_path
+    return str(Path(database_path).resolve())
+
+
+@dataclass(frozen=True)
+class _MySQLConnectionParams:
+    user: str | None
+    password: str | None
+    host: str | None
+    port: int | None
+    database: str | None
+
+
+def _parse_mysql_connection_string(connection_string: str) -> _MySQLConnectionParams:
+    parsed = urlparse(connection_string)
+    if parsed.scheme not in {
+        "mysql",
+        "mysql+mysqlconnector",
+        "mysql+mysql-connector-python",
+    }:
+        raise ValueError("mysql backend requires a mysql:// connection string")
+
+    return _MySQLConnectionParams(
+        user=unquote(parsed.username) if parsed.username is not None else None,
+        password=unquote(parsed.password) if parsed.password is not None else None,
+        host=parsed.hostname,
+        port=parsed.port,
+        database=(parsed.path[1:] if parsed.path else None) or None,
+    )
+
+
+class _MySQLCursor:
+    def __init__(self, cursor: Any) -> None:
+        self._cursor = cursor
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        rows = self._cursor.fetchall()
+        self._cursor.close()
+        return list(rows)
+
+
+class _MySQLConnection:
+    def __init__(self, connection: Any) -> None:
+        self._connection = connection
+
+    def __enter__(self) -> _MySQLConnection:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        self._connection.close()
+
+    def execute(self, query: str, parameters: Sequence[object] | None = None) -> _QueryResult:
+        cursor = self._connection.cursor()
+        cursor.execute(query, tuple(parameters) if parameters else ())
+        return _MySQLCursor(cursor)
+
+
+def _build_mysql_connection(connection_string: str) -> Callable[[], _ExecutableConnection]:
+    def connect() -> _ExecutableConnection:
+        try:
+            from mysql import connector  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise _MissingMySQLDependencyError(
+                "mysql backend requires optional dependency `mysql-connector-python`"
+            ) from exc
+
+        parsed = _parse_mysql_connection_string(connection_string)
+
+        connection_kwargs: dict[str, object] = {"autocommit": True}
+        if parsed.user is not None:
+            connection_kwargs["user"] = parsed.user
+        if parsed.password is not None:
+            connection_kwargs["password"] = parsed.password
+        if parsed.host is not None:
+            connection_kwargs["host"] = parsed.host
+        if parsed.port is not None:
+            connection_kwargs["port"] = parsed.port
+        if parsed.database is not None:
+            connection_kwargs["database"] = parsed.database
+
+        connection = connector.connect(**connection_kwargs)
+        return _MySQLConnection(connection)
+
+    return connect
+
+
+_DUCKDB_MEMORY_UPSERT_SQL = """
+INSERT INTO memories(memory_id, payload)
+VALUES (?, ?)
+ON CONFLICT(memory_id) DO UPDATE SET payload = excluded.payload
+"""
+
+_DUCKDB_EDGE_UPSERT_SQL = """
+INSERT INTO edges(edge_id, source_id, target_id, payload)
+VALUES (?, ?, ?, ?)
+ON CONFLICT(edge_id) DO UPDATE SET payload = excluded.payload
+"""
+
+_POSTGRES_MEMORY_UPSERT_SQL = """
+INSERT INTO memories(memory_id, payload)
+VALUES (%s, %s)
+ON CONFLICT(memory_id) DO UPDATE SET payload = EXCLUDED.payload
+"""
+
+_POSTGRES_EDGE_UPSERT_SQL = """
+INSERT INTO edges(edge_id, source_id, target_id, payload)
+VALUES (%s, %s, %s, %s)
+ON CONFLICT(edge_id) DO UPDATE SET payload = EXCLUDED.payload
+"""
+
+_MYSQL_MEMORY_UPSERT_SQL = """
+INSERT INTO memories(memory_id, payload)
+VALUES (%s, %s)
+ON DUPLICATE KEY UPDATE payload = VALUES(payload)
+"""
+
+_MYSQL_EDGE_UPSERT_SQL = """
+INSERT INTO edges(edge_id, source_id, target_id, payload)
+VALUES (%s, %s, %s, %s)
+ON DUPLICATE KEY UPDATE payload = VALUES(payload)
+"""
+
+
+class DuckDBMemoryStore:
+    """Relational memory store backed by DuckDB."""
+
+    def __init__(self, database_path: str) -> None:
+        self._database_path = _resolve_file_path(database_path)
+        self._backend = _backend_for(
+            "duckdb",
+            self._database_path,
+            _build_duckdb_connection(self._database_path),
+            parameter_style="?",
+            upsert_memory_sql=_DUCKDB_MEMORY_UPSERT_SQL,
+            upsert_edge_sql=_DUCKDB_EDGE_UPSERT_SQL,
+        )
+
+    def put(self, memory: MemoryAtom) -> None:
+        self.put_many((memory,))
+
+    def put_many(self, memories: Sequence[MemoryAtom]) -> None:
+        self._backend.put_memories(memories)
+
+    def get(self, memory_id: str) -> MemoryAtom | None:
+        return self._backend.get_memory(memory_id)
+
+    def list(self) -> tuple[MemoryAtom, ...]:
+        return self._backend.list_memories()
+
+
+class DuckDBGraphStore:
+    """Relational graph store backed by DuckDB."""
+
+    def __init__(self, database_path: str) -> None:
+        self._database_path = _resolve_file_path(database_path)
+        self._backend = _backend_for(
+            "duckdb",
+            self._database_path,
+            _build_duckdb_connection(self._database_path),
+            parameter_style="?",
+            upsert_memory_sql=_DUCKDB_MEMORY_UPSERT_SQL,
+            upsert_edge_sql=_DUCKDB_EDGE_UPSERT_SQL,
+        )
+
+    def upsert_memory(self, memory: MemoryAtom) -> None:
+        self._backend.put_memories((memory,))
+
+    def upsert_memories(self, memories: Sequence[MemoryAtom]) -> None:
+        self._backend.put_memories(memories)
+
+    def upsert_edge(self, edge: MemoryEdge) -> None:
+        self._backend.upsert_edges((edge,))
+
+    def upsert_edges(self, edges: Sequence[MemoryEdge]) -> None:
+        self._backend.upsert_edges(edges)
+
+    def shares_memory_store(self, memory_store: MemoryStore) -> bool:
+        return (
+            isinstance(memory_store, DuckDBMemoryStore) and memory_store._backend is self._backend
+        )
+
+    def get_memory(self, memory_id: str) -> MemoryAtom | None:
+        return self._backend.get_memory(memory_id)
+
+    def neighbors(self, memory_id: str) -> tuple[MemoryEdge, ...]:
+        return self._backend.get_neighbors(memory_id)
+
+    def list_edges(self) -> tuple[MemoryEdge, ...]:
+        return self._backend.list_edges()
+
+
+class PostgreSQLMemoryStore:
+    """Relational memory store backed by PostgreSQL."""
+
+    def __init__(self, connection_string: str) -> None:
+        self._connection_string = connection_string
+        self._backend = _backend_for(
+            "postgresql",
+            connection_string,
+            _build_postgresql_connection(connection_string),
+            parameter_style="%s",
+            upsert_memory_sql=_POSTGRES_MEMORY_UPSERT_SQL,
+            upsert_edge_sql=_POSTGRES_EDGE_UPSERT_SQL,
+        )
+
+    def put(self, memory: MemoryAtom) -> None:
+        self.put_many((memory,))
+
+    def put_many(self, memories: Sequence[MemoryAtom]) -> None:
+        self._backend.put_memories(memories)
+
+    def get(self, memory_id: str) -> MemoryAtom | None:
+        return self._backend.get_memory(memory_id)
+
+    def list(self) -> tuple[MemoryAtom, ...]:
+        return self._backend.list_memories()
+
+
+class PostgreSQLGraphStore:
+    """Relational graph store backed by PostgreSQL."""
+
+    def __init__(self, connection_string: str) -> None:
+        self._connection_string = connection_string
+        self._backend = _backend_for(
+            "postgresql",
+            connection_string,
+            _build_postgresql_connection(connection_string),
+            parameter_style="%s",
+            upsert_memory_sql=_POSTGRES_MEMORY_UPSERT_SQL,
+            upsert_edge_sql=_POSTGRES_EDGE_UPSERT_SQL,
+        )
+
+    def upsert_memory(self, memory: MemoryAtom) -> None:
+        self._backend.put_memories((memory,))
+
+    def upsert_memories(self, memories: Sequence[MemoryAtom]) -> None:
+        self._backend.put_memories(memories)
+
+    def upsert_edge(self, edge: MemoryEdge) -> None:
+        self._backend.upsert_edges((edge,))
+
+    def upsert_edges(self, edges: Sequence[MemoryEdge]) -> None:
+        self._backend.upsert_edges(edges)
+
+    def shares_memory_store(self, memory_store: MemoryStore) -> bool:
+        return (
+            isinstance(memory_store, PostgreSQLMemoryStore)
+            and memory_store._backend is self._backend
+        )
+
+    def get_memory(self, memory_id: str) -> MemoryAtom | None:
+        return self._backend.get_memory(memory_id)
+
+    def neighbors(self, memory_id: str) -> tuple[MemoryEdge, ...]:
+        return self._backend.get_neighbors(memory_id)
+
+    def list_edges(self) -> tuple[MemoryEdge, ...]:
+        return self._backend.list_edges()
+
+
+class MySQLMemoryStore:
+    """Relational memory store backed by MySQL."""
+
+    def __init__(self, connection_string: str) -> None:
+        self._connection_string = connection_string
+        self._backend = _backend_for(
+            "mysql",
+            connection_string,
+            _build_mysql_connection(connection_string),
+            parameter_style="%s",
+            upsert_memory_sql=_MYSQL_MEMORY_UPSERT_SQL,
+            upsert_edge_sql=_MYSQL_EDGE_UPSERT_SQL,
+        )
+
+    def put(self, memory: MemoryAtom) -> None:
+        self.put_many((memory,))
+
+    def put_many(self, memories: Sequence[MemoryAtom]) -> None:
+        self._backend.put_memories(memories)
+
+    def get(self, memory_id: str) -> MemoryAtom | None:
+        return self._backend.get_memory(memory_id)
+
+    def list(self) -> tuple[MemoryAtom, ...]:
+        return self._backend.list_memories()
+
+
+class MySQLGraphStore:
+    """Relational graph store backed by MySQL."""
+
+    def __init__(self, connection_string: str) -> None:
+        self._connection_string = connection_string
+        self._backend = _backend_for(
+            "mysql",
+            connection_string,
+            _build_mysql_connection(connection_string),
+            parameter_style="%s",
+            upsert_memory_sql=_MYSQL_MEMORY_UPSERT_SQL,
+            upsert_edge_sql=_MYSQL_EDGE_UPSERT_SQL,
+        )
+
+    def upsert_memory(self, memory: MemoryAtom) -> None:
+        self._backend.put_memories((memory,))
+
+    def upsert_memories(self, memories: Sequence[MemoryAtom]) -> None:
+        self._backend.put_memories(memories)
+
+    def upsert_edge(self, edge: MemoryEdge) -> None:
+        self._backend.upsert_edges((edge,))
+
+    def upsert_edges(self, edges: Sequence[MemoryEdge]) -> None:
+        self._backend.upsert_edges(edges)
+
+    def shares_memory_store(self, memory_store: MemoryStore) -> bool:
+        return isinstance(memory_store, MySQLMemoryStore) and memory_store._backend is self._backend
+
+    def get_memory(self, memory_id: str) -> MemoryAtom | None:
+        return self._backend.get_memory(memory_id)
+
+    def neighbors(self, memory_id: str) -> tuple[MemoryEdge, ...]:
+        return self._backend.get_neighbors(memory_id)
+
+    def list_edges(self) -> tuple[MemoryEdge, ...]:
+        return self._backend.list_edges()
+
+
+__all__ = [
+    "DuckDBMemoryStore",
+    "DuckDBGraphStore",
+    "PostgreSQLMemoryStore",
+    "PostgreSQLGraphStore",
+    "MySQLMemoryStore",
+    "MySQLGraphStore",
+]

--- a/tests/contracts/test_storage.py
+++ b/tests/contracts/test_storage.py
@@ -14,7 +14,16 @@ from cellin.runtime.storage import (
     StorageConfig,
     build_storage_bundle,
 )
-from cellin.stores import SQLiteMemoryStore, SQLiteVecStore
+from cellin.stores import (
+    DuckDBGraphStore,
+    DuckDBMemoryStore,
+    MySQLGraphStore,
+    MySQLMemoryStore,
+    PostgreSQLGraphStore,
+    PostgreSQLMemoryStore,
+    SQLiteMemoryStore,
+    SQLiteVecStore,
+)
 
 
 def test_load_workspace_migrates_legacy_database_path(tmp_path: Path) -> None:
@@ -127,6 +136,108 @@ def test_build_storage_bundle_resolves_pgvector_backend(
     assert bundle.vector_store.connection_string == "postgresql://cellin/test"
 
 
+def test_build_storage_bundle_resolves_duckdb_backends_and_backend_shares_storage(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    shared_backend = object()
+
+    class _FakeDuckDBMemoryStore(DuckDBMemoryStore):
+        def __init__(self, database_path: str) -> None:
+            self._database_path = database_path
+            self._backend = shared_backend
+
+    class _FakeDuckDBGraphStore(DuckDBGraphStore):
+        def __init__(self, database_path: str) -> None:
+            self._database_path = database_path
+            self._backend = shared_backend
+
+    monkeypatch.setattr("cellin.runtime.storage.DuckDBMemoryStore", _FakeDuckDBMemoryStore)
+    monkeypatch.setattr("cellin.runtime.storage.DuckDBGraphStore", _FakeDuckDBGraphStore)
+
+    config = StorageConfig(
+        memory=StorageBackendConfig("duckdb", "local.duckdb"),
+        graph=StorageBackendConfig("duckdb", "local.duckdb"),
+        vector=StorageBackendConfig("in_memory_vector_index"),
+        representation=StorageBackendConfig("in_memory_vector_index"),
+    )
+    bundle = build_storage_bundle(config, workspace_root=tmp_path)
+
+    assert isinstance(bundle.memory_store, _FakeDuckDBMemoryStore)
+    assert isinstance(bundle.graph_store, _FakeDuckDBGraphStore)
+    assert isinstance(bundle.graph_store._backend, object)
+    assert bundle.graph_store.shares_memory_store(bundle.memory_store)
+    assert bundle.memory_store._database_path == str((tmp_path / "local.duckdb").resolve())
+
+
+def test_build_storage_bundle_resolves_postgresql_memory_graph_backends(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    shared_backend = object()
+
+    class _FakePostgreSQLMemoryStore(PostgreSQLMemoryStore):
+        def __init__(self, connection_string: str) -> None:
+            self._connection_string = connection_string
+            self._backend = shared_backend
+
+    class _FakePostgreSQLGraphStore(PostgreSQLGraphStore):
+        def __init__(self, connection_string: str) -> None:
+            self._connection_string = connection_string
+            self._backend = shared_backend
+
+    monkeypatch.setattr("cellin.runtime.storage.PostgreSQLMemoryStore", _FakePostgreSQLMemoryStore)
+    monkeypatch.setattr("cellin.runtime.storage.PostgreSQLGraphStore", _FakePostgreSQLGraphStore)
+
+    connection_string = "postgresql://cellin/test"
+    config = StorageConfig(
+        memory=StorageBackendConfig("postgresql", connection_string),
+        graph=StorageBackendConfig("postgresql", connection_string),
+        vector=StorageBackendConfig("in_memory_vector_index"),
+        representation=StorageBackendConfig("in_memory_vector_index"),
+    )
+    bundle = build_storage_bundle(config, workspace_root=tmp_path)
+
+    assert isinstance(bundle.memory_store, _FakePostgreSQLMemoryStore)
+    assert isinstance(bundle.graph_store, _FakePostgreSQLGraphStore)
+    assert bundle.memory_store._connection_string == connection_string
+    assert bundle.graph_store.shares_memory_store(bundle.memory_store)
+
+
+def test_build_storage_bundle_resolves_mysql_memory_graph_backends(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    shared_backend = object()
+
+    class _FakeMySQLMemoryStore(MySQLMemoryStore):
+        def __init__(self, connection_string: str) -> None:
+            self._connection_string = connection_string
+            self._backend = shared_backend
+
+    class _FakeMySQLGraphStore(MySQLGraphStore):
+        def __init__(self, connection_string: str) -> None:
+            self._connection_string = connection_string
+            self._backend = shared_backend
+
+    monkeypatch.setattr("cellin.runtime.storage.MySQLMemoryStore", _FakeMySQLMemoryStore)
+    monkeypatch.setattr("cellin.runtime.storage.MySQLGraphStore", _FakeMySQLGraphStore)
+
+    connection_string = "mysql://cellin:test@localhost:3306/cellin"
+    config = StorageConfig(
+        memory=StorageBackendConfig("mysql", connection_string),
+        graph=StorageBackendConfig("mysql", connection_string),
+        vector=StorageBackendConfig("in_memory_vector_index"),
+        representation=StorageBackendConfig("in_memory_vector_index"),
+    )
+    bundle = build_storage_bundle(config, workspace_root=tmp_path)
+
+    assert isinstance(bundle.memory_store, _FakeMySQLMemoryStore)
+    assert isinstance(bundle.graph_store, _FakeMySQLGraphStore)
+    assert bundle.memory_store._connection_string == connection_string
+    assert bundle.graph_store.shares_memory_store(bundle.memory_store)
+
+
 def test_build_storage_bundle_rejects_pgvector_without_connection_string(
     tmp_path: Path,
 ) -> None:
@@ -138,6 +249,42 @@ def test_build_storage_bundle_rejects_pgvector_without_connection_string(
     )
 
     with pytest.raises(StorageBackendError, match="pgvector backend requires a connection string"):
+        build_storage_bundle(config, workspace_root=tmp_path)
+
+
+def test_build_storage_bundle_rejects_postgresql_without_connection_string(tmp_path: Path) -> None:
+    config = StorageConfig(
+        memory=StorageBackendConfig("postgresql"),
+        graph=StorageBackendConfig("postgresql"),
+        vector=StorageBackendConfig("in_memory_vector_index"),
+        representation=StorageBackendConfig("in_memory_vector_index"),
+    )
+    with pytest.raises(
+        StorageBackendError,
+        match="postgresql backend requires a connection string",
+    ):
+        build_storage_bundle(config, workspace_root=tmp_path)
+
+
+def test_build_storage_bundle_rejects_mysql_without_connection_string(tmp_path: Path) -> None:
+    config = StorageConfig(
+        memory=StorageBackendConfig("mysql"),
+        graph=StorageBackendConfig("mysql"),
+        vector=StorageBackendConfig("in_memory_vector_index"),
+        representation=StorageBackendConfig("in_memory_vector_index"),
+    )
+    with pytest.raises(StorageBackendError, match="mysql backend requires a connection string"):
+        build_storage_bundle(config, workspace_root=tmp_path)
+
+
+def test_build_storage_bundle_rejects_duckdb_without_database_path(tmp_path: Path) -> None:
+    config = StorageConfig(
+        memory=StorageBackendConfig("duckdb"),
+        graph=StorageBackendConfig("duckdb"),
+        vector=StorageBackendConfig("in_memory_vector_index"),
+        representation=StorageBackendConfig("in_memory_vector_index"),
+    )
+    with pytest.raises(StorageBackendError, match="database_path"):
         build_storage_bundle(config, workspace_root=tmp_path)
 
 

--- a/tests/integration/stores/test_sql_backends.py
+++ b/tests/integration/stores/test_sql_backends.py
@@ -1,0 +1,277 @@
+"""Integration coverage for first-party SQL memory and graph backends."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable, Sequence
+from datetime import UTC, datetime
+from types import ModuleType
+
+import pytest
+
+from cellin.core import (
+    DecayState,
+    EdgeKind,
+    MemoryAtom,
+    MemoryEdge,
+    MemoryKind,
+    Modality,
+    Provenance,
+    RetrievalStats,
+)
+from cellin.stores import (
+    DuckDBGraphStore,
+    DuckDBMemoryStore,
+    MySQLGraphStore,
+    MySQLMemoryStore,
+    PostgreSQLGraphStore,
+    PostgreSQLMemoryStore,
+    sql_backends,
+)
+
+
+def _memory(memory_id: str, text: str) -> MemoryAtom:
+    return MemoryAtom(
+        memory_id=memory_id,
+        kind=MemoryKind.ATOM,
+        text=text,
+        provenance=Provenance(source_id=memory_id, source_type="fixture"),
+        modality=Modality.TEXT,
+        created_at=datetime(2026, 4, 5, tzinfo=UTC),
+        observed_at=datetime(2026, 4, 5, tzinfo=UTC),
+        decay=DecayState(half_life_days=14.0),
+        retrieval=RetrievalStats(),
+    )
+
+
+def _edge(
+    edge_id: str,
+    source_id: str,
+    target_id: str,
+    *,
+    archived: bool,
+) -> MemoryEdge:
+    return MemoryEdge(
+        edge_id=edge_id,
+        source_id=source_id,
+        target_id=target_id,
+        kind=EdgeKind.SUPPORTS,
+        provenance=Provenance(source_id=edge_id, source_type="fixture"),
+        created_at=datetime(2026, 4, 5, tzinfo=UTC),
+        metadata={"archived": archived},
+    )
+
+
+class _FakeSQLResult:
+    def __init__(self, rows: Sequence[tuple[object, ...]]) -> None:
+        self._rows = rows
+
+    def fetchall(self) -> list[tuple[object, ...]]:
+        return list(self._rows)
+
+
+class _FakeSQLEngine:
+    def __init__(self) -> None:
+        self.memories: dict[str, str] = {}
+        self.edges: dict[str, tuple[str, str, str]] = {}
+        self.queries: list[tuple[str, tuple[object, ...]]] = []
+
+    def execute(self, query: str, parameters: Sequence[object] = ()) -> list[tuple[object, ...]]:
+        normalized_query = " ".join(query.lower().split())
+        params = tuple(parameters)
+        self.queries.append((query, params))
+
+        if "create table if not exists memories" in normalized_query:
+            return []
+        if "create table if not exists edges" in normalized_query:
+            return []
+
+        if "insert into memories" in normalized_query:
+            memory_id = str(params[0])
+            payload = str(params[1])
+            self.memories[memory_id] = payload
+            return []
+
+        if "select payload from memories where memory_id" in normalized_query:
+            memory_id = str(params[0])
+            payload = self.memories.get(memory_id)
+            return [(payload,)] if payload is not None else []
+
+        if "select payload from memories order by memory_id" in normalized_query:
+            return [(payload,) for _, payload in sorted(self.memories.items())]
+
+        if "insert into edges" in normalized_query:
+            edge_id = str(params[0])
+            source_id = str(params[1])
+            target_id = str(params[2])
+            payload = str(params[3])
+            self.edges[edge_id] = (source_id, target_id, payload)
+            return []
+
+        if "from edges" in normalized_query and "where source_id" in normalized_query:
+            memory_id = str(params[0])
+            rows = []
+            for _, (source_id, target_id, payload) in sorted(self.edges.items()):
+                if source_id == memory_id or target_id == memory_id:
+                    rows.append((payload,))
+            return rows
+
+        if "from edges order by edge_id" in normalized_query:
+            return [(payload,) for _, (_, _, payload) in sorted(self.edges.items())]
+
+        return []
+
+
+class _FakeSQLConnection:
+    def __init__(self, engine: _FakeSQLEngine) -> None:
+        self._engine = engine
+
+    def __enter__(self) -> _FakeSQLConnection:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        del exc_type, exc, tb
+
+    def execute(
+        self,
+        query: str,
+        params: Sequence[object] = (),
+    ) -> _FakeSQLResult:
+        rows = self._engine.execute(query, params)
+        return _FakeSQLResult(rows)
+
+
+class _FakeMySQLCursor:
+    def __init__(self, engine: _FakeSQLEngine) -> None:
+        self._engine = engine
+        self._rows: list[tuple[object, ...]] = []
+
+    def execute(self, query: str, params: Sequence[object] = ()) -> _FakeMySQLCursor:
+        self._rows = self._engine.execute(query, params)
+        return self
+
+    def fetchall(self) -> list[tuple[object, ...]]:
+        return list(self._rows)
+
+    def close(self) -> None:
+        self._rows = []
+
+
+class _FakeMySQLConnection:
+    def __init__(self, engine: _FakeSQLEngine) -> None:
+        self._engine = engine
+
+    def __enter__(self) -> _FakeMySQLConnection:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        del exc_type, exc, tb
+
+    def close(self) -> None:
+        return None
+
+    def cursor(self) -> _FakeMySQLCursor:
+        return _FakeMySQLCursor(self._engine)
+
+
+def _install_duckdb(monkeypatch: pytest.MonkeyPatch, engine: _FakeSQLEngine) -> None:
+    module = ModuleType("duckdb")
+    module.connect = lambda _: _FakeSQLConnection(engine)
+    monkeypatch.setitem(sys.modules, "duckdb", module)
+
+
+def _install_postgresql(monkeypatch: pytest.MonkeyPatch, engine: _FakeSQLEngine) -> None:
+    module = ModuleType("psycopg")
+    module.connect = lambda *_: _FakeSQLConnection(engine)
+    monkeypatch.setitem(sys.modules, "psycopg", module)
+
+
+def _install_mysql(monkeypatch: pytest.MonkeyPatch, engine: _FakeSQLEngine) -> None:
+    connector_module = ModuleType("mysql.connector")
+    connector_module.connect = lambda **_: _FakeMySQLConnection(engine)
+    mysql_module = ModuleType("mysql")
+    mysql_module.connector = connector_module
+    monkeypatch.setitem(sys.modules, "mysql", mysql_module)
+    monkeypatch.setitem(sys.modules, "mysql.connector", connector_module)
+
+
+@pytest.mark.parametrize(
+    "label,memory_cls,graph_cls,backend_id,install_driver",
+    [
+        ("duckdb", DuckDBMemoryStore, DuckDBGraphStore, "cellin.duckdb", _install_duckdb),
+        (
+            "postgresql",
+            PostgreSQLMemoryStore,
+            PostgreSQLGraphStore,
+            "postgresql://cellin/test",
+            _install_postgresql,
+        ),
+        (
+            "mysql",
+            MySQLMemoryStore,
+            MySQLGraphStore,
+            "mysql://cellin:test@localhost:3306/cellin",
+            _install_mysql,
+        ),
+    ],
+)
+def test_sql_backends_share_memory_store_and_filter_archived_edges(
+    label: str,
+    memory_cls: type,
+    graph_cls: type,
+    backend_id: str,
+    install_driver: Callable[[pytest.MonkeyPatch, _FakeSQLEngine], None],
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sql_backends._BACKENDS.clear()
+    engine = _FakeSQLEngine()
+    install_driver(monkeypatch, engine)
+
+    active = _edge("edge-active", "memory-1", "memory-2", archived=False)
+    archived = _edge("edge-archived", "memory-1", "memory-3", archived=True)
+    support_memory = _memory("support-memory", "Support memory")
+
+    connection_key = str((tmp_path / backend_id).resolve()) if label == "duckdb" else backend_id
+    memory_store = memory_cls(connection_key)
+    graph_store = graph_cls(connection_key)
+    initial_create_count = len(
+        [query for query, _ in engine.queries if "CREATE TABLE IF NOT EXISTS" in query.upper()]
+    )
+
+    memory_store.put(_memory("memory-1", "Atlas memory"))
+    memory_store.put(_memory("memory-2", "Second memory"))
+    memory_store.put_many(())
+    graph_store.upsert_edges((active, archived))
+    graph_store.upsert_memories((support_memory,))
+    graph_store.upsert_edge(active)
+    graph_store.upsert_edges(())
+
+    assert memory_store.get("memory-1") == _memory("memory-1", "Atlas memory")
+    assert memory_store.get("missing-memory") is None
+    assert graph_store.get_memory("memory-1") == _memory("memory-1", "Atlas memory")
+    assert graph_store.neighbors("memory-1") == (active,)
+    assert graph_store.list_edges() == (active,)
+    assert graph_store.shares_memory_store(memory_store)
+    assert memory_store.list() == (
+        _memory("memory-1", "Atlas memory"),
+        _memory("memory-2", "Second memory"),
+        _memory("support-memory", "Support memory"),
+    )
+
+    # Re-instantiating stores with the same connection should be idempotent and share
+    # one initialized schema.
+    duplicate_memory_store = memory_cls(connection_key)
+    duplicate_graph_store = graph_cls(connection_key)
+    duplicate_graph_store.upsert_memory(_memory("memory-1", "Atlas revised"))
+    duplicate_memory_store.put(_memory("memory-3", "Third memory"))
+
+    assert duplicate_graph_store.shares_memory_store(duplicate_memory_store)
+    assert duplicate_graph_store.shares_memory_store(memory_store)
+    assert memory_store.get("memory-1").text == "Atlas revised"
+
+    final_create_count = len(
+        [query for query, _ in engine.queries if "CREATE TABLE IF NOT EXISTS" in query.upper()]
+    )
+    assert final_create_count == initial_create_count
+    assert final_create_count == 2

--- a/tests/unit/test_sql_backends_unit.py
+++ b/tests/unit/test_sql_backends_unit.py
@@ -1,0 +1,101 @@
+"""Unit tests for low-level SQL backend internals."""
+
+from __future__ import annotations
+
+import builtins
+
+import pytest
+
+from cellin.stores import sql_backends
+
+
+class _NullResultConnection:
+    def __enter__(self) -> _NullResultConnection:
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+        del exc_type, exc, tb
+
+    def execute(self, query: str, parameters: tuple[object, ...] = ()) -> None:
+        del query, parameters
+        return None
+
+
+def test_sql_backend_relational_backend_guard_paths() -> None:
+    sql_backends._BACKENDS.clear()
+    backend = sql_backends._backend_for(
+        "null-backend",
+        "null-key",
+        lambda: _NullResultConnection(),
+        parameter_style="?",
+        upsert_memory_sql=sql_backends._DUCKDB_MEMORY_UPSERT_SQL,
+        upsert_edge_sql=sql_backends._DUCKDB_EDGE_UPSERT_SQL,
+    )
+
+    assert backend.get_memory("absent") is None
+    assert backend.list_memories() == ()
+    backend.put_memories(())
+    backend.upsert_edges(())
+    backend._ensure_schema()
+
+
+def test_sql_backends_build_with_missing_dependencies(monkeypatch: pytest.MonkeyPatch) -> None:
+    original_import = builtins.__import__
+
+    def _import_with_missing_module(
+        name: str,
+        import_globals: object | None = None,
+        import_locals: object | None = None,
+        fromlist: tuple[object, ...] | None = (),
+        level: int = 0,
+    ) -> object:
+        if name in {"duckdb", "psycopg", "mysql"}:
+            raise ModuleNotFoundError(f"No module named {name}")
+        return original_import(
+            name,
+            import_globals,
+            import_locals,
+            fromlist,
+            level,
+        )
+
+    monkeypatch.setattr(builtins, "__import__", _import_with_missing_module)
+
+    with pytest.raises(
+        sql_backends._MissingDuckDBDependencyError,
+        match="duckdb backend requires optional dependency",
+    ):
+        sql_backends._build_duckdb_connection("cellin.duckdb")()
+
+    with pytest.raises(
+        sql_backends._MissingPostgreSQLDependencyError,
+        match="postgresql backend requires optional dependency",
+    ):
+        sql_backends._build_postgresql_connection("postgresql://localhost/db")()
+
+    with pytest.raises(
+        sql_backends._MissingMySQLDependencyError,
+        match="mysql backend requires optional dependency `mysql-connector-python`",
+    ):
+        sql_backends._build_mysql_connection("mysql://localhost/db")()
+
+
+def test_parse_mysql_connection_string_and_memory_path_resolution() -> None:
+    assert sql_backends._parse_mysql_connection_string("mysql://user:pw@localhost:3306/cellin") == (
+        sql_backends._MySQLConnectionParams(
+            user="user",
+            password="pw",
+            host="localhost",
+            port=3306,
+            database="cellin",
+        )
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="mysql backend requires a mysql:// connection string",
+    ):
+        sql_backends._parse_mysql_connection_string("postgresql://cellin/test")
+
+    assert sql_backends._resolve_file_path(":memory:") == ":memory:"
+    assert sql_backends._resolve_file_path("sample.db").endswith("/sample.db")

--- a/uv.lock
+++ b/uv.lock
@@ -43,6 +43,22 @@ wheels = [
 name = "cellin"
 source = { editable = "." }
 
+[package.optional-dependencies]
+duckdb = [
+    { name = "duckdb" },
+]
+mysql = [
+    { name = "mysql-connector-python" },
+]
+postgresql = [
+    { name = "psycopg" },
+]
+sql-backends = [
+    { name = "duckdb" },
+    { name = "mysql-connector-python" },
+    { name = "psycopg" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "build" },
@@ -56,6 +72,15 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [
+    { name = "duckdb", marker = "extra == 'duckdb'" },
+    { name = "duckdb", marker = "extra == 'sql-backends'" },
+    { name = "mysql-connector-python", marker = "extra == 'mysql'" },
+    { name = "mysql-connector-python", marker = "extra == 'sql-backends'" },
+    { name = "psycopg", marker = "extra == 'postgresql'" },
+    { name = "psycopg", marker = "extra == 'sql-backends'" },
+]
+provides-extras = ["duckdb", "mysql", "postgresql", "sql-backends"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -330,6 +355,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "duckdb"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/62/590caabec6c41003f46a244b6fd707d35ca2e552e0c70cbf454e08bf6685/duckdb-1.5.1.tar.gz", hash = "sha256:b370d1620a34a4538ef66524fcee9de8171fa263c701036a92bc0b4c1f2f9c6d", size = 17995082, upload-time = "2026-03-23T12:12:15.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/06/be4c62f812c6e23898733073ace0482eeb18dffabe0585d63a3bf38bca1e/duckdb-1.5.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:6f7361d66cc801d9eb4df734b139cd7b0e3c257a16f3573ebd550ddb255549e6", size = 30113703, upload-time = "2026-03-23T12:11:02.536Z" },
+    { url = "https://files.pythonhosted.org/packages/44/03/1794dcdda75ff203ab0982ff7eb5232549b58b9af66f243f1b7212d6d6be/duckdb-1.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0a6acc2040bec1f05de62a2f3f68f4c12f3ec7d6012b4317d0ab1a195af26225", size = 15991802, upload-time = "2026-03-23T12:11:06.321Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/293bccd838a293d42ea26dec7f4eb4f58b57b6c9ffcfabc6518a5f20a24a/duckdb-1.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ed6d23a3f806898e69c77430ebd8da0c79c219f97b9acbc9a29a653e09740c59", size = 14246803, upload-time = "2026-03-23T12:11:09.624Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2c/7b4f11879aa2924838168b4640da999dccda1b4a033d43cb998fd6dc33ea/duckdb-1.5.1-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6af347debc8b721aa72e48671166282da979d5e5ae52dbc660ab417282b48e23", size = 19271654, upload-time = "2026-03-23T12:11:13.354Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d6/8f9a6b1fbcc669108ec6a4d625a70be9e480b437ed9b70cd56b78cd577a6/duckdb-1.5.1-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8150c569b2aa4573b51ba8475e814aa41fd53a3d510c1ffb96f1139f46faf611", size = 21386100, upload-time = "2026-03-23T12:11:16.758Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/8d02c6473273468cf8d43fd5d73c677f8cdfcd036c1e884df0613f124c2b/duckdb-1.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:054ad424b051b334052afac58cb216f3b1ebb8579fc8c641e60f0182e8725ea9", size = 13083506, upload-time = "2026-03-23T12:11:19.785Z" },
+    { url = "https://files.pythonhosted.org/packages/96/0b/2be786b9c153eb263bf5d3d5f7ab621b14a715d7e70f92b24ecf8536369e/duckdb-1.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:6ba302115f63f6482c000ccfd62efdb6c41d9d182a5bcd4a90e7ab8cd13856eb", size = 13888862, upload-time = "2026-03-23T12:11:22.84Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/f2/af476945e3b97417945b0f660b5efa661863547c0ea104251bb6387342b1/duckdb-1.5.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:26e56b5f0c96189e3288d83cf7b476e23615987902f801e5788dee15ee9f24a9", size = 30113759, upload-time = "2026-03-23T12:11:26.5Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/9d/5a542b3933647369e601175190093597ce0ac54909aea0dd876ec51ffad4/duckdb-1.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:972d0dbf283508f9bc446ee09c3838cb7c7f114b5bdceee41753288c97fe2f7c", size = 15991463, upload-time = "2026-03-23T12:11:30.025Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a5/b59cff67f5e0420b8f337ad86406801cffacae219deed83961dcceefda67/duckdb-1.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:482f8a13f2600f527e427f73c42b5aa75536f9892868068f0aaf573055a0135f", size = 14246482, upload-time = "2026-03-23T12:11:33.33Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/12/d72a82fe502aae82b97b481bf909be8e22db5a403290799ad054b4f90eb4/duckdb-1.5.1-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da137802688190835b4c863cafa77fd7e29dff662ee6d905a9ffc14f00299c91", size = 19270816, upload-time = "2026-03-23T12:11:36.79Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c3/ee49319b15f139e04c067378f0e763f78336fbab38ba54b0852467dd9da4/duckdb-1.5.1-cp313-cp313-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5d4147422d91ccdc2d2abf6ed24196025e020259d1d267970ae20c13c2ce84b1", size = 21385695, upload-time = "2026-03-23T12:11:40.465Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f5/a15498e75a27a136c791ca1889beade96d388dadf9811375db155fc96d1a/duckdb-1.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:05fc91767d0cfc4cf2fa68966ab5b479ac07561752e42dd0ae30327bd160f64a", size = 13084065, upload-time = "2026-03-23T12:11:43.763Z" },
+    { url = "https://files.pythonhosted.org/packages/93/81/b3612d2bbe237f75791095e16767c61067ea5d31c76e8591c212dac13bd0/duckdb-1.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:a28531cee2a5a42d89f9ba4da53bfeb15681f12acc0263476c8705380dadce07", size = 13892892, upload-time = "2026-03-23T12:11:47.222Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/75/e9e7893542ca738bcde2d41d459e3438950219c71c57ad28b049dc2ae616/duckdb-1.5.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:eba81e0b3011c1f23df7ea47ef4ffaa8239817959ae291515b6efd068bde2161", size = 30123677, upload-time = "2026-03-23T12:11:51.511Z" },
+    { url = "https://files.pythonhosted.org/packages/df/db/f7420ee7109a922124c02f377ae1c56156e9e4aa434f4726848adaef0219/duckdb-1.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:afab8b4b1f4469c3879bb049dd039f8fce402712050324e9524a43d7324c5e87", size = 15996808, upload-time = "2026-03-23T12:11:54.964Z" },
+    { url = "https://files.pythonhosted.org/packages/df/57/2c4c3de1f1110417592741863ba58b4eca2f7690a421712762ddbdcd72e6/duckdb-1.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:71dddcebbc5a70e946a06c30b59b5dd7999c9833d307168f90fb4e4b672ab63e", size = 14248990, upload-time = "2026-03-23T12:11:58.576Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e173b33ffac53124a3e39e97fb60a538f26651a0df6e393eb9bf7540126c/duckdb-1.5.1-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac2804043bd1bc10b5da18f8f4c706877197263a510c41be9b4c0062f5783dcc", size = 19276013, upload-time = "2026-03-23T12:12:02.034Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/4c/47e838393aa90d3d78549c8c04cb09452efeb14aaae0ee24dc0bd61c3a41/duckdb-1.5.1-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8843bd9594e1387f1e601439e19ad73abdf57356104fd1e53a708255bb95a13d", size = 21387569, upload-time = "2026-03-23T12:12:05.693Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/9b/ce65743e0e85f5c984d2f7e8a81bc908d0bac345d6d8b6316436b29430e7/duckdb-1.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:d68c5a01a283cb13b79eafe016fe5869aa11bff8c46e7141c70aa0aac808010f", size = 13603876, upload-time = "2026-03-23T12:12:09.344Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ac/f9e4e731635192571f86f52d86234f537c7f8ca4f6917c56b29051c077ef/duckdb-1.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:a3be2072315982e232bfe49c9d3db0a59ba67b2240a537ef42656cc772a887c7", size = 14370790, upload-time = "2026-03-23T12:12:12.497Z" },
 ]
 
 [[package]]
@@ -751,6 +805,30 @@ wheels = [
 ]
 
 [[package]]
+name = "mysql-connector-python"
+version = "9.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6e/c89babc7de3df01467d159854414659c885152579903a8220c8db02a3835/mysql_connector_python-9.6.0.tar.gz", hash = "sha256:c453bb55347174d87504b534246fb10c589daf5d057515bf615627198a3c7ef1", size = 12254999, upload-time = "2026-02-10T12:04:52.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/d9/2a4b4d90b52f4241f0f71618cd4bd8779dd6d18db8058b0a4dd83ec0541c/mysql_connector_python-9.6.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9664e217c72dd6fb700f4c8512af90261f72d2f5d7c00c4e13e4c1e09bfa3d5e", size = 17585672, upload-time = "2026-02-10T12:03:52.955Z" },
+    { url = "https://files.pythonhosted.org/packages/33/91/2495835733a054e716a17dc28404748b33f2dc1da1ae4396fb45574adf40/mysql_connector_python-9.6.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:1ed4b5c4761e5333035293e746683890e4ef2e818e515d14023fd80293bc31fa", size = 18452624, upload-time = "2026-02-10T12:03:56.153Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/69/e83abbbbf7f8eed855b5a5ff7285bc0afb1199418ac036c7691edf41e154/mysql_connector_python-9.6.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5095758dcb89a6bce2379f349da336c268c407129002b595c5dba82ce387e2a5", size = 34169154, upload-time = "2026-02-10T12:03:58.831Z" },
+    { url = "https://files.pythonhosted.org/packages/82/44/67bb61c71f398fbc739d07e8dcadad94e2f655874cb32ae851454066bea0/mysql_connector_python-9.6.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4ae4e7780fad950a4f267dea5851048d160f5b71314a342cdbf30b154f1c74f7", size = 34542947, upload-time = "2026-02-10T12:04:02.408Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/39/994c4f7e9c59d3ca534a831d18442ac4c529865db20aeaa4fd94e2af5efd/mysql_connector_python-9.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:c180e0b4100d7402e03993bfac5c97d18e01d7ca9d198d742fffc245077f8ffe", size = 16515709, upload-time = "2026-02-10T12:04:04.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/58/9521aa678708ec6cebfd40524c14c3d151e4f29e3774e6086aa0a30d203b/mysql_connector_python-9.6.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:e86e45a7b540ca09af8a18ecfa761e0cdeccfdb62818331614ec030ae44bfd26", size = 17585837, upload-time = "2026-02-10T12:04:07.004Z" },
+    { url = "https://files.pythonhosted.org/packages/39/8d/b108f9bcce9780f6a1f91decb2af54defdaf845e237ddc42f2b4578f1cd7/mysql_connector_python-9.6.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:8d3e9252384e1b7f95b07020664f2673d9c29c5e95eeda2e048b3331e190b9d4", size = 18452844, upload-time = "2026-02-10T12:04:09.418Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/28/735cd93d16e76dc2feb4abb3f1229a1d9475af34d80c26712fec6abe1d70/mysql_connector_python-9.6.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:0fa18ead33cb699ea92005695077cef09aa494eebf51164ee30c891c3eaea90c", size = 34169374, upload-time = "2026-02-10T12:04:12.13Z" },
+    { url = "https://files.pythonhosted.org/packages/42/07/069983799cf4050c68f61a494f94b06f095fee6026ab0dd863a14de30867/mysql_connector_python-9.6.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a26490cb029bf7b18a1d2093101105b3526a1036b51ad01553d30138f5beb8d2", size = 34543019, upload-time = "2026-02-10T12:04:15.065Z" },
+    { url = "https://files.pythonhosted.org/packages/32/00/fbeb7d666ab8153f719e620bac5abfbc74640e8ec511612493110a75fe66/mysql_connector_python-9.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:3460ed976e1b88b7284335d9397a3c519dff56d71580ca1f76ff1c0c7714c813", size = 16515701, upload-time = "2026-02-10T12:04:19.26Z" },
+    { url = "https://files.pythonhosted.org/packages/70/51/13cc90b2a703784cd9a0aa0a6fce07946cf6a2abe7c8fd0b585562e250fc/mysql_connector_python-9.6.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e2cc13cd3dcdb845d636e52c4e7a9509b63da09bec6ce1b3696be53a79847e2d", size = 17585800, upload-time = "2026-02-10T12:04:21.6Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/6b/ce7ab998fbdd17f35a1b54624365d039045cbb2d42bbc7b03f50d7597c7b/mysql_connector_python-9.6.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:a08c2149d4b52a010c4353f18c84716d18114a4ecd00b466ea34138de2c640f2", size = 18452823, upload-time = "2026-02-10T12:04:23.995Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/8157ed61d17878c33511dcb97c68ecaaaf6220bea5a2944ea4eba73cc63a/mysql_connector_python-9.6.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:b00228b985edd208b20f45c5e684c54e08e31e01bc1d8c3c18a36641c3be5bf7", size = 34171594, upload-time = "2026-02-10T12:04:27.401Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/06/5efdd28819afdb9f1487a62842fda4277febe128a3cd6e9090dbe0a6524e/mysql_connector_python-9.6.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4617ef5216da7ca32dd46afda61a1552807762434127413bba46fbe4379f59d4", size = 34542851, upload-time = "2026-02-10T12:04:31.021Z" },
+    { url = "https://files.pythonhosted.org/packages/40/6a/26e08a4a79f159cd8e5b64eb10bd056e7735b65d4464d98641f59eb9ca3a/mysql_connector_python-9.6.0-cp314-cp314-win_amd64.whl", hash = "sha256:bc782f64ca00b6b933d4c6a35568f1349d115cc4434c849b5b9edc015bee3e62", size = 17002947, upload-time = "2026-02-10T12:04:34.386Z" },
+    { url = "https://files.pythonhosted.org/packages/15/dd/b3250826c29cee7816de4409a2fe5e469a68b9a89f6bfaa5eed74f05532c/mysql_connector_python-9.6.0-py2.py3-none-any.whl", hash = "sha256:44b0fb57207ebc6ae05b5b21b7968a9ed33b29187fe87b38951bad2a334d75d5", size = 480527, upload-time = "2026-02-10T12:04:36.176Z" },
+]
+
+[[package]]
 name = "nh3"
 version = "0.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -827,6 +905,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/b6/379d0a960f8f435ec78720462fd94c4863e7a31237cf81bf76d0af5883bf/psycopg-3.3.3.tar.gz", hash = "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9", size = 165624, upload-time = "2026-02-18T16:52:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/5b/181e2e3becb7672b502f0ed7f16ed7352aca7c109cfb94cf3878a9186db9/psycopg-3.3.3-py3-none-any.whl", hash = "sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698", size = 212768, upload-time = "2026-02-18T16:46:27.365Z" },
 ]
 
 [[package]]
@@ -1115,6 +1206,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue
Add first-party DuckDB, PostgreSQL, and MySQL storage roles for both memory and graph roles, while preserving the existing SQLite path through the runtime storage registry.

## Root cause
Storage role selection had only in-memory, sqlite, and vector implementations, so production relational stores were not available as first-party options for the memory/graph seam; optional dependency handling and shared initialization semantics were incomplete outside sqlite.

## Fix
- Added shared SQL-backed relational backend primitives in `src/cellin/stores/sql_backends.py` with idempotent schema initialization/migration semantics.
- Added first-party implementations:
  - `DuckDBMemoryStore` / `DuckDBGraphStore`
  - `PostgreSQLMemoryStore` / `PostgreSQLGraphStore`
  - `MySQLMemoryStore` / `MySQLGraphStore`
- Wired new backends into the runtime factory in `src/cellin/runtime/storage.py` and exported them from `src/cellin/stores/__init__.py`.
- Added explicit optional dependency errors for missing drivers with helpful messages.
- Added contract, integration, and unit tests in `tests/contracts/test_storage.py`, `tests/integration/stores/test_sql_backends.py`, and `tests/unit/test_sql_backends_unit.py`.
- Added optional dependency metadata in `pyproject.toml` (`duckdb`, `postgresql`, `mysql`, `sql-backends`) and documented SQL backend setup in README.

## Validation
- `make release-smoke`

Closes #74
