### PR TITLE
feat(storage): add mongodb and redis backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,36 @@ Use `postgresql` and `mysql` with connection strings:
 }
 ```
 
+For document and cache-oriented presets, install optional dependencies as needed:
+
+```bash
+python3 -m pip install cellin[mongodb]
+python3 -m pip install cellin[redis]
+python3 -m pip install cellin[document-cache-backends]
+```
+
+Use `mongodb` when you want durable document storage for both memories and edges:
+
+```json
+{
+  "memory": { "backend": "mongodb", "database_path": "mongodb://user:pass@host:27017/cellin" },
+  "graph": { "backend": "mongodb", "database_path": "mongodb://user:pass@host:27017/cellin" }
+}
+```
+
+Use `redis` for low-latency cache-oriented deployments where operators control TTL or eviction:
+
+```json
+{
+  "memory": { "backend": "redis", "database_path": "redis://host:6379/0" },
+  "graph": { "backend": "redis", "database_path": "redis://host:6379/0" }
+}
+```
+
+MongoDB stores whole memory and edge documents and preserves archived entries as tombstones in the
+document payloads. Redis stores JSON payloads per key and also preserves archived entries as
+tombstones, filtering them from neighbor and edge listing reads rather than hard-deleting them.
+
 
 ## Primary surfaces
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,11 @@ dev = [
 
 [project.optional-dependencies]
 duckdb = ["duckdb"]
+document-cache-backends = ["pymongo", "redis"]
+mongodb = ["pymongo"]
 mysql = ["mysql-connector-python"]
 postgresql = ["psycopg"]
+redis = ["redis"]
 sql-backends = ["duckdb", "psycopg", "mysql-connector-python"]
 
 [tool.hatch.build.targets.wheel]

--- a/src/cellin/runtime/storage.py
+++ b/src/cellin/runtime/storage.py
@@ -13,11 +13,15 @@ from cellin.stores import (
     InMemoryGraphStore,
     InMemoryMemoryStore,
     InMemoryVectorIndex,
+    MongoDBGraphStore,
+    MongoDBMemoryStore,
     MySQLGraphStore,
     MySQLMemoryStore,
     PGVectorStore,
     PostgreSQLGraphStore,
     PostgreSQLMemoryStore,
+    RedisGraphStore,
+    RedisMemoryStore,
     SQLiteGraphStore,
     SQLiteMemoryStore,
     SQLiteVecStore,
@@ -141,6 +145,17 @@ def _build_sqlite_graph_store(
     return SQLiteGraphStore(database_path)
 
 
+def _resolve_connection_string(
+    config: StorageBackendConfig,
+    *,
+    backend_name: str,
+) -> str:
+    connection_string = config.database_path
+    if not connection_string:
+        raise StorageBackendError(f"{backend_name} backend requires a connection string")
+    return connection_string
+
+
 def _build_duckdb_memory_store(
     config: StorageBackendConfig,
     *,
@@ -171,10 +186,7 @@ def _build_postgresql_memory_store(
     workspace_root: Path,
 ) -> MemoryStore:
     del workspace_root
-    connection_string = config.database_path
-    if not connection_string:
-        raise StorageBackendError("postgresql backend requires a connection string")
-    return PostgreSQLMemoryStore(connection_string)
+    return PostgreSQLMemoryStore(_resolve_connection_string(config, backend_name="postgresql"))
 
 
 def _build_postgresql_graph_store(
@@ -183,10 +195,7 @@ def _build_postgresql_graph_store(
     workspace_root: Path,
 ) -> GraphStore:
     del workspace_root
-    connection_string = config.database_path
-    if not connection_string:
-        raise StorageBackendError("postgresql backend requires a connection string")
-    return PostgreSQLGraphStore(connection_string)
+    return PostgreSQLGraphStore(_resolve_connection_string(config, backend_name="postgresql"))
 
 
 def _build_mysql_memory_store(
@@ -195,10 +204,7 @@ def _build_mysql_memory_store(
     workspace_root: Path,
 ) -> MemoryStore:
     del workspace_root
-    connection_string = config.database_path
-    if not connection_string:
-        raise StorageBackendError("mysql backend requires a connection string")
-    return MySQLMemoryStore(connection_string)
+    return MySQLMemoryStore(_resolve_connection_string(config, backend_name="mysql"))
 
 
 def _build_mysql_graph_store(
@@ -207,10 +213,7 @@ def _build_mysql_graph_store(
     workspace_root: Path,
 ) -> GraphStore:
     del workspace_root
-    connection_string = config.database_path
-    if not connection_string:
-        raise StorageBackendError("mysql backend requires a connection string")
-    return MySQLGraphStore(connection_string)
+    return MySQLGraphStore(_resolve_connection_string(config, backend_name="mysql"))
 
 
 def _build_in_memory_memory_store(
@@ -229,6 +232,42 @@ def _build_in_memory_graph_store(
 ) -> GraphStore:
     del config, workspace_root
     return InMemoryGraphStore()
+
+
+def _build_mongodb_memory_store(
+    config: StorageBackendConfig,
+    *,
+    workspace_root: Path,
+) -> MemoryStore:
+    del workspace_root
+    return MongoDBMemoryStore(_resolve_connection_string(config, backend_name="mongodb"))
+
+
+def _build_mongodb_graph_store(
+    config: StorageBackendConfig,
+    *,
+    workspace_root: Path,
+) -> GraphStore:
+    del workspace_root
+    return MongoDBGraphStore(_resolve_connection_string(config, backend_name="mongodb"))
+
+
+def _build_redis_memory_store(
+    config: StorageBackendConfig,
+    *,
+    workspace_root: Path,
+) -> MemoryStore:
+    del workspace_root
+    return RedisMemoryStore(_resolve_connection_string(config, backend_name="redis"))
+
+
+def _build_redis_graph_store(
+    config: StorageBackendConfig,
+    *,
+    workspace_root: Path,
+) -> GraphStore:
+    del workspace_root
+    return RedisGraphStore(_resolve_connection_string(config, backend_name="redis"))
 
 
 def _build_vector_store(
@@ -270,6 +309,8 @@ _MEMORY_BACKEND_REGISTRY: dict[str, BackendBuilder] = {
     "sqlite": _build_sqlite_memory_store,
     "postgresql": _build_postgresql_memory_store,
     "in_memory": _build_in_memory_memory_store,
+    "mongodb": _build_mongodb_memory_store,
+    "redis": _build_redis_memory_store,
 }
 
 
@@ -279,6 +320,8 @@ _GRAPH_BACKEND_REGISTRY: dict[str, BackendBuilder] = {
     "sqlite": _build_sqlite_graph_store,
     "postgresql": _build_postgresql_graph_store,
     "in_memory": _build_in_memory_graph_store,
+    "mongodb": _build_mongodb_graph_store,
+    "redis": _build_redis_graph_store,
 }
 
 

--- a/src/cellin/stores/__init__.py
+++ b/src/cellin/stores/__init__.py
@@ -1,7 +1,9 @@
 """Local persistence primitives for Cellin."""
 
 from cellin.stores.in_memory import InMemoryGraphStore, InMemoryMemoryStore
+from cellin.stores.mongodb import MongoDBGraphStore, MongoDBMemoryStore
 from cellin.stores.pgvector import PGVectorStore
+from cellin.stores.redis import RedisGraphStore, RedisMemoryStore
 from cellin.stores.sql_backends import (
     DuckDBGraphStore,
     DuckDBMemoryStore,
@@ -24,8 +26,12 @@ __all__ = [
     "MySQLMemoryStore",
     "PostgreSQLGraphStore",
     "PostgreSQLMemoryStore",
+    "MongoDBGraphStore",
+    "MongoDBMemoryStore",
     "SearchResult",
     "PGVectorStore",
+    "RedisGraphStore",
+    "RedisMemoryStore",
     "SQLiteGraphStore",
     "SQLiteMemoryStore",
     "SQLiteVecStore",

--- a/src/cellin/stores/_graph_serialization.py
+++ b/src/cellin/stores/_graph_serialization.py
@@ -1,0 +1,231 @@
+"""Shared serialization helpers for memory and graph persistence backends."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from typing import cast
+
+from cellin.core import (
+    DecayState,
+    EdgeKind,
+    EmbeddingRecord,
+    MemoryAtom,
+    MemoryEdge,
+    MemoryKind,
+    Modality,
+    Provenance,
+    RetrievalStats,
+)
+from cellin.core.models import JSONValue
+
+
+def _dt(value: datetime | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def _parse_dt(value: object) -> datetime | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise TypeError("datetime payload values must be ISO-8601 strings")
+    return datetime.fromisoformat(value)
+
+
+def _require_mapping(value: object, *, field_name: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise TypeError(f"{field_name} payload must be a mapping")
+    return {str(key): cast(object, nested) for key, nested in value.items()}
+
+
+def _require_str(value: object, *, field_name: str) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} payload must be a string")
+    return value
+
+
+def _require_number(value: object, *, field_name: str) -> float:
+    if not isinstance(value, int | float):
+        raise TypeError(f"{field_name} payload must be numeric")
+    return float(value)
+
+
+def _require_list(value: object, *, field_name: str) -> Sequence[object]:
+    if not isinstance(value, list):
+        raise TypeError(f"{field_name} payload must be a list")
+    return tuple(value)
+
+
+def memory_payload(memory: MemoryAtom) -> dict[str, object]:
+    return {
+        "memory_id": memory.memory_id,
+        "kind": memory.kind.value,
+        "text": memory.text,
+        "provenance": {
+            "source_id": memory.provenance.source_id,
+            "source_type": memory.provenance.source_type,
+            "uri": memory.provenance.uri,
+            "ingest_run_id": memory.provenance.ingest_run_id,
+            "metadata": memory.provenance.metadata,
+        },
+        "modality": memory.modality.value,
+        "created_at": _dt(memory.created_at),
+        "observed_at": _dt(memory.observed_at),
+        "artifact_id": memory.artifact_id,
+        "salience_score": memory.salience_score,
+        "trust_score": memory.trust_score,
+        "decay": {
+            "archived": memory.decay.archived,
+            "half_life_days": memory.decay.half_life_days,
+            "last_reinforced_at": _dt(memory.decay.last_reinforced_at),
+        },
+        "retrieval": {
+            "access_count": memory.retrieval.access_count,
+            "last_accessed_at": _dt(memory.retrieval.last_accessed_at),
+        },
+        "embeddings": [
+            {"key": embedding.key, "vector": list(embedding.vector), "model": embedding.model}
+            for embedding in memory.embeddings
+        ],
+        "metadata": memory.metadata,
+    }
+
+
+def load_memory_payload(raw: Mapping[str, object]) -> MemoryAtom:
+    provenance = _require_mapping(raw.get("provenance"), field_name="provenance")
+    decay = _require_mapping(raw.get("decay"), field_name="decay")
+    retrieval = _require_mapping(raw.get("retrieval"), field_name="retrieval")
+    embeddings = _require_list(raw.get("embeddings", []), field_name="embeddings")
+    created_at = _parse_dt(raw.get("created_at"))
+    if created_at is None:
+        raise TypeError("created_at payload must be present")
+
+    return MemoryAtom(
+        memory_id=_require_str(raw.get("memory_id"), field_name="memory_id"),
+        kind=MemoryKind(_require_str(raw.get("kind"), field_name="kind")),
+        text=_require_str(raw.get("text"), field_name="text"),
+        provenance=Provenance(
+            source_id=_require_str(provenance.get("source_id"), field_name="provenance.source_id"),
+            source_type=_require_str(
+                provenance.get("source_type"),
+                field_name="provenance.source_type",
+            ),
+            uri=cast(str | None, provenance.get("uri")),
+            ingest_run_id=cast(str | None, provenance.get("ingest_run_id")),
+            metadata=cast(dict[str, JSONValue], provenance.get("metadata", {})),
+        ),
+        modality=Modality(_require_str(raw.get("modality"), field_name="modality")),
+        created_at=created_at,
+        observed_at=_parse_dt(raw.get("observed_at")),
+        artifact_id=cast(str | None, raw.get("artifact_id")),
+        salience_score=_require_number(raw.get("salience_score"), field_name="salience_score"),
+        trust_score=_require_number(raw.get("trust_score"), field_name="trust_score"),
+        decay=DecayState(
+            archived=bool(decay.get("archived", False)),
+            half_life_days=_require_number(
+                decay.get("half_life_days"),
+                field_name="decay.half_life_days",
+            ),
+            last_reinforced_at=_parse_dt(decay.get("last_reinforced_at")),
+        ),
+        retrieval=RetrievalStats(
+            access_count=int(
+                _require_number(
+                    retrieval.get("access_count"),
+                    field_name="retrieval.access_count",
+                )
+            ),
+            last_accessed_at=_parse_dt(retrieval.get("last_accessed_at")),
+        ),
+        embeddings=tuple(
+            EmbeddingRecord(
+                key=_require_str(entry.get("key"), field_name="embeddings[].key"),
+                vector=tuple(
+                    _require_number(component, field_name="embeddings[].vector[]")
+                    for component in _require_list(
+                        entry.get("vector"),
+                        field_name="embeddings[].vector",
+                    )
+                ),
+                model=cast(str | None, entry.get("model")),
+            )
+            for entry in (
+                _require_mapping(candidate, field_name="embeddings[]") for candidate in embeddings
+            )
+        ),
+        metadata=cast(dict[str, JSONValue], raw.get("metadata", {})),
+    )
+
+
+def dump_memory(memory: MemoryAtom) -> str:
+    return json.dumps(memory_payload(memory), sort_keys=True)
+
+
+def load_memory(payload: str) -> MemoryAtom:
+    raw = json.loads(payload)
+    if not isinstance(raw, dict):
+        raise TypeError("memory payload must decode to an object")
+    return load_memory_payload(cast(Mapping[str, object], raw))
+
+
+def edge_payload(edge: MemoryEdge) -> dict[str, object]:
+    return {
+        "edge_id": edge.edge_id,
+        "source_id": edge.source_id,
+        "target_id": edge.target_id,
+        "kind": edge.kind.value,
+        "provenance": {
+            "source_id": edge.provenance.source_id,
+            "source_type": edge.provenance.source_type,
+            "uri": edge.provenance.uri,
+            "ingest_run_id": edge.provenance.ingest_run_id,
+            "metadata": edge.provenance.metadata,
+        },
+        "created_at": _dt(edge.created_at),
+        "weight": edge.weight,
+        "metadata": edge.metadata,
+    }
+
+
+def load_edge_payload(raw: Mapping[str, object]) -> MemoryEdge:
+    provenance = _require_mapping(raw.get("provenance"), field_name="provenance")
+    created_at = _parse_dt(raw.get("created_at"))
+    if created_at is None:
+        raise TypeError("created_at payload must be present")
+
+    return MemoryEdge(
+        edge_id=_require_str(raw.get("edge_id"), field_name="edge_id"),
+        source_id=_require_str(raw.get("source_id"), field_name="source_id"),
+        target_id=_require_str(raw.get("target_id"), field_name="target_id"),
+        kind=EdgeKind(_require_str(raw.get("kind"), field_name="kind")),
+        provenance=Provenance(
+            source_id=_require_str(provenance.get("source_id"), field_name="provenance.source_id"),
+            source_type=_require_str(
+                provenance.get("source_type"),
+                field_name="provenance.source_type",
+            ),
+            uri=cast(str | None, provenance.get("uri")),
+            ingest_run_id=cast(str | None, provenance.get("ingest_run_id")),
+            metadata=cast(dict[str, JSONValue], provenance.get("metadata", {})),
+        ),
+        created_at=created_at,
+        weight=_require_number(raw.get("weight"), field_name="weight"),
+        metadata=cast(dict[str, JSONValue], raw.get("metadata", {})),
+    )
+
+
+def dump_edge(edge: MemoryEdge) -> str:
+    return json.dumps(edge_payload(edge), sort_keys=True)
+
+
+def load_edge(payload: str) -> MemoryEdge:
+    raw = json.loads(payload)
+    if not isinstance(raw, dict):
+        raise TypeError("edge payload must decode to an object")
+    return load_edge_payload(cast(Mapping[str, object], raw))
+
+
+def edge_is_archived(edge: MemoryEdge) -> bool:
+    archived = edge.metadata.get("archived")
+    return bool(archived) if isinstance(archived, bool) else False

--- a/src/cellin/stores/mongodb.py
+++ b/src/cellin/stores/mongodb.py
@@ -1,0 +1,192 @@
+"""MongoDB-backed memory and graph stores for Cellin."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any, cast
+from urllib.parse import urlparse
+
+from cellin.core import MemoryAtom, MemoryEdge, MemoryStore
+from cellin.stores._graph_serialization import (
+    edge_is_archived,
+    edge_payload,
+    load_edge_payload,
+    load_memory_payload,
+    memory_payload,
+)
+
+
+class _MissingMongoDependencyError(RuntimeError):
+    """Raised when MongoDB dependencies are unavailable."""
+
+
+def _as_mapping(raw: object) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise TypeError("MongoDB documents must decode to mappings")
+    return {str(key): value for key, value in raw.items()}
+
+
+def _normalize_memory_document(raw: Mapping[str, Any]) -> dict[str, Any]:
+    document = dict(raw)
+    document["memory_id"] = document.get("memory_id", document.get("_id"))
+    return document
+
+
+def _normalize_edge_document(raw: Mapping[str, Any]) -> dict[str, Any]:
+    document = dict(raw)
+    document["edge_id"] = document.get("edge_id", document.get("_id"))
+    return document
+
+
+def _sorted_documents(rows: Iterable[object]) -> list[dict[str, Any]]:
+    documents = [_as_mapping(row) for row in rows]
+    return sorted(
+        (dict(document) for document in documents),
+        key=lambda document: str(document.get("_id", "")),
+    )
+
+
+def _database_name(connection_string: str) -> str:
+    parsed = urlparse(connection_string)
+    database = parsed.path.strip("/")
+    return database or "cellin"
+
+
+class _MongoBackend:
+    """Low-level MongoDB collection access shared by memory and graph roles."""
+
+    def __init__(self, connection_string: str) -> None:
+        try:
+            import pymongo  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover - environment dependent
+            raise _MissingMongoDependencyError(
+                "mongodb backend requires optional dependency `pymongo`"
+            ) from exc
+
+        client = pymongo.MongoClient(connection_string)
+        database = client[_database_name(connection_string)]
+        self._memory_collection = database["cellin_memories"]
+        self._edge_collection = database["cellin_edges"]
+
+    def put_memories(self, memories: tuple[MemoryAtom, ...]) -> None:
+        if not memories:
+            return
+
+        for memory in memories:
+            payload = cast(dict[str, Any], memory_payload(memory))
+            payload["_id"] = memory.memory_id
+            self._memory_collection.update_one(
+                {"_id": memory.memory_id},
+                {"$set": payload},
+                upsert=True,
+            )
+
+    def get_memory(self, memory_id: str) -> MemoryAtom | None:
+        raw = self._memory_collection.find_one({"_id": memory_id})
+        if raw is None:
+            return None
+        return load_memory_payload(_normalize_memory_document(_as_mapping(raw)))
+
+    def list_memories(self) -> tuple[MemoryAtom, ...]:
+        return tuple(
+            load_memory_payload(_normalize_memory_document(document))
+            for document in _sorted_documents(self._memory_collection.find())
+        )
+
+    def upsert_edges(self, edges: tuple[MemoryEdge, ...]) -> None:
+        if not edges:
+            return
+
+        for edge in edges:
+            payload = cast(dict[str, Any], edge_payload(edge))
+            payload["_id"] = edge.edge_id
+            self._edge_collection.update_one(
+                {"_id": edge.edge_id},
+                {"$set": payload},
+                upsert=True,
+            )
+
+    def neighbors(self, memory_id: str) -> tuple[MemoryEdge, ...]:
+        rows = self._edge_collection.find(
+            {"$or": [{"source_id": memory_id}, {"target_id": memory_id}]}
+        )
+        edges = [
+            load_edge_payload(_normalize_edge_document(document))
+            for document in _sorted_documents(rows)
+        ]
+        return tuple(edge for edge in edges if not edge_is_archived(edge))
+
+    def list_edges(self) -> tuple[MemoryEdge, ...]:
+        edges = [
+            load_edge_payload(_normalize_edge_document(document))
+            for document in _sorted_documents(self._edge_collection.find())
+        ]
+        return tuple(edge for edge in edges if not edge_is_archived(edge))
+
+
+_BACKENDS: dict[str, _MongoBackend] = {}
+
+
+def _backend_for(connection_string: str) -> _MongoBackend:
+    backend = _BACKENDS.get(connection_string)
+    if backend is None:
+        backend = _MongoBackend(connection_string)
+        _BACKENDS[connection_string] = backend
+    return backend
+
+
+class MongoDBMemoryStore:
+    """Persist memory atoms as MongoDB documents keyed by `memory_id`."""
+
+    def __init__(self, connection_string: str, *, _backend: _MongoBackend | None = None) -> None:
+        self._backend = _backend or _backend_for(connection_string)
+
+    def put(self, memory: MemoryAtom) -> None:
+        self.put_many((memory,))
+
+    def put_many(self, memories: tuple[MemoryAtom, ...]) -> None:
+        self._backend.put_memories(memories)
+
+    def get(self, memory_id: str) -> MemoryAtom | None:
+        return self._backend.get_memory(memory_id)
+
+    def list(self) -> tuple[MemoryAtom, ...]:
+        return self._backend.list_memories()
+
+
+class MongoDBGraphStore:
+    """Persist graph edges and supporting memory records in MongoDB."""
+
+    def __init__(
+        self,
+        connection_string: str,
+        *,
+        _backend: _MongoBackend | None = None,
+    ) -> None:
+        self._backend = _backend or _backend_for(connection_string)
+
+    def upsert_memory(self, memory: MemoryAtom) -> None:
+        self._backend.put_memories((memory,))
+
+    def upsert_memories(self, memories: tuple[MemoryAtom, ...]) -> None:
+        self._backend.put_memories(memories)
+
+    def upsert_edge(self, edge: MemoryEdge) -> None:
+        self.upsert_edges((edge,))
+
+    def upsert_edges(self, edges: tuple[MemoryEdge, ...]) -> None:
+        self._backend.upsert_edges(edges)
+
+    def shares_memory_store(self, memory_store: MemoryStore) -> bool:
+        return (
+            isinstance(memory_store, MongoDBMemoryStore) and memory_store._backend is self._backend
+        )
+
+    def get_memory(self, memory_id: str) -> MemoryAtom | None:
+        return self._backend.get_memory(memory_id)
+
+    def neighbors(self, memory_id: str) -> tuple[MemoryEdge, ...]:
+        return self._backend.neighbors(memory_id)
+
+    def list_edges(self) -> tuple[MemoryEdge, ...]:
+        return self._backend.list_edges()

--- a/src/cellin/stores/redis.py
+++ b/src/cellin/stores/redis.py
@@ -1,0 +1,152 @@
+"""Redis-backed memory and graph stores for Cellin."""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+from cellin.core import MemoryAtom, MemoryEdge, MemoryStore
+from cellin.stores._graph_serialization import (
+    dump_edge,
+    dump_memory,
+    edge_is_archived,
+    load_edge,
+    load_memory,
+)
+
+
+class _MissingRedisDependencyError(RuntimeError):
+    """Raised when Redis dependencies are unavailable."""
+
+
+def _redis_namespace(connection_string: str) -> str:
+    parsed = urlparse(connection_string)
+    database = parsed.path.strip("/") or "0"
+    return f"cellin:{database}"
+
+
+class _RedisBackend:
+    """Low-level Redis access shared between memory and graph roles."""
+
+    def __init__(self, connection_string: str) -> None:
+        try:
+            import redis  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover - environment dependent
+            raise _MissingRedisDependencyError(
+                "redis backend requires optional dependency `redis`"
+            ) from exc
+
+        self._client = redis.Redis.from_url(connection_string, decode_responses=True)
+        self._namespace = _redis_namespace(connection_string)
+
+    def _memory_key(self, memory_id: str) -> str:
+        return f"{self._namespace}:memory:{memory_id}"
+
+    def _edge_key(self, edge_id: str) -> str:
+        return f"{self._namespace}:edge:{edge_id}"
+
+    def put_memories(self, memories: tuple[MemoryAtom, ...]) -> None:
+        for memory in memories:
+            self._client.set(self._memory_key(memory.memory_id), dump_memory(memory))
+
+    def get_memory(self, memory_id: str) -> MemoryAtom | None:
+        payload = self._client.get(self._memory_key(memory_id))
+        if payload is None:
+            return None
+        return load_memory(str(payload))
+
+    def list_memories(self) -> tuple[MemoryAtom, ...]:
+        keys = sorted(str(key) for key in self._client.scan_iter(f"{self._namespace}:memory:*"))
+        return tuple(
+            load_memory(str(payload))
+            for key in keys
+            if (payload := self._client.get(key)) is not None
+        )
+
+    def upsert_edges(self, edges: tuple[MemoryEdge, ...]) -> None:
+        for edge in edges:
+            self._client.set(self._edge_key(edge.edge_id), dump_edge(edge))
+
+    def neighbors(self, memory_id: str) -> tuple[MemoryEdge, ...]:
+        edges = []
+        for key in sorted(str(key) for key in self._client.scan_iter(f"{self._namespace}:edge:*")):
+            payload = self._client.get(key)
+            if payload is None:
+                continue
+            edge = load_edge(str(payload))
+            if edge_is_archived(edge):
+                continue
+            if edge.source_id == memory_id or edge.target_id == memory_id:
+                edges.append(edge)
+        return tuple(edges)
+
+    def list_edges(self) -> tuple[MemoryEdge, ...]:
+        edges = []
+        for key in sorted(str(key) for key in self._client.scan_iter(f"{self._namespace}:edge:*")):
+            payload = self._client.get(key)
+            if payload is None:
+                continue
+            edge = load_edge(str(payload))
+            if not edge_is_archived(edge):
+                edges.append(edge)
+        return tuple(edges)
+
+
+_BACKENDS: dict[str, _RedisBackend] = {}
+
+
+def _backend_for(connection_string: str) -> _RedisBackend:
+    backend = _BACKENDS.get(connection_string)
+    if backend is None:
+        backend = _RedisBackend(connection_string)
+        _BACKENDS[connection_string] = backend
+    return backend
+
+
+class RedisMemoryStore:
+    """Persist memory atoms in Redis using JSON payloads."""
+
+    def __init__(self, connection_string: str, *, _backend: _RedisBackend | None = None) -> None:
+        self._backend = _backend or _backend_for(connection_string)
+
+    def put(self, memory: MemoryAtom) -> None:
+        self.put_many((memory,))
+
+    def put_many(self, memories: tuple[MemoryAtom, ...]) -> None:
+        self._backend.put_memories(memories)
+
+    def get(self, memory_id: str) -> MemoryAtom | None:
+        return self._backend.get_memory(memory_id)
+
+    def list(self) -> tuple[MemoryAtom, ...]:
+        return self._backend.list_memories()
+
+
+class RedisGraphStore:
+    """Persist graph edges and supporting memories in Redis."""
+
+    def __init__(self, connection_string: str, *, _backend: _RedisBackend | None = None) -> None:
+        self._backend = _backend or _backend_for(connection_string)
+
+    def upsert_memory(self, memory: MemoryAtom) -> None:
+        self._backend.put_memories((memory,))
+
+    def upsert_memories(self, memories: tuple[MemoryAtom, ...]) -> None:
+        self._backend.put_memories(memories)
+
+    def upsert_edge(self, edge: MemoryEdge) -> None:
+        self.upsert_edges((edge,))
+
+    def upsert_edges(self, edges: tuple[MemoryEdge, ...]) -> None:
+        self._backend.upsert_edges(edges)
+
+    def shares_memory_store(self, memory_store: MemoryStore) -> bool:
+        return isinstance(memory_store, RedisMemoryStore) and memory_store._backend is self._backend
+
+    def get_memory(self, memory_id: str) -> MemoryAtom | None:
+        return self._backend.get_memory(memory_id)
+
+    def neighbors(self, memory_id: str) -> tuple[MemoryEdge, ...]:
+        return self._backend.neighbors(memory_id)
+
+    def list_edges(self) -> tuple[MemoryEdge, ...]:
+        return self._backend.list_edges()

--- a/tests/contracts/test_storage.py
+++ b/tests/contracts/test_storage.py
@@ -17,10 +17,14 @@ from cellin.runtime.storage import (
 from cellin.stores import (
     DuckDBGraphStore,
     DuckDBMemoryStore,
+    MongoDBGraphStore,
+    MongoDBMemoryStore,
     MySQLGraphStore,
     MySQLMemoryStore,
     PostgreSQLGraphStore,
     PostgreSQLMemoryStore,
+    RedisGraphStore,
+    RedisMemoryStore,
     SQLiteMemoryStore,
     SQLiteVecStore,
 )
@@ -285,6 +289,96 @@ def test_build_storage_bundle_rejects_duckdb_without_database_path(tmp_path: Pat
         representation=StorageBackendConfig("in_memory_vector_index"),
     )
     with pytest.raises(StorageBackendError, match="database_path"):
+        build_storage_bundle(config, workspace_root=tmp_path)
+
+
+def test_build_storage_bundle_resolves_mongodb_backends(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    shared_backend = object()
+
+    class _FakeMongoMemoryStore(MongoDBMemoryStore):
+        def __init__(self, connection_string: str) -> None:
+            self._connection_string = connection_string
+            self._backend = shared_backend
+
+    class _FakeMongoGraphStore(MongoDBGraphStore):
+        def __init__(self, connection_string: str) -> None:
+            self._connection_string = connection_string
+            self._backend = shared_backend
+
+    monkeypatch.setattr("cellin.runtime.storage.MongoDBMemoryStore", _FakeMongoMemoryStore)
+    monkeypatch.setattr("cellin.runtime.storage.MongoDBGraphStore", _FakeMongoGraphStore)
+    config = StorageConfig(
+        memory=StorageBackendConfig("mongodb", "mongodb://localhost:27017/cellin"),
+        graph=StorageBackendConfig("mongodb", "mongodb://localhost:27017/cellin"),
+        vector=StorageBackendConfig("in_memory_vector_index"),
+        representation=StorageBackendConfig("in_memory_vector_index"),
+    )
+
+    bundle = build_storage_bundle(config, workspace_root=tmp_path)
+
+    assert isinstance(bundle.memory_store, _FakeMongoMemoryStore)
+    assert isinstance(bundle.graph_store, _FakeMongoGraphStore)
+    assert bundle.memory_store._connection_string == "mongodb://localhost:27017/cellin"
+    assert bundle.graph_store.shares_memory_store(bundle.memory_store)
+
+
+def test_build_storage_bundle_rejects_mongodb_without_connection_string(tmp_path: Path) -> None:
+    config = StorageConfig(
+        memory=StorageBackendConfig("mongodb"),
+        graph=StorageBackendConfig("mongodb"),
+        vector=StorageBackendConfig("in_memory_vector_index"),
+        representation=StorageBackendConfig("in_memory_vector_index"),
+    )
+
+    with pytest.raises(StorageBackendError, match="mongodb backend requires a connection string"):
+        build_storage_bundle(config, workspace_root=tmp_path)
+
+
+def test_build_storage_bundle_resolves_redis_backends(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    shared_backend = object()
+
+    class _FakeRedisMemoryStore(RedisMemoryStore):
+        def __init__(self, connection_string: str) -> None:
+            self._connection_string = connection_string
+            self._backend = shared_backend
+
+    class _FakeRedisGraphStore(RedisGraphStore):
+        def __init__(self, connection_string: str) -> None:
+            self._connection_string = connection_string
+            self._backend = shared_backend
+
+    monkeypatch.setattr("cellin.runtime.storage.RedisMemoryStore", _FakeRedisMemoryStore)
+    monkeypatch.setattr("cellin.runtime.storage.RedisGraphStore", _FakeRedisGraphStore)
+    config = StorageConfig(
+        memory=StorageBackendConfig("redis", "redis://localhost:6379/0"),
+        graph=StorageBackendConfig("redis", "redis://localhost:6379/0"),
+        vector=StorageBackendConfig("in_memory_vector_index"),
+        representation=StorageBackendConfig("in_memory_vector_index"),
+    )
+
+    bundle = build_storage_bundle(config, workspace_root=tmp_path)
+
+    assert isinstance(bundle.memory_store, _FakeRedisMemoryStore)
+    assert isinstance(bundle.graph_store, _FakeRedisGraphStore)
+    assert bundle.memory_store._connection_string == "redis://localhost:6379/0"
+    assert bundle.graph_store.shares_memory_store(bundle.memory_store)
+
+
+def test_build_storage_bundle_rejects_redis_without_connection_string(tmp_path: Path) -> None:
+    config = StorageConfig(
+        memory=StorageBackendConfig("redis"),
+        graph=StorageBackendConfig("redis"),
+        vector=StorageBackendConfig("in_memory_vector_index"),
+        representation=StorageBackendConfig("in_memory_vector_index"),
+    )
+
+    with pytest.raises(StorageBackendError, match="redis backend requires a connection string"):
         build_storage_bundle(config, workspace_root=tmp_path)
 
 

--- a/tests/integration/stores/test_document_cache_backends.py
+++ b/tests/integration/stores/test_document_cache_backends.py
@@ -1,0 +1,214 @@
+"""Integration coverage for MongoDB and Redis-backed memory and graph stores."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from datetime import UTC, datetime
+from types import ModuleType
+
+import pytest
+
+from cellin.core import (
+    DecayState,
+    EdgeKind,
+    MemoryAtom,
+    MemoryEdge,
+    MemoryKind,
+    Modality,
+    Provenance,
+    RetrievalStats,
+)
+from cellin.stores import MongoDBGraphStore, MongoDBMemoryStore, RedisGraphStore, RedisMemoryStore
+from cellin.stores import mongodb as mongodb_stores
+from cellin.stores import redis as redis_stores
+
+
+def _memory(memory_id: str, text: str) -> MemoryAtom:
+    now = datetime(2026, 4, 5, tzinfo=UTC)
+    return MemoryAtom(
+        memory_id=memory_id,
+        kind=MemoryKind.ATOM,
+        text=text,
+        provenance=Provenance(source_id=memory_id, source_type="fixture"),
+        modality=Modality.TEXT,
+        created_at=now,
+        observed_at=now,
+        decay=DecayState(half_life_days=14.0),
+        retrieval=RetrievalStats(),
+    )
+
+
+def _edge(edge_id: str, source_id: str, target_id: str, *, archived: bool) -> MemoryEdge:
+    return MemoryEdge(
+        edge_id=edge_id,
+        source_id=source_id,
+        target_id=target_id,
+        kind=EdgeKind.SUPPORTS,
+        provenance=Provenance(source_id=edge_id, source_type="fixture"),
+        created_at=datetime(2026, 4, 5, tzinfo=UTC),
+        metadata={"archived": archived},
+    )
+
+
+class _FakeMongoCollection:
+    def __init__(self) -> None:
+        self._documents: dict[str, dict[str, object]] = {}
+
+    def update_one(
+        self,
+        query: dict[str, object],
+        update: dict[str, dict[str, object]],
+        *,
+        upsert: bool,
+    ) -> None:
+        del upsert
+        document = dict(update["$set"])
+        self._documents[str(query["_id"])] = document
+
+    def find_one(self, query: dict[str, object]) -> dict[str, object] | None:
+        document = self._documents.get(str(query["_id"]))
+        return dict(document) if document is not None else None
+
+    def find(self, query: dict[str, object] | None = None) -> list[dict[str, object]]:
+        rows = list(self._documents.values())
+        if query is None:
+            return [dict(row) for row in rows]
+        conditions = query.get("$or", [])
+        assert isinstance(conditions, list)
+        result = []
+        for row in rows:
+            for condition in conditions:
+                assert isinstance(condition, dict)
+                field, expected = next(iter(condition.items()))
+                if row.get(field) == expected:
+                    result.append(dict(row))
+                    break
+        return result
+
+
+class _FakeMongoDatabase:
+    def __init__(self) -> None:
+        self._collections: dict[str, _FakeMongoCollection] = {}
+
+    def __getitem__(self, name: str) -> _FakeMongoCollection:
+        collection = self._collections.get(name)
+        if collection is None:
+            collection = _FakeMongoCollection()
+            self._collections[name] = collection
+        return collection
+
+
+class _FakeMongoClient:
+    def __init__(self) -> None:
+        self._databases: dict[str, _FakeMongoDatabase] = {}
+
+    def __getitem__(self, name: str) -> _FakeMongoDatabase:
+        database = self._databases.get(name)
+        if database is None:
+            database = _FakeMongoDatabase()
+            self._databases[name] = database
+        return database
+
+
+class _FakeRedisClient:
+    def __init__(self) -> None:
+        self._payloads: dict[str, str] = {}
+
+    def set(self, key: str, value: str) -> None:
+        self._payloads[key] = value
+
+    def get(self, key: str) -> str | None:
+        return self._payloads.get(key)
+
+    def scan_iter(self, pattern: str) -> tuple[str, ...]:
+        prefix = pattern[:-1] if pattern.endswith("*") else pattern
+        return tuple(key for key in sorted(self._payloads) if key.startswith(prefix))
+
+
+def _install_fake_mongodb(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _FakeMongoClient()
+    module = ModuleType("pymongo")
+    module.MongoClient = lambda *_args, **_kwargs: client
+    monkeypatch.setitem(sys.modules, "pymongo", module)
+
+
+def _install_fake_redis(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _FakeRedisClient()
+
+    class _RedisFactory:
+        @staticmethod
+        def from_url(*_args, **_kwargs) -> _FakeRedisClient:
+            return client
+
+    module = ModuleType("redis")
+    module.Redis = _RedisFactory
+    monkeypatch.setitem(sys.modules, "redis", module)
+
+
+@pytest.mark.parametrize(
+    "memory_cls,graph_cls,connection_string,install_backend,clear_backends",
+    [
+        (
+            MongoDBMemoryStore,
+            MongoDBGraphStore,
+            "mongodb://localhost:27017/cellin",
+            _install_fake_mongodb,
+            mongodb_stores._BACKENDS.clear,
+        ),
+        (
+            RedisMemoryStore,
+            RedisGraphStore,
+            "redis://localhost:6379/0",
+            _install_fake_redis,
+            redis_stores._BACKENDS.clear,
+        ),
+    ],
+)
+def test_document_and_cache_backends_share_memory_store_and_filter_archived_edges(
+    memory_cls: type,
+    graph_cls: type,
+    connection_string: str,
+    install_backend: Callable[[pytest.MonkeyPatch], None],
+    clear_backends: Callable[[], None],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_backends()
+    install_backend(monkeypatch)
+
+    active = _edge("edge-active", "memory-1", "memory-2", archived=False)
+    archived = _edge("edge-archived", "memory-1", "memory-3", archived=True)
+    support_memory = _memory("support-memory", "Support memory")
+
+    memory_store = memory_cls(connection_string)
+    graph_store = graph_cls(connection_string)
+
+    memory_store.put(_memory("memory-1", "Atlas memory"))
+    memory_store.put(_memory("memory-2", "Second memory"))
+    memory_store.put_many(())
+    graph_store.upsert_edges((active, archived))
+    graph_store.upsert_memories((support_memory,))
+    graph_store.upsert_edge(active)
+    graph_store.upsert_edges(())
+
+    assert memory_store.get("memory-1") == _memory("memory-1", "Atlas memory")
+    assert memory_store.get("missing-memory") is None
+    assert graph_store.get_memory("memory-1") == _memory("memory-1", "Atlas memory")
+    assert graph_store.neighbors("memory-1") == (active,)
+    assert graph_store.list_edges() == (active,)
+    assert graph_store.shares_memory_store(memory_store)
+    assert memory_store.list() == (
+        _memory("memory-1", "Atlas memory"),
+        _memory("memory-2", "Second memory"),
+        _memory("support-memory", "Support memory"),
+    )
+
+    duplicate_memory_store = memory_cls(connection_string)
+    duplicate_graph_store = graph_cls(connection_string)
+    duplicate_graph_store.upsert_memory(_memory("memory-1", "Atlas revised"))
+    duplicate_memory_store.put(_memory("memory-3", "Third memory"))
+
+    assert duplicate_graph_store.shares_memory_store(duplicate_memory_store)
+    assert duplicate_graph_store.shares_memory_store(memory_store)
+    assert memory_store.get("memory-1").text == "Atlas revised"
+    assert duplicate_memory_store.get("memory-3") == _memory("memory-3", "Third memory")

--- a/tests/unit/test_document_cache_backends_unit.py
+++ b/tests/unit/test_document_cache_backends_unit.py
@@ -1,0 +1,51 @@
+"""Unit tests for MongoDB and Redis backend helpers."""
+
+from __future__ import annotations
+
+import builtins
+import sys
+
+import pytest
+
+from cellin.stores import mongodb as mongodb_stores
+from cellin.stores import redis as redis_stores
+
+
+def test_document_and_cache_backends_require_optional_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_import = builtins.__import__
+
+    def _missing_backend(
+        name: str,
+        globals: object | None = None,
+        locals: object | None = None,
+        fromlist: tuple[object, ...] | None = (),
+        level: int = 0,
+    ) -> object:
+        if name in {"pymongo", "redis"}:
+            raise ModuleNotFoundError(f"No module named {name}")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.delitem(sys.modules, "pymongo", raising=False)
+    monkeypatch.delitem(sys.modules, "redis", raising=False)
+    monkeypatch.setattr(builtins, "__import__", _missing_backend)
+
+    with pytest.raises(
+        mongodb_stores._MissingMongoDependencyError,
+        match="mongodb backend requires optional dependency `pymongo`",
+    ):
+        mongodb_stores._MongoBackend("mongodb://localhost:27017/cellin")
+
+    with pytest.raises(
+        redis_stores._MissingRedisDependencyError,
+        match="redis backend requires optional dependency `redis`",
+    ):
+        redis_stores._RedisBackend("redis://localhost:6379/0")
+
+
+def test_document_and_cache_backend_namespaces_default_safely() -> None:
+    assert mongodb_stores._database_name("mongodb://localhost:27017") == "cellin"
+    assert mongodb_stores._database_name("mongodb://localhost:27017/runtime") == "runtime"
+    assert redis_stores._redis_namespace("redis://localhost:6379") == "cellin:0"
+    assert redis_stores._redis_namespace("redis://localhost:6379/9") == "cellin:9"

--- a/uv.lock
+++ b/uv.lock
@@ -44,14 +44,24 @@ name = "cellin"
 source = { editable = "." }
 
 [package.optional-dependencies]
+document-cache-backends = [
+    { name = "pymongo" },
+    { name = "redis" },
+]
 duckdb = [
     { name = "duckdb" },
+]
+mongodb = [
+    { name = "pymongo" },
 ]
 mysql = [
     { name = "mysql-connector-python" },
 ]
 postgresql = [
     { name = "psycopg" },
+]
+redis = [
+    { name = "redis" },
 ]
 sql-backends = [
     { name = "duckdb" },
@@ -79,8 +89,12 @@ requires-dist = [
     { name = "mysql-connector-python", marker = "extra == 'sql-backends'" },
     { name = "psycopg", marker = "extra == 'postgresql'" },
     { name = "psycopg", marker = "extra == 'sql-backends'" },
+    { name = "pymongo", marker = "extra == 'document-cache-backends'" },
+    { name = "pymongo", marker = "extra == 'mongodb'" },
+    { name = "redis", marker = "extra == 'document-cache-backends'" },
+    { name = "redis", marker = "extra == 'redis'" },
 ]
-provides-extras = ["duckdb", "mysql", "postgresql", "sql-backends"]
+provides-extras = ["document-cache-backends", "duckdb", "mongodb", "mysql", "postgresql", "redis", "sql-backends"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -346,6 +360,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/65/5bf43286d566f8171917cae23ac6add941654ccf085d739195a4eacf1674/cryptography-46.0.6-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:341359d6c9e68834e204ceaf25936dffeafea3829ab80e9503860dcc4f4dac58", size = 4448061, upload-time = "2026-03-25T23:34:29.375Z" },
     { url = "https://files.pythonhosted.org/packages/e0/25/7e49c0fa7205cf3597e525d156a6bce5b5c9de1fd7e8cb01120e459f205a/cryptography-46.0.6-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9a9c42a2723999a710445bc0d974e345c32adfd8d2fac6d8a251fa829ad31cfb", size = 4399103, upload-time = "2026-03-25T23:34:32.036Z" },
     { url = "https://files.pythonhosted.org/packages/44/46/466269e833f1c4718d6cd496ffe20c56c9c8d013486ff66b4f69c302a68d/cryptography-46.0.6-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6617f67b1606dfd9fe4dbfa354a9508d4a6d37afe30306fe6c101b7ce3274b72", size = 4659255, upload-time = "2026-03-25T23:34:33.679Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
 ]
 
 [[package]]
@@ -952,6 +975,57 @@ wheels = [
 ]
 
 [[package]]
+name = "pymongo"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/9c/a4895c4b785fc9865a84a56e14b5bd21ca75aadc3dab79c14187cdca189b/pymongo-4.16.0.tar.gz", hash = "sha256:8ba8405065f6e258a6f872fe62d797a28f383a12178c7153c01ed04e845c600c", size = 2495323, upload-time = "2026-01-07T18:05:48.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/03/6dd7c53cbde98de469a3e6fb893af896dca644c476beb0f0c6342bcc368b/pymongo-4.16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bd4911c40a43a821dfd93038ac824b756b6e703e26e951718522d29f6eb166a8", size = 917619, upload-time = "2026-01-07T18:04:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e1/328915f2734ea1f355dc9b0e98505ff670f5fab8be5e951d6ed70971c6aa/pymongo-4.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:25a6b03a68f9907ea6ec8bc7cf4c58a1b51a18e23394f962a6402f8e46d41211", size = 917364, upload-time = "2026-01-07T18:04:20.861Z" },
+    { url = "https://files.pythonhosted.org/packages/41/fe/4769874dd9812a1bc2880a9785e61eba5340da966af888dd430392790ae0/pymongo-4.16.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:91ac0cb0fe2bf17616c2039dac88d7c9a5088f5cb5829b27c9d250e053664d31", size = 1686901, upload-time = "2026-01-07T18:04:22.219Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/8d/15707b9669fdc517bbc552ac60da7124dafe7ac1552819b51e97ed4038b4/pymongo-4.16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf0ec79e8ca7077f455d14d915d629385153b6a11abc0b93283ed73a8013e376", size = 1723034, upload-time = "2026-01-07T18:04:24.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/af/3d5d16ff11d447d40c1472da1b366a31c7380d7ea2922a449c7f7f495567/pymongo-4.16.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2d0082631a7510318befc2b4fdab140481eb4b9dd62d9245e042157085da2a70", size = 1797161, upload-time = "2026-01-07T18:04:25.964Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/725ab8664eeec73ec125b5a873448d80f5d8cf2750aaaf804cbc538a50a5/pymongo-4.16.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:85dc2f3444c346ea019a371e321ac868a4fab513b7a55fe368f0cc78de8177cc", size = 1780938, upload-time = "2026-01-07T18:04:28.745Z" },
+    { url = "https://files.pythonhosted.org/packages/22/50/dd7e9095e1ca35f93c3c844c92eb6eb0bc491caeb2c9bff3b32fe3c9b18f/pymongo-4.16.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dabbf3c14de75a20cc3c30bf0c6527157224a93dfb605838eabb1a2ee3be008d", size = 1714342, upload-time = "2026-01-07T18:04:30.331Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c9/542776987d5c31ae8e93e92680ea2b6e5a2295f398b25756234cabf38a39/pymongo-4.16.0-cp312-cp312-win32.whl", hash = "sha256:60307bb91e0ab44e560fe3a211087748b2b5f3e31f403baf41f5b7b0a70bd104", size = 887868, upload-time = "2026-01-07T18:04:32.124Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d4/b4045a7ccc5680fb496d01edf749c7a9367cc8762fbdf7516cf807ef679b/pymongo-4.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:f513b2c6c0d5c491f478422f6b5b5c27ac1af06a54c93ef8631806f7231bd92e", size = 907554, upload-time = "2026-01-07T18:04:33.685Z" },
+    { url = "https://files.pythonhosted.org/packages/60/4c/33f75713d50d5247f2258405142c0318ff32c6f8976171c4fcae87a9dbdf/pymongo-4.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:dfc320f08ea9a7ec5b2403dc4e8150636f0d6150f4b9792faaae539c88e7db3b", size = 892971, upload-time = "2026-01-07T18:04:35.594Z" },
+    { url = "https://files.pythonhosted.org/packages/47/84/148d8b5da8260f4679d6665196ae04ab14ffdf06f5fe670b0ab11942951f/pymongo-4.16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d15f060bc6d0964a8bb70aba8f0cb6d11ae99715438f640cff11bbcf172eb0e8", size = 972009, upload-time = "2026-01-07T18:04:38.303Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/9f3a8daf583d0adaaa033a3e3e58194d2282737dc164014ff33c7a081103/pymongo-4.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4a19ea46a0fe71248965305a020bc076a163311aefbaa1d83e47d06fa30ac747", size = 971784, upload-time = "2026-01-07T18:04:39.669Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/f2/b6c24361fcde24946198573c0176406bfd5f7b8538335f3d939487055322/pymongo-4.16.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:311d4549d6bf1f8c61d025965aebb5ba29d1481dc6471693ab91610aaffbc0eb", size = 1947174, upload-time = "2026-01-07T18:04:41.368Z" },
+    { url = "https://files.pythonhosted.org/packages/47/1a/8634192f98cf740b3d174e1018dd0350018607d5bd8ac35a666dc49c732b/pymongo-4.16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:46ffb728d92dd5b09fc034ed91acf5595657c7ca17d4cf3751322cd554153c17", size = 1991727, upload-time = "2026-01-07T18:04:42.965Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/2f/0c47ac84572b28e23028a23a3798a1f725e1c23b0cf1c1424678d16aff42/pymongo-4.16.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:acda193f440dd88c2023cb00aa8bd7b93a9df59978306d14d87a8b12fe426b05", size = 2082497, upload-time = "2026-01-07T18:04:44.652Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/57/9f46ef9c862b2f0cf5ce798f3541c201c574128d31ded407ba4b3918d7b6/pymongo-4.16.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5d9fdb386cf958e6ef6ff537d6149be7edb76c3268cd6833e6c36aa447e4443f", size = 2064947, upload-time = "2026-01-07T18:04:46.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/5421c0998f38e32288100a07f6cb2f5f9f352522157c901910cb2927e211/pymongo-4.16.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:91899dd7fb9a8c50f09c3c1cf0cb73bfbe2737f511f641f19b9650deb61c00ca", size = 1980478, upload-time = "2026-01-07T18:04:48.017Z" },
+    { url = "https://files.pythonhosted.org/packages/92/93/bfc448d025e12313a937d6e1e0101b50cc9751636b4b170e600fe3203063/pymongo-4.16.0-cp313-cp313-win32.whl", hash = "sha256:2cd60cd1e05de7f01927f8e25ca26b3ea2c09de8723241e5d3bcfdc70eaff76b", size = 934672, upload-time = "2026-01-07T18:04:49.538Z" },
+    { url = "https://files.pythonhosted.org/packages/96/10/12710a5e01218d50c3dd165fd72c5ed2699285f77348a3b1a119a191d826/pymongo-4.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3ead8a0050c53eaa55935895d6919d393d0328ec24b2b9115bdbe881aa222673", size = 959237, upload-time = "2026-01-07T18:04:51.382Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/56/d288bcd1d05bc17ec69df1d0b1d67bc710c7c5dbef86033a5a4d2e2b08e6/pymongo-4.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:dbbc5b254c36c37d10abb50e899bc3939bbb7ab1e7c659614409af99bd3e7675", size = 940909, upload-time = "2026-01-07T18:04:52.904Z" },
+    { url = "https://files.pythonhosted.org/packages/30/9e/4d343f8d0512002fce17915a89477b9f916bda1205729e042d8f23acf194/pymongo-4.16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:8a254d49a9ffe9d7f888e3c677eed3729b14ce85abb08cd74732cead6ccc3c66", size = 1026634, upload-time = "2026-01-07T18:04:54.359Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/e3/341f88c5535df40c0450fda915f582757bb7d988cdfc92990a5e27c4c324/pymongo-4.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a1bf44e13cf2d44d2ea2e928a8140d5d667304abe1a61c4d55b4906f389fbe64", size = 1026252, upload-time = "2026-01-07T18:04:56.642Z" },
+    { url = "https://files.pythonhosted.org/packages/af/64/9471b22eb98f0a2ca0b8e09393de048502111b2b5b14ab1bd9e39708aab5/pymongo-4.16.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f1c5f1f818b669875d191323a48912d3fcd2e4906410e8297bb09ac50c4d5ccc", size = 2207399, upload-time = "2026-01-07T18:04:58.255Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ac/47c4d50b25a02f21764f140295a2efaa583ee7f17992a5e5fa542b3a690f/pymongo-4.16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77cfd37a43a53b02b7bd930457c7994c924ad8bbe8dff91817904bcbf291b371", size = 2260595, upload-time = "2026-01-07T18:04:59.788Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/1b/0ce1ce9dd036417646b2fe6f63b58127acff3cf96eeb630c34ec9cd675ff/pymongo-4.16.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:36ef2fee50eee669587d742fb456e349634b4fcf8926208766078b089054b24b", size = 2366958, upload-time = "2026-01-07T18:05:01.942Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/3c/a5a17c0d413aa9d6c17bc35c2b472e9e79cda8068ba8e93433b5f43028e9/pymongo-4.16.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:55f8d5a6fe2fa0b823674db2293f92d74cd5f970bc0360f409a1fc21003862d3", size = 2346081, upload-time = "2026-01-07T18:05:03.576Z" },
+    { url = "https://files.pythonhosted.org/packages/65/19/f815533d1a88fb8a3b6c6e895bb085ffdae68ccb1e6ed7102202a307f8e2/pymongo-4.16.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9caacac0dd105e2555521002e2d17afc08665187017b466b5753e84c016628e6", size = 2246053, upload-time = "2026-01-07T18:05:05.459Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/88/4be3ec78828dc64b212c123114bd6ae8db5b7676085a7b43cc75d0131bd2/pymongo-4.16.0-cp314-cp314-win32.whl", hash = "sha256:c789236366525c3ee3cd6e4e450a9ff629a7d1f4d88b8e18a0aea0615fd7ecf8", size = 989461, upload-time = "2026-01-07T18:05:07.018Z" },
+    { url = "https://files.pythonhosted.org/packages/af/5a/ab8d5af76421b34db483c9c8ebc3a2199fb80ae63dc7e18f4cf1df46306a/pymongo-4.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:2b0714d7764efb29bf9d3c51c964aed7c4c7237b341f9346f15ceaf8321fdb35", size = 1017803, upload-time = "2026-01-07T18:05:08.499Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f4/98d68020728ac6423cf02d17cfd8226bf6cce5690b163d30d3f705e8297e/pymongo-4.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:12762e7cc0f8374a8cae3b9f9ed8dabb5d438c7b33329232dd9b7de783454033", size = 997184, upload-time = "2026-01-07T18:05:09.944Z" },
+    { url = "https://files.pythonhosted.org/packages/50/00/dc3a271daf06401825b9c1f4f76f018182c7738281ea54b9762aea0560c1/pymongo-4.16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1c01e8a7cd0ea66baf64a118005535ab5bf9f9eb63a1b50ac3935dccf9a54abe", size = 1083303, upload-time = "2026-01-07T18:05:11.702Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4b/b5375ee21d12eababe46215011ebc63801c0d2c5ffdf203849d0d79f9852/pymongo-4.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4c4872299ebe315a79f7f922051061634a64fda95b6b17677ba57ef00b2ba2a4", size = 1083233, upload-time = "2026-01-07T18:05:13.182Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e3/52efa3ca900622c7dcb56c5e70f15c906816d98905c22d2ee1f84d9a7b60/pymongo-4.16.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:78037d02389745e247fe5ab0bcad5d1ab30726eaac3ad79219c7d6bbb07eec53", size = 2527438, upload-time = "2026-01-07T18:05:14.981Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/96/43b1be151c734e7766c725444bcbfa1de6b60cc66bfb406203746839dd25/pymongo-4.16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c126fb72be2518395cc0465d4bae03125119136462e1945aea19840e45d89cfc", size = 2600399, upload-time = "2026-01-07T18:05:16.794Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/62/fa64a5045dfe3a1cd9217232c848256e7bc0136cffb7da4735c5e0d30e40/pymongo-4.16.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f3867dc225d9423c245a51eaac2cfcd53dde8e0a8d8090bb6aed6e31bd6c2d4f", size = 2720960, upload-time = "2026-01-07T18:05:18.498Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7b/01577eb97e605502821273a5bc16ce0fb0be5c978fe03acdbff471471202/pymongo-4.16.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f25001a955073b80510c0c3db0e043dbbc36904fd69e511c74e3d8640b8a5111", size = 2699344, upload-time = "2026-01-07T18:05:20.073Z" },
+    { url = "https://files.pythonhosted.org/packages/55/68/6ef6372d516f703479c3b6cbbc45a5afd307173b1cbaccd724e23919bb1a/pymongo-4.16.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d9885aad05f82fd7ea0c9ca505d60939746b39263fa273d0125170da8f59098", size = 2577133, upload-time = "2026-01-07T18:05:22.052Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c7/b5337093bb01da852f945802328665f85f8109dbe91d81ea2afe5ff059b9/pymongo-4.16.0-cp314-cp314t-win32.whl", hash = "sha256:948152b30eddeae8355495f9943a3bf66b708295c0b9b6f467de1c620f215487", size = 1040560, upload-time = "2026-01-07T18:05:23.888Z" },
+    { url = "https://files.pythonhosted.org/packages/96/8c/5b448cd1b103f3889d5713dda37304c81020ff88e38a826e8a75ddff4610/pymongo-4.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f6e42c1bc985d9beee884780ae6048790eb4cd565c46251932906bdb1630034a", size = 1075081, upload-time = "2026-01-07T18:05:26.874Z" },
+    { url = "https://files.pythonhosted.org/packages/32/cd/ddc794cdc8500f6f28c119c624252fb6dfb19481c6d7ed150f13cf468a6d/pymongo-4.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:6b2a20edb5452ac8daa395890eeb076c570790dfce6b7a44d788af74c2f8cf96", size = 1047725, upload-time = "2026-01-07T18:05:28.47Z" },
+]
+
+[[package]]
 name = "pyproject-hooks"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1081,6 +1155,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/a9/104ec9234c8448c4379768221ea6df01260cd6c2ce13182d4eac531c8342/readme_renderer-44.0.tar.gz", hash = "sha256:8712034eabbfa6805cacf1402b4eeb2a73028f72d1166d6f5cb7f9c047c5d1e1", size = 32056, upload-time = "2024-07-08T15:00:57.805Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e1/67/921ec3024056483db83953ae8e48079ad62b92db7880013ca77632921dd0/readme_renderer-44.0-py3-none-any.whl", hash = "sha256:2fbca89b81a08526aadf1357a8c2ae889ec05fb03f5da67f9769c9a592166151", size = 13310, upload-time = "2024-07-08T15:00:56.577Z" },
+]
+
+[[package]]
+name = "redis"
+version = "7.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/7f/3759b1d0d72b7c92f0d70ffd9dc962b7b7b5ee74e135f9d7d8ab06b8a318/redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad", size = 4943913, upload-time = "2026-03-24T09:14:37.53Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/3a/95deec7db1eb53979973ebd156f3369a72732208d1391cd2e5d127062a32/redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec", size = 409772, upload-time = "2026-03-24T09:14:35.968Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Issue
Add first-party MongoDB and Redis storage roles for both memory and graph roles, while preserving the role-specific runtime storage registry introduced in the storage expansion work.

## Root cause
Cellin had relational and in-memory storage options, but no first-party document or cache-oriented memory/graph stores. That left the advertised backend matrix incomplete and made archive semantics for non-relational backends undefined.

## Fix
- Added  /  and  / .
- Added shared serialization helpers for memory and edge payloads so MongoDB and Redis store semantics stay aligned.
- Wired  and  into  and storage resolution tests.
- Added optional dependency extras in  and documented deployment tradeoffs in .
- Added fake-driver integration and unit coverage for backend behavior and missing dependency errors.

## Validation
- ........................................................................ [ 50%]
......................................................................   [100%]
142 passed in 0.35s
- Success: no issues found in 46 source files
- python3 -m uv run ruff format --check src tests docs scripts
81 files already formatted
python3 -m uv run ruff check src tests docs scripts
All checks passed!
python3 -m uv run mypy src
Success: no issues found in 46 source files
python3 -m uv run pytest --cov=src/cellin --cov-report=term-missing:skip-covered --cov-report=json:coverage.json
============================= test session starts ==============================
platform darwin -- Python 3.14.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/benranford/Projects/cellin-75
configfile: pyproject.toml
testpaths: tests
plugins: cov-7.1.0
collected 142 items

tests/contracts/test_registry.py ......                                  [  4%]
tests/contracts/test_runtime_additional.py ...                           [  6%]
tests/contracts/test_storage.py ....................                     [ 20%]
tests/evals/test_assets.py ......                                        [ 24%]
tests/evals/test_assets_additional.py ........                           [ 30%]
tests/evals/test_entrypoint.py ..                                        [ 31%]
tests/evals/test_runner.py ...                                           [ 33%]
tests/evals/test_smoke.py .                                              [ 34%]
tests/integration/cli/test_cli.py ...                                    [ 36%]
tests/integration/cli/test_cli_additional.py ...                         [ 38%]
tests/integration/dreaming/test_dreaming.py .....                        [ 42%]
tests/integration/dreaming/test_scheduler_service_additional.py ..       [ 43%]
tests/integration/dreaming/test_strategy_edge_cases.py ....              [ 46%]
tests/integration/ingest/test_adapters_and_pipeline_paths.py ...         [ 48%]
tests/integration/ingest/test_pipeline.py ..                             [ 50%]
tests/integration/retrieval/test_candidate_generation.py ..........      [ 57%]
tests/integration/retrieval/test_service_additional.py ..                [ 58%]
tests/integration/retrieval/test_weighted_retriever.py ......            [ 62%]
tests/integration/stores/test_document_cache_backends.py ..              [ 64%]
tests/integration/stores/test_in_memory.py ...                           [ 66%]
tests/integration/stores/test_pgvector.py ..                             [ 67%]
tests/integration/stores/test_sql_backends.py ...                        [ 69%]
tests/integration/stores/test_sqlite_and_vector_index.py ...........     [ 77%]
tests/unit/test_candidate_generation_additional.py ......                [ 81%]
tests/unit/test_cli_config.py .......                                    [ 86%]
tests/unit/test_document_cache_backends_unit.py ..                       [ 88%]
tests/unit/test_package.py .                                             [ 88%]
tests/unit/test_ranking_additional.py ...                                [ 90%]
tests/unit/test_release_versioning.py ..........                         [ 97%]
tests/unit/test_sql_backends_unit.py ...                                 [100%]

=============================== warnings summary ===============================
tests/integration/cli/test_cli_additional.py::test_cli_handles_no_pending_dreams_and_missing_trace_file
  /opt/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/re/__init__.py:287: ResourceWarning: unclosed database in <sqlite3.Connection object at 0x10c0e9210>
    def compile(pattern, flags=0):
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/integration/cli/test_cli_additional.py::test_cli_handles_no_pending_dreams_and_missing_trace_file
  /opt/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/re/__init__.py:287: ResourceWarning: unclosed database in <sqlite3.Connection object at 0x10c0bbb50>
    def compile(pattern, flags=0):
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/unit/test_candidate_generation_additional.py::test_candidate_index_merges_duplicate_candidates
  /opt/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/tokenize.py:472: ResourceWarning: unclosed database in <sqlite3.Connection object at 0x10bf2e980>
    def tokenize(readline):
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/unit/test_candidate_generation_additional.py::test_candidate_index_merges_duplicate_candidates
  /opt/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/tokenize.py:472: ResourceWarning: unclosed database in <sqlite3.Connection object at 0x10bf2ea70>
    def tokenize(readline):
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

tests/unit/test_candidate_generation_additional.py::test_candidate_index_merges_duplicate_candidates
  /opt/homebrew/Cellar/python@3.14/3.14.3_1/Frameworks/Python.framework/Versions/3.14/lib/python3.14/tokenize.py:472: ResourceWarning: unclosed database in <sqlite3.Connection object at 0x10bf2f2e0>
    def tokenize(readline):
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================ tests coverage ================================
_______________ coverage: platform darwin, python 3.14.3-final-0 _______________

Name                                        Stmts   Miss  Cover   Missing
-------------------------------------------------------------------------
src/cellin/cli/config.py                       95      2    98%   57, 77
src/cellin/dreaming/strategies.py             202      1    99%   97
src/cellin/evals/runner.py                    163      2    99%   49, 385
src/cellin/ingest/pipeline.py                  84      1    99%   45
src/cellin/stores/_graph_serialization.py      67      9    87%   32, 38, 44, 50, 56, 102, 168, 195, 225
src/cellin/stores/mongodb.py                   99      1    99%   25
src/cellin/stores/pgvector.py                  38      1    97%   41
src/cellin/stores/redis.py                     92      2    98%   74, 87
src/cellin/stores/sql_backends.py             274      1    99%   119
src/cellin/stores/sqlite.py                   109      1    99%   155
-------------------------------------------------------------------------
TOTAL                                        2581     21    99%

36 files skipped due to complete coverage.
Coverage JSON written to file coverage.json
======================= 142 passed, 5 warnings in 0.82s ========================
python3 -m uv run python scripts/check_coverage.py --coverage-json coverage.json --source-root src/cellin --overall 98 --package 98
Overall coverage: 99.19% (2560/2581) [minimum 98.00%]
Per-package coverage:
- cellin: 100.00% (4/4) [minimum 98.00%]
- cli: 99.18% (243/245) [minimum 98.00%]
- core: 100.00% (252/252) [minimum 98.00%]
- dreaming: 99.71% (341/342) [minimum 98.00%]
- evals: 99.34% (301/303) [minimum 98.00%]
- ingest: 99.43% (173/174) [minimum 98.00%]
- ranking: 100.00% (78/78) [minimum 98.00%]
- retrieval: 100.00% (168/168) [minimum 98.00%]
- runtime: 100.00% (203/203) [minimum 98.00%]
- stores: 98.15% (797/812) [minimum 98.00%]
Coverage thresholds satisfied.
python3 -m uv run python -m cellin.evals smoke --output eval-results/smoke.json
smoke: ok -> eval-results/smoke.json
python3 -m uv run mkdocs build --strict
python3 -m uv run python scripts/release/verify_version.py   --release-kind any
version=0.2.0 release_kind=any
rm -rf dist build
python3 -m uv run python -m build
Successfully built cellin-0.2.0.tar.gz and cellin-0.2.0-py3-none-any.whl
python3 -m uv run twine check --strict dist/*
Checking dist/cellin-0.2.0-py3-none-any.whl: PASSED
Checking dist/cellin-0.2.0.tar.gz: PASSED
tmpdir=$(mktemp -d); \
		python3 -m venv "$tmpdir/venv"; \
		"$tmpdir/venv/bin/pip" install --upgrade pip >/dev/null; \
		"$tmpdir/venv/bin/pip" install dist/*.whl >/dev/null; \
		expected_version=$(python3 scripts/release/verify_version.py --print-version); \
		"$tmpdir/venv/bin/cellin" --version | grep -q "$expected_version"; \
		"$tmpdir/venv/bin/cellin" plugin list | grep -q "in-memory-trace-sink"; \
		rm -rf "$tmpdir"

Closes #75