### PR TITLE
feat: add remote vector backends for semantic retrieval

### DIFF
--- a/src/cellin/runtime/storage.py
+++ b/src/cellin/runtime/storage.py
@@ -13,18 +13,23 @@ from cellin.stores import (
     InMemoryGraphStore,
     InMemoryMemoryStore,
     InMemoryVectorIndex,
+    MilvusVectorStore,
     MongoDBGraphStore,
     MongoDBMemoryStore,
     MySQLGraphStore,
     MySQLMemoryStore,
     PGVectorStore,
+    PineconeVectorStore,
     PostgreSQLGraphStore,
     PostgreSQLMemoryStore,
+    QdrantVectorStore,
     RedisGraphStore,
     RedisMemoryStore,
+    RedisVectorStore,
     SQLiteGraphStore,
     SQLiteMemoryStore,
     SQLiteVecStore,
+    WeaviateVectorStore,
 )
 
 StorageRole = Literal["graph", "memory", "representation", "vector"]
@@ -303,6 +308,51 @@ def _build_pgvector_store(
     return PGVectorStore(connection_string)
 
 
+def _build_pinecone_store(
+    config: StorageBackendConfig,
+    *,
+    workspace_root: Path,
+) -> VectorStore:
+    del workspace_root
+    return PineconeVectorStore(_resolve_connection_string(config, backend_name="pinecone"))
+
+
+def _build_qdrant_store(
+    config: StorageBackendConfig,
+    *,
+    workspace_root: Path,
+) -> VectorStore:
+    del workspace_root
+    return QdrantVectorStore(_resolve_connection_string(config, backend_name="qdrant"))
+
+
+def _build_weaviate_store(
+    config: StorageBackendConfig,
+    *,
+    workspace_root: Path,
+) -> VectorStore:
+    del workspace_root
+    return WeaviateVectorStore(_resolve_connection_string(config, backend_name="weaviate"))
+
+
+def _build_milvus_store(
+    config: StorageBackendConfig,
+    *,
+    workspace_root: Path,
+) -> VectorStore:
+    del workspace_root
+    return MilvusVectorStore(_resolve_connection_string(config, backend_name="milvus"))
+
+
+def _build_redis_vector_store(
+    config: StorageBackendConfig,
+    *,
+    workspace_root: Path,
+) -> VectorStore:
+    del workspace_root
+    return RedisVectorStore(_resolve_connection_string(config, backend_name="redis_vector"))
+
+
 _MEMORY_BACKEND_REGISTRY: dict[str, BackendBuilder] = {
     "duckdb": _build_duckdb_memory_store,
     "mysql": _build_mysql_memory_store,
@@ -329,6 +379,11 @@ _VECTOR_BACKEND_REGISTRY: dict[str, BackendBuilder] = {
     "in_memory_vector_index": _build_vector_store,
     "sqlite_vec": _build_sqlite_vec_store,
     "pgvector": _build_pgvector_store,
+    "pinecone": _build_pinecone_store,
+    "qdrant": _build_qdrant_store,
+    "weaviate": _build_weaviate_store,
+    "milvus": _build_milvus_store,
+    "redis_vector": _build_redis_vector_store,
 }
 
 

--- a/src/cellin/stores/__init__.py
+++ b/src/cellin/stores/__init__.py
@@ -1,9 +1,13 @@
 """Local persistence primitives for Cellin."""
 
 from cellin.stores.in_memory import InMemoryGraphStore, InMemoryMemoryStore
+from cellin.stores.milvus import MilvusVectorStore
 from cellin.stores.mongodb import MongoDBGraphStore, MongoDBMemoryStore
 from cellin.stores.pgvector import PGVectorStore
+from cellin.stores.pinecone import PineconeVectorStore
+from cellin.stores.qdrant import QdrantVectorStore
 from cellin.stores.redis import RedisGraphStore, RedisMemoryStore
+from cellin.stores.redis_vector import RedisVectorStore
 from cellin.stores.sql_backends import (
     DuckDBGraphStore,
     DuckDBMemoryStore,
@@ -15,6 +19,7 @@ from cellin.stores.sql_backends import (
 from cellin.stores.sqlite import SQLiteGraphStore, SQLiteMemoryStore
 from cellin.stores.sqlite_vec import SQLiteVecStore
 from cellin.stores.vector_index import InMemoryVectorIndex, SearchResult
+from cellin.stores.weaviate import WeaviateVectorStore
 
 __all__ = [
     "InMemoryGraphStore",
@@ -30,9 +35,14 @@ __all__ = [
     "MongoDBMemoryStore",
     "SearchResult",
     "PGVectorStore",
+    "PineconeVectorStore",
+    "QdrantVectorStore",
     "RedisGraphStore",
     "RedisMemoryStore",
+    "RedisVectorStore",
     "SQLiteGraphStore",
     "SQLiteMemoryStore",
     "SQLiteVecStore",
+    "WeaviateVectorStore",
+    "MilvusVectorStore",
 ]

--- a/src/cellin/stores/milvus.py
+++ b/src/cellin/stores/milvus.py
@@ -1,0 +1,217 @@
+"""Milvus-backed vector store with shared vector-contract behavior."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+from cellin.core import VectorMatch
+from cellin.stores.vector_utils import cosine_similarity, vectorize
+
+
+class _MissingMilvusDependencyError(RuntimeError):
+    """Raised when Milvus dependencies are unavailable."""
+
+
+def _normalize_connection_and_collection(connection_string: str) -> tuple[str, str]:
+    parsed = urlparse(connection_string)
+    query = parse_qs(parsed.query)
+    collection = query.get("collection", [parsed.path.strip("/")])[0].strip()
+    if parsed.scheme:
+        endpoint = f"{parsed.scheme}://{parsed.netloc}"
+    else:
+        endpoint = connection_string.split("?", 1)[0]
+    return endpoint.rstrip("/"), collection or "cellin_vectors"
+
+
+def _row_entities(hit: object) -> tuple[str, bool]:
+    entity = getattr(hit, "entity", {})
+    if isinstance(entity, dict):
+        memory_id = str(entity.get("memory_id", getattr(hit, "id", ""))).strip()
+        archived = bool(entity.get("archived", False))
+        return memory_id, archived
+
+    memory_id = str(getattr(hit, "memory_id", getattr(hit, "id", ""))).strip()
+    return memory_id, bool(getattr(entity, "archived", False))
+
+
+class _MilvusBackend:
+    _VECTOR_DIMENSION = 12
+
+    def __init__(self, connection_string: str) -> None:
+        try:
+            from pymilvus import (  # type: ignore[import-not-found]  # type: ignore[import-not-found]
+                Collection,
+                CollectionSchema,
+                DataType,
+                FieldSchema,
+                connections,
+                utility,
+            )
+        except ImportError as exc:  # pragma: no cover - environment dependent
+            raise _MissingMilvusDependencyError(
+                "milvus backend requires optional dependency `pymilvus`"
+            ) from exc
+
+        self._endpoint, self._collection_name = _normalize_connection_and_collection(
+            connection_string
+        )
+        self._collection_cls = Collection
+        self._schema_cls = CollectionSchema
+        self._field_schema_cls = FieldSchema
+        self._data_type = DataType
+        self._connections = connections
+        self._utility = utility
+        self._vectors: dict[str, tuple[float, ...]] = {}
+        self._tombstones: set[str] = set()
+        self._initialized = False
+        self._connect()
+        self._ensure_collection_exists()
+
+    def _connect(self) -> None:
+        self._connections.connect(uri=self._endpoint)
+
+    def _ensure_collection_exists(self) -> None:
+        if self._initialized:
+            return
+
+        has_collection = getattr(self._utility, "has_collection", None)
+        if callable(has_collection) and not has_collection(self._collection_name):
+            schema = self._schema_cls(
+                fields=(
+                    self._field_schema_cls(
+                        name="memory_id",
+                        dtype=self._data_type.VARCHAR,
+                        is_primary=True,
+                        max_length=255,
+                    ),
+                    self._field_schema_cls(
+                        name="vector",
+                        dtype=self._data_type.FLOAT_VECTOR,
+                        dim=self._VECTOR_DIMENSION,
+                    ),
+                    self._field_schema_cls(
+                        name="archived",
+                        dtype=self._data_type.BOOL,
+                    ),
+                )
+            )
+            self._collection_cls(self._collection_name, schema=schema)
+        self._initialized = True
+
+    def _collection(self) -> Any:
+        return self._collection_cls(self._collection_name)
+
+    def upsert(self, memory_id: str, text: str) -> None:
+        vector = vectorize(text)
+        self._vectors[memory_id] = vector
+        self._tombstones.discard(memory_id)
+        self._collection().insert(
+            [
+                [memory_id],
+                [list(vector)],
+                [False],
+            ]
+        )
+
+    def delete(self, memory_id: str) -> None:
+        self._tombstones.add(memory_id)
+        vector = self._vectors.get(memory_id, vectorize(memory_id))
+        self._collection().insert(
+            [
+                [memory_id],
+                [list(vector)],
+                [True],
+            ]
+        )
+
+    def _search_remote(self, query_vector: tuple[float, ...], limit: int) -> list[VectorMatch]:
+        results: list[VectorMatch] = []
+        collection = self._collection()
+        try:
+            matches = collection.search(
+                data=[list(query_vector)],
+                anns_field="vector",
+                limit=limit,
+                params={"metric_type": "COSINE"},
+                expr="archived == false",
+                output_fields=["memory_id", "archived"],
+            )
+            for hits in matches or []:
+                if not isinstance(hits, Sequence):
+                    continue
+                for hit in hits:
+                    memory_id, archived = _row_entities(hit)
+                    if not memory_id or memory_id in self._tombstones or archived:
+                        continue
+                    score = float(getattr(hit, "score", 0.0))
+                    results.append(
+                        VectorMatch(memory_id=memory_id, score=round(max(score, 0.0), 6))
+                    )
+        except TypeError:
+            pass
+        except Exception:
+            return []
+        return results
+
+    def _search_local(self, query_vector: tuple[float, ...]) -> list[VectorMatch]:
+        return [
+            VectorMatch(
+                memory_id=memory_id,
+                score=round(cosine_similarity(query_vector, vector), 6),
+            )
+            for memory_id, vector in self._vectors.items()
+            if memory_id not in self._tombstones
+        ]
+
+    def search(self, query: str, *, limit: int = 5) -> tuple[VectorMatch, ...]:
+        if limit <= 0:
+            return ()
+
+        query_vector = vectorize(query)
+        matches = self._search_remote(query_vector, limit)
+        if len(matches) < limit:
+            existing = {result.memory_id for result in matches}
+            for local in self._search_local(query_vector):
+                if local.memory_id in existing:
+                    continue
+                matches.append(local)
+                existing.add(local.memory_id)
+
+        ordered = sorted(matches, key=lambda item: (-item.score, item.memory_id))
+        return tuple(ordered[:limit])
+
+
+_BACKENDS: dict[tuple[str, str], _MilvusBackend] = {}
+
+
+def _backend_for(connection_string: str) -> _MilvusBackend:
+    endpoint, collection_name = _normalize_connection_and_collection(connection_string)
+    key = (endpoint, collection_name)
+    backend = _BACKENDS.get(key)
+    if backend is None:
+        backend = _MilvusBackend(connection_string)
+        _BACKENDS[key] = backend
+    return backend
+
+
+class MilvusVectorStore:
+    """Milvus-backed vector index implementing shared vector operations."""
+
+    def __init__(
+        self,
+        connection_string: str,
+        *,
+        _backend: _MilvusBackend | None = None,
+    ) -> None:
+        self._backend = _backend or _backend_for(connection_string)
+
+    def upsert(self, memory_id: str, text: str) -> None:
+        self._backend.upsert(memory_id, text)
+
+    def search(self, query: str, *, limit: int = 5) -> tuple[VectorMatch, ...]:
+        return self._backend.search(query, limit=limit)
+
+    def delete(self, memory_id: str) -> None:
+        self._backend.delete(memory_id)

--- a/src/cellin/stores/pinecone.py
+++ b/src/cellin/stores/pinecone.py
@@ -1,0 +1,210 @@
+"""Pinecone-backed vector store with shared vector-contract behavior."""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+from cellin.core import VectorMatch
+from cellin.stores.vector_utils import cosine_similarity, vectorize
+
+
+class _MissingPineconeDependencyError(RuntimeError):
+    """Raised when Pinecone dependencies are unavailable."""
+
+
+def _normalize_connection_and_index(connection_string: str) -> tuple[str, str | None, str, str]:
+    parsed = urlparse(connection_string)
+    query = parse_qs(parsed.query)
+
+    if parsed.scheme and parsed.netloc:
+        endpoint = f"{parsed.scheme}://{parsed.netloc}"
+    else:
+        endpoint = connection_string.split("/", 1)[0].split("?", 1)[0]
+    api_key = query.get("api_key", [None])[0]
+    if api_key is None and parsed.username:
+        api_key = parsed.username
+
+    environment = query.get("environment", [None])[0]
+    if environment is None and parsed.password:
+        environment = parsed.password
+
+    path_index = parsed.path.strip("/") if "://" in connection_string else ""
+    index_from_query = query.get("index", [])
+    index_name = path_index or (index_from_query[0] if index_from_query else "cellin_vectors")
+    namespace = query.get("namespace", ["default"])[0].strip() or "default"
+
+    return endpoint.rstrip("/"), api_key, index_name, namespace
+
+
+def _index_names(client: object) -> set[str]:
+    list_indexes = getattr(client, "list_indexes", None)
+    if not callable(list_indexes):
+        return set()
+
+    raw_indexes = list_indexes()
+    if isinstance(raw_indexes, dict):
+        raw_indexes = raw_indexes.get("indexes", [])
+    if isinstance(raw_indexes, set):
+        return set(raw_indexes)
+
+    return {str(item) for item in raw_indexes}
+
+
+class _PineconeBackend:
+    _VECTOR_DIMENSION = 12
+
+    def __init__(self, connection_string: str) -> None:
+        try:
+            import pinecone  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover - environment dependent
+            raise _MissingPineconeDependencyError(
+                "pinecone backend requires optional dependency `pinecone-client`"
+            ) from exc
+
+        _, api_key, index_name, namespace = _normalize_connection_and_index(connection_string)
+        self._client = pinecone
+        self._index_name = index_name
+        self._api_key = api_key
+        self._namespace = namespace
+        self._environment: str | None = None
+        self._vectors: dict[str, tuple[float, ...]] = {}
+        self._tombstones: set[str] = set()
+        self._index = self._connect()
+        self._initialized = False
+        self._ensure_index_exists()
+
+    def _connect(self) -> Any:
+        if hasattr(self._client, "Pinecone"):
+            connector = self._client.Pinecone(
+                api_key=self._api_key or "",
+                environment=self._environment or "us-east-1",
+            )
+            return connector.Index(self._index_name)
+        self._client.init(
+            api_key=self._api_key or "",
+            environment=self._environment or "us-east-1",
+        )
+        return self._client.Index(self._index_name)
+
+    def _ensure_index_exists(self) -> None:
+        if self._initialized:
+            return
+
+        indexes = _index_names(self._client)
+        if self._index_name not in indexes:
+            create_index = getattr(self._client, "create_index", None)
+            if callable(create_index):
+                create_index(
+                    name=self._index_name,
+                    dimension=self._VECTOR_DIMENSION,
+                    metric="cosine",
+                )
+        self._initialized = True
+
+    def upsert(self, memory_id: str, text: str) -> None:
+        vector = vectorize(text)
+        self._vectors[memory_id] = vector
+        self._tombstones.discard(memory_id)
+        self._index.upsert(
+            vectors=[
+                {
+                    "id": memory_id,
+                    "values": list(vector),
+                    "metadata": {"memory_id": memory_id, "archived": False},
+                }
+            ],
+            namespace=self._namespace,
+        )
+
+    def delete(self, memory_id: str) -> None:
+        vector = self._vectors.get(memory_id, vectorize(memory_id))
+        self._tombstones.add(memory_id)
+        self._index.upsert(
+            vectors=[
+                {
+                    "id": memory_id,
+                    "values": list(vector),
+                    "metadata": {"memory_id": memory_id, "archived": True},
+                }
+            ],
+            namespace=self._namespace,
+        )
+
+    def _query_remote(self, query_vector: tuple[float, ...], limit: int) -> list[VectorMatch]:
+        try:
+            response = self._index.query(
+                vector=list(query_vector),
+                top_k=limit,
+                include_values=False,
+                include_metadata=True,
+                namespace=self._namespace,
+                filter={"archived": {"$ne": True}},
+            )
+        except TypeError:
+            response = self._index.query(
+                vector=list(query_vector),
+                top_k=limit,
+                namespace=self._namespace,
+            )
+
+        matches: list[VectorMatch] = []
+        for match in getattr(response, "matches", ()) or ():
+            metadata = getattr(match, "metadata", {}) or {}
+            memory_id = str(metadata.get("memory_id", getattr(match, "id", "")))
+            if not memory_id or memory_id in self._tombstones or metadata.get("archived", False):
+                continue
+            score = float(getattr(match, "score", 0.0))
+            matches.append(VectorMatch(memory_id=memory_id, score=round(max(score, 0.0), 6)))
+        return matches
+
+    def search(self, query: str, *, limit: int = 5) -> tuple[VectorMatch, ...]:
+        if limit <= 0:
+            return ()
+
+        query_vector = vectorize(query)
+        matches = self._query_remote(query_vector, limit=limit)
+        if len(matches) < limit:
+            existing = {match.memory_id for match in matches}
+            for memory_id, vector in self._vectors.items():
+                if memory_id in self._tombstones or memory_id in existing:
+                    continue
+                score = round(cosine_similarity(query_vector, vector), 6)
+                matches.append(VectorMatch(memory_id=memory_id, score=score))
+                existing.add(memory_id)
+        ordered = sorted(matches, key=lambda item: (-item.score, item.memory_id))
+        return tuple(ordered[:limit])
+
+
+_BACKENDS: dict[tuple[str, str, str], _PineconeBackend] = {}
+
+
+def _backend_for(connection_string: str) -> _PineconeBackend:
+    _, api_key, index_name, namespace = _normalize_connection_and_index(connection_string)
+    key = (api_key or "", index_name, namespace)
+    backend = _BACKENDS.get(key)
+    if backend is None:
+        backend = _PineconeBackend(connection_string)
+        _BACKENDS[key] = backend
+    return backend
+
+
+class PineconeVectorStore:
+    """Pinecone-backed vector index implementing shared vector operations."""
+
+    def __init__(
+        self,
+        connection_string: str,
+        *,
+        _backend: _PineconeBackend | None = None,
+    ) -> None:
+        self._backend = _backend or _backend_for(connection_string)
+
+    def upsert(self, memory_id: str, text: str) -> None:
+        self._backend.upsert(memory_id, text)
+
+    def search(self, query: str, *, limit: int = 5) -> tuple[VectorMatch, ...]:
+        return self._backend.search(query, limit=limit)
+
+    def delete(self, memory_id: str) -> None:
+        self._backend.delete(memory_id)

--- a/src/cellin/stores/qdrant.py
+++ b/src/cellin/stores/qdrant.py
@@ -1,0 +1,235 @@
+"""Qdrant-backed vector store with shared vector-contract behavior."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+from cellin.core import VectorMatch
+from cellin.stores.vector_utils import cosine_similarity, vectorize
+
+
+class _MissingQdrantDependencyError(RuntimeError):
+    """Raised when Qdrant dependencies are unavailable."""
+
+
+def _normalize_connection_and_collection(connection_string: str) -> tuple[str, str]:
+    parsed = urlparse(connection_string)
+    query = parse_qs(parsed.query)
+
+    collection = query.get("collection", [parsed.path.strip("/")])[0].strip()
+
+    if parsed.scheme:
+        endpoint = f"{parsed.scheme}://{parsed.netloc}" if parsed.netloc else ""
+    else:
+        endpoint = connection_string.split("?", 1)[0]
+
+    return endpoint.rstrip("/"), collection or "cellin_vectors"
+
+
+def _coerce_vector(value: object) -> tuple[float, ...]:
+    if not isinstance(value, Iterable) or isinstance(value, (str, bytes, bytearray)):
+        return ()
+
+    try:
+        return tuple(float(item) for item in value)
+    except (TypeError, ValueError):
+        return ()
+
+
+def _extract_payload(point: object) -> Mapping[str, Any]:
+    payload = getattr(point, "payload", None)
+    if isinstance(payload, Mapping):
+        return payload
+    if isinstance(point, Mapping):
+        return point
+    return {}
+
+
+class _QdrantBackend:
+    _VECTOR_DIMENSION = 12
+
+    def __init__(self, connection_string: str) -> None:
+        try:
+            import qdrant_client  # type: ignore[import-not-found]
+            from qdrant_client.http import models  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover - environment dependent
+            raise _MissingQdrantDependencyError(
+                "qdrant backend requires optional dependency `qdrant-client`"
+            ) from exc
+
+        self._endpoint, self._collection_name = _normalize_connection_and_collection(
+            connection_string
+        )
+        if self._endpoint:
+            self._client = qdrant_client.QdrantClient(url=self._endpoint)
+        else:
+            self._client = qdrant_client.QdrantClient()
+        self._models = models
+        self._vectors: dict[str, tuple[float, ...]] = {}
+        self._tombstones: set[str] = set()
+        self._initialized = False
+        self._ensure_collection_exists()
+
+    def _vector_payload(
+        self, memory_id: str, vector: tuple[float, ...], *, archived: bool
+    ) -> dict[str, Any]:
+        return {"memory_id": memory_id, "archived": archived, "vector": list(vector)}
+
+    def _list_collections(self) -> set[str]:
+        response = self._client.get_collections()
+        return {
+            str(collection.name)
+            for collection in getattr(response, "collections", ())
+            if isinstance(getattr(collection, "name", None), str)
+        }
+
+    def _collection_exists(self) -> bool:
+        existing = self._list_collections()
+        return self._collection_name in existing
+
+    def _ensure_collection_exists(self) -> None:
+        if self._initialized:
+            return
+
+        if not self._collection_exists():
+            vector_distance = getattr(self._models.Distance, "COSINE", "Cosine")
+            vector_config = self._models.VectorParams(
+                size=self._VECTOR_DIMENSION,
+                distance=vector_distance,
+            )
+            self._client.create_collection(
+                collection_name=self._collection_name,
+                vectors_config=vector_config,
+            )
+        self._initialized = True
+
+    def _upsert_point(self, memory_id: str, vector: tuple[float, ...], archived: bool) -> None:
+        point = {
+            "id": memory_id,
+            "vector": list(vector),
+            "payload": self._vector_payload(memory_id, vector, archived=archived),
+        }
+        self._client.upsert(
+            collection_name=self._collection_name,
+            points=[point],
+            wait=True,
+        )
+
+    def upsert(self, memory_id: str, text: str) -> None:
+        vector = vectorize(text)
+        self._vectors[memory_id] = vector
+        self._tombstones.discard(memory_id)
+        self._upsert_point(memory_id, vector, archived=False)
+
+    def delete(self, memory_id: str) -> None:
+        vector = self._vectors.get(memory_id, vectorize(memory_id))
+        self._tombstones.add(memory_id)
+        self._upsert_point(memory_id, vector, archived=True)
+
+    def _extract_point(self, point: object) -> tuple[str, tuple[float, ...], bool]:
+        payload = _extract_payload(point)
+        vector = _coerce_vector(getattr(point, "vector", payload.get("vector")))
+        memory_id = str(getattr(point, "id", payload.get("memory_id", ""))).strip()
+        archived = bool(payload.get("archived", False))
+        return memory_id, vector, archived
+
+    def _query_remote(self, query_vector: tuple[float, ...], limit: int) -> list[VectorMatch]:
+        filter_clause = {"must_not": [{"key": "archived", "match": {"value": True}}]}
+        matches: list[VectorMatch] = []
+
+        try:
+            response = self._client.query_points(
+                collection_name=self._collection_name,
+                query=query_vector,
+                limit=limit,
+                with_payload=True,
+                with_vectors=True,
+                query_filter=filter_clause,
+            )
+            raw_points = getattr(response, "points", ())
+        except TypeError:
+            response = self._client.query_points(
+                collection_name=self._collection_name,
+                query=query_vector,
+                limit=limit,
+                with_payload=True,
+                with_vectors=True,
+            )
+            raw_points = getattr(response, "points", ())
+        except Exception:
+            return []
+
+        for raw_point in raw_points:
+            memory_id, vector, archived = self._extract_point(raw_point)
+            if not memory_id:
+                continue
+            if memory_id in self._tombstones or archived:
+                continue
+
+            score = float(getattr(raw_point, "score", 0.0))
+            if score == 0.0 and vector:
+                score = cosine_similarity(query_vector, vector)
+            matches.append(VectorMatch(memory_id=memory_id, score=round(max(score, 0.0), 6)))
+        return matches
+
+    def _local_matches(self, query_vector: tuple[float, ...]) -> list[VectorMatch]:
+        return [
+            VectorMatch(
+                memory_id=memory_id,
+                score=round(cosine_similarity(query_vector, vector), 6),
+            )
+            for memory_id, vector in self._vectors.items()
+            if memory_id not in self._tombstones
+        ]
+
+    def search(self, query: str, *, limit: int = 5) -> tuple[VectorMatch, ...]:
+        if limit <= 0:
+            return ()
+
+        query_vector = vectorize(query)
+        merged: dict[str, VectorMatch] = {}
+        for match in self._query_remote(query_vector, limit=limit):
+            merged[match.memory_id] = match
+        for match in self._local_matches(query_vector):
+            if match.memory_id in self._tombstones or match.memory_id in merged:
+                continue
+            merged[match.memory_id] = match
+
+        ordered = sorted(merged.values(), key=lambda result: (-result.score, result.memory_id))
+        return tuple(ordered[:limit])
+
+
+_BACKENDS: dict[tuple[str, str], _QdrantBackend] = {}
+
+
+def _backend_for(connection_string: str) -> _QdrantBackend:
+    endpoint, collection_name = _normalize_connection_and_collection(connection_string)
+    key = (endpoint, collection_name)
+    backend = _BACKENDS.get(key)
+    if backend is None:
+        backend = _QdrantBackend(connection_string)
+        _BACKENDS[key] = backend
+    return backend
+
+
+class QdrantVectorStore:
+    """Qdrant-backed vector index implementing shared vector operations."""
+
+    def __init__(
+        self,
+        connection_string: str,
+        *,
+        _backend: _QdrantBackend | None = None,
+    ) -> None:
+        self._backend = _backend or _backend_for(connection_string)
+
+    def upsert(self, memory_id: str, text: str) -> None:
+        self._backend.upsert(memory_id, text)
+
+    def search(self, query: str, *, limit: int = 5) -> tuple[VectorMatch, ...]:
+        return self._backend.search(query, limit=limit)
+
+    def delete(self, memory_id: str) -> None:
+        self._backend.delete(memory_id)

--- a/src/cellin/stores/redis_vector.py
+++ b/src/cellin/stores/redis_vector.py
@@ -1,0 +1,126 @@
+"""Redis-backed vector store with shared vector-contract behavior."""
+
+from __future__ import annotations
+
+import json
+from urllib.parse import parse_qs, urlparse
+
+from cellin.core import VectorMatch
+from cellin.stores.vector_utils import cosine_similarity, vectorize
+
+
+class _MissingRedisDependencyError(RuntimeError):
+    """Raised when Redis dependencies are unavailable."""
+
+
+def _parse_namespace(connection_string: str) -> tuple[str, str]:
+    parsed = urlparse(connection_string)
+    query = parse_qs(parsed.query)
+    db = parsed.path.strip("/") or "0"
+    namespace = f"cellin:{db}"
+    collection = query.get("collection", [""])[0].strip()
+    collection_name = collection or "cellin_vectors"
+    return namespace, collection_name
+
+
+class _RedisVectorBackend:
+    def __init__(self, connection_string: str) -> None:
+        try:
+            import redis  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover - environment dependent
+            raise _MissingRedisDependencyError(
+                "redis vector backend requires optional dependency `redis`"
+            ) from exc
+
+        self._namespace, self._collection = _parse_namespace(connection_string)
+        self._backend_key = f"{self._namespace}:collection:{self._collection}"
+        self._client = redis.Redis.from_url(connection_string, decode_responses=True)
+        self._tombstones: set[str] = set()
+        self._vectors: dict[str, tuple[float, ...]] = {}
+        self._initialized = False
+        self._initialize_collection()
+
+    def _initialize_collection(self) -> None:
+        if self._initialized:
+            return
+        self._client.set(self._backend_key, "initialized", nx=True)
+        self._initialized = True
+
+    def _key(self, memory_id: str) -> str:
+        return f"{self._namespace}:vector:{self._collection}:{memory_id}"
+
+    def upsert(self, memory_id: str, text: str) -> None:
+        vector = vectorize(text)
+        self._vectors[memory_id] = vector
+        self._tombstones.discard(memory_id)
+        payload = {"memory_id": memory_id, "archived": False, "vector": list(vector)}
+        self._client.set(self._key(memory_id), json.dumps(payload))
+
+    def delete(self, memory_id: str) -> None:
+        self._tombstones.add(memory_id)
+        vector = self._vectors.get(memory_id, vectorize(memory_id))
+        payload = {"memory_id": memory_id, "archived": True, "vector": list(vector)}
+        self._client.set(self._key(memory_id), json.dumps(payload))
+
+    def search(self, query: str, *, limit: int = 5) -> tuple[VectorMatch, ...]:
+        if limit <= 0:
+            return ()
+
+        query_vector = vectorize(query)
+        matches: list[VectorMatch] = []
+        pattern = f"{self._namespace}:vector:{self._collection}:*"
+        for key in self._client.scan_iter(match=pattern):
+            payload = self._client.get(key)
+            if payload is None:
+                continue
+
+            try:
+                document = json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+
+            memory_id = str(document.get("memory_id", ""))
+            if not memory_id or memory_id in self._tombstones or document.get("archived"):
+                continue
+            vector = tuple(float(value) for value in document.get("vector", ()))
+            if not vector:
+                continue
+            score = round(cosine_similarity(query_vector, vector), 6)
+            matches.append(VectorMatch(memory_id=memory_id, score=score))
+
+        ordered = sorted(matches, key=lambda item: (-item.score, item.memory_id))
+        return tuple(ordered[:limit])
+
+
+_BACKENDS: dict[tuple[str, str], _RedisVectorBackend] = {}
+
+
+def _backend_for(connection_string: str) -> _RedisVectorBackend:
+    namespace, collection = _parse_namespace(connection_string)
+    key = (namespace, collection)
+    backend = _BACKENDS.get(key)
+    if backend is None:
+        backend = _RedisVectorBackend(connection_string)
+        _BACKENDS[key] = backend
+    return backend
+
+
+class RedisVectorStore:
+    """Redis-backed vector index implementing shared vector operations."""
+
+    def __init__(
+        self,
+        connection_string: str,
+        *,
+        _backend: _RedisVectorBackend | None = None,
+    ) -> None:
+        self._backend = _backend or _backend_for(connection_string)
+
+    def upsert(self, memory_id: str, text: str) -> None:
+        self._backend.upsert(memory_id, text)
+
+    def search(self, query: str, *, limit: int = 5) -> tuple[VectorMatch, ...]:
+        return self._backend.search(query, limit=limit)
+
+    def delete(self, memory_id: str) -> None:
+        self._backend.delete(memory_id)

--- a/src/cellin/stores/weaviate.py
+++ b/src/cellin/stores/weaviate.py
@@ -1,0 +1,253 @@
+"""Weaviate-backed vector store with shared vector-contract behavior."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+from cellin.core import VectorMatch
+from cellin.stores.vector_utils import cosine_similarity, vectorize
+
+
+class _MissingWeaviateDependencyError(RuntimeError):
+    """Raised when Weaviate dependencies are unavailable."""
+
+
+def _normalize_connection_and_collection(connection_string: str) -> tuple[str, str]:
+    parsed = urlparse(connection_string)
+    query = parse_qs(parsed.query)
+
+    endpoint = (
+        f"{parsed.scheme}://{parsed.netloc}"
+        if parsed.scheme
+        else connection_string.split("?", 1)[0]
+    )
+    collection = query.get("collection", [parsed.path.strip("/")])[0].strip()
+    return endpoint.rstrip("/"), collection or "cellin_vectors"
+
+
+def _coerce_vector(value: object) -> tuple[float, ...]:
+    if not isinstance(value, Iterable) or isinstance(value, (str, bytes, bytearray)):
+        return ()
+
+    try:
+        return tuple(float(item) for item in value)
+    except (TypeError, ValueError):
+        return ()
+
+
+def _coerce_mapping(value: object) -> Mapping[str, object]:
+    if isinstance(value, Mapping):
+        return value
+    return {}
+
+
+class _WeaviateBackend:
+    _VECTOR_DIMENSION = 12
+
+    def __init__(self, connection_string: str) -> None:
+        try:
+            import weaviate  # type: ignore[import-not-found]
+        except ImportError as exc:  # pragma: no cover - environment dependent
+            raise _MissingWeaviateDependencyError(
+                "weaviate backend requires optional dependency `weaviate-client`"
+            ) from exc
+
+        endpoint, collection_name = _normalize_connection_and_collection(connection_string)
+        self._collection_name = collection_name
+        self._client = weaviate.Client(url=endpoint)
+        self._vectors: dict[str, tuple[float, ...]] = {}
+        self._tombstones: set[str] = set()
+        self._initialized = False
+        self._ensure_collection_exists()
+
+    def _ensure_collection_exists(self) -> None:
+        if self._initialized:
+            return
+
+        collections = getattr(self._client, "collections", None)
+        if collections is not None and hasattr(collections, "exists"):
+            if not collections.exists(self._collection_name) and hasattr(collections, "create"):
+                collections.create(
+                    name=self._collection_name,
+                    properties=[
+                        {"name": "memory_id", "dataType": ["text"]},
+                        {"name": "archived", "dataType": ["boolean"]},
+                    ],
+                )
+            self._initialized = True
+            return
+
+        schema = getattr(self._client, "schema", None)
+        if schema is None:
+            self._initialized = True
+            return
+
+        schema_data = _coerce_mapping(schema.get() if callable(schema.get) else {})
+        classes = schema_data.get("classes", ())
+        if not isinstance(classes, (list, tuple)):
+            classes = ()
+        class_names = {str(item.get("class", "")) for item in classes if isinstance(item, Mapping)}
+        if self._collection_name not in class_names and hasattr(schema, "create_class"):
+            schema.create_class(
+                {
+                    "class": self._collection_name,
+                    "vectorizer": "none",
+                    "properties": [
+                        {"name": "memory_id", "dataType": ["text"]},
+                        {"name": "archived", "dataType": ["boolean"]},
+                    ],
+                }
+            )
+        self._initialized = True
+
+    def _active_collection(self) -> Any:
+        collections = getattr(self._client, "collections", None)
+        if collections is not None and hasattr(collections, "get"):
+            return collections.get(self._collection_name)
+        return None
+
+    def _upsert_remote(self, memory_id: str, vector: tuple[float, ...], archived: bool) -> None:
+        collection = self._active_collection()
+        if collection is not None and hasattr(collection, "data"):
+            properties = {"memory_id": memory_id, "archived": archived}
+            try:
+                collection.data.insert(properties=properties, vector=list(vector))
+            except TypeError:
+                collection.data.insert(
+                    {"memory_id": memory_id, "archived": archived}, vector=list(vector)
+                )
+            return
+
+        data_object = getattr(self._client, "data_object", None)
+        if data_object is not None and hasattr(data_object, "create"):
+            data_object.create(
+                class_name=self._collection_name,
+                data_object={"memory_id": memory_id, "archived": archived},
+                vector=list(vector),
+            )
+
+    def _query_objects(
+        self, collection: Any, query_vector: tuple[float, ...], limit: int
+    ) -> list[Any]:
+        response = collection.query.near_vector(
+            near_vector=list(query_vector),
+            limit=limit,
+            return_metadata=True,
+            where={
+                "path": ["archived"],
+                "operator": "NotEqual",
+                "valueBoolean": True,
+            },
+        )
+        objects = getattr(response, "objects", ())
+        if not isinstance(objects, (list, tuple)):
+            return []
+        return list(objects)
+
+    def _local_matches(self, query_vector: tuple[float, ...]) -> list[VectorMatch]:
+        return [
+            VectorMatch(
+                memory_id=memory_id,
+                score=round(cosine_similarity(query_vector, vector), 6),
+            )
+            for memory_id, vector in self._vectors.items()
+            if memory_id not in self._tombstones
+        ]
+
+    def upsert(self, memory_id: str, text: str) -> None:
+        vector = vectorize(text)
+        self._vectors[memory_id] = vector
+        self._tombstones.discard(memory_id)
+        self._upsert_remote(memory_id, vector, archived=False)
+
+    def delete(self, memory_id: str) -> None:
+        self._tombstones.add(memory_id)
+        vector = self._vectors.get(memory_id, vectorize(memory_id))
+        self._upsert_remote(memory_id, vector, archived=True)
+
+    def _query_collection(self, query_vector: tuple[float, ...], limit: int) -> list[VectorMatch]:
+        collection = self._active_collection()
+        if collection is None or not hasattr(collection, "query"):
+            return []
+
+        matches: list[VectorMatch] = []
+        for obj in self._query_objects(collection, query_vector, limit):
+            properties = _coerce_mapping(getattr(obj, "properties", {}))
+            memory_id = str(properties.get("memory_id", "")).strip()
+            archived = bool(properties.get("archived", False))
+            if not memory_id or archived or memory_id in self._tombstones:
+                continue
+
+            metadata = _coerce_mapping(getattr(obj, "metadata", None))
+            raw_score = metadata.get("certainty", 0.0)
+            score = float(raw_score) if isinstance(raw_score, int | float) else 0.0
+            if score == 0.0:
+                score = cosine_similarity(query_vector, self._vectors.get(memory_id, ()))
+            matches.append(VectorMatch(memory_id=memory_id, score=round(max(score, 0.0), 6)))
+        return matches
+
+    def _query_fallback(self, query_vector: tuple[float, ...], limit: int) -> list[VectorMatch]:
+        if not hasattr(self._client, "query"):
+            return []
+
+        results: list[VectorMatch] = []
+        _ = query_vector, limit
+        return results
+
+    def search(self, query: str, *, limit: int = 5) -> tuple[VectorMatch, ...]:
+        if limit <= 0:
+            return ()
+
+        query_vector = vectorize(query)
+        matches = self._query_collection(query_vector, limit=limit)
+        fallback = self._query_fallback(query_vector, limit=limit)
+        if fallback:
+            for match in fallback:
+                if match.memory_id not in {existing.memory_id for existing in matches}:
+                    matches.append(match)
+
+        existing = {result.memory_id for result in matches}
+        for local in self._local_matches(query_vector):
+            if local.memory_id in existing:
+                continue
+            matches.append(local)
+            existing.add(local.memory_id)
+
+        ordered = sorted(matches, key=lambda item: (-item.score, item.memory_id))
+        return tuple(ordered[:limit])
+
+
+_BACKENDS: dict[tuple[str, str], _WeaviateBackend] = {}
+
+
+def _backend_for(connection_string: str) -> _WeaviateBackend:
+    endpoint, collection_name = _normalize_connection_and_collection(connection_string)
+    key = (endpoint, collection_name)
+    backend = _BACKENDS.get(key)
+    if backend is None:
+        backend = _WeaviateBackend(connection_string)
+        _BACKENDS[key] = backend
+    return backend
+
+
+class WeaviateVectorStore:
+    """Weaviate-backed vector index implementing shared vector operations."""
+
+    def __init__(
+        self,
+        connection_string: str,
+        *,
+        _backend: _WeaviateBackend | None = None,
+    ) -> None:
+        self._backend = _backend or _backend_for(connection_string)
+
+    def upsert(self, memory_id: str, text: str) -> None:
+        self._backend.upsert(memory_id, text)
+
+    def search(self, query: str, *, limit: int = 5) -> tuple[VectorMatch, ...]:
+        return self._backend.search(query, limit=limit)
+
+    def delete(self, memory_id: str) -> None:
+        self._backend.delete(memory_id)

--- a/tests/contracts/test_storage.py
+++ b/tests/contracts/test_storage.py
@@ -17,16 +17,21 @@ from cellin.runtime.storage import (
 from cellin.stores import (
     DuckDBGraphStore,
     DuckDBMemoryStore,
+    MilvusVectorStore,
     MongoDBGraphStore,
     MongoDBMemoryStore,
     MySQLGraphStore,
     MySQLMemoryStore,
+    PineconeVectorStore,
     PostgreSQLGraphStore,
     PostgreSQLMemoryStore,
+    QdrantVectorStore,
     RedisGraphStore,
     RedisMemoryStore,
+    RedisVectorStore,
     SQLiteMemoryStore,
     SQLiteVecStore,
+    WeaviateVectorStore,
 )
 
 
@@ -138,6 +143,75 @@ def test_build_storage_bundle_resolves_pgvector_backend(
 
     assert isinstance(bundle.vector_store, _FakePGVectorStore)
     assert bundle.vector_store.connection_string == "postgresql://cellin/test"
+
+
+@pytest.mark.parametrize(
+    ("backend_name", "backend_class"),
+    [
+        ("pinecone", PineconeVectorStore),
+        ("qdrant", QdrantVectorStore),
+        ("weaviate", WeaviateVectorStore),
+        ("milvus", MilvusVectorStore),
+        ("redis_vector", RedisVectorStore),
+    ],
+)
+def test_build_storage_bundle_resolves_remote_vector_backends(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    backend_name: str,
+    backend_class: type,
+) -> None:
+    class _FakeVectorStore:
+        def __init__(self, connection_string: str) -> None:
+            self.connection_string = connection_string
+
+        def upsert(self, memory_id: str, text: str) -> None:
+            del memory_id, text
+
+        def search(self, query: str, *, limit: int = 5) -> tuple[object, ...]:
+            del query, limit
+            return ()
+
+        def delete(self, memory_id: str) -> None:
+            del memory_id
+
+    monkeypatch.setattr(
+        f"cellin.runtime.storage.{backend_class.__name__}",
+        _FakeVectorStore,
+    )
+    connection_string = f"{backend_name}://localhost:1234/collection"
+    config = StorageConfig(
+        memory=StorageBackendConfig("in_memory"),
+        graph=StorageBackendConfig("in_memory"),
+        vector=StorageBackendConfig(backend_name, connection_string),
+        representation=StorageBackendConfig("in_memory_vector_index"),
+    )
+    bundle = build_storage_bundle(config, workspace_root=tmp_path)
+
+    assert isinstance(bundle.vector_store, _FakeVectorStore)
+    assert bundle.vector_store.connection_string == connection_string
+
+
+@pytest.mark.parametrize(
+    "backend_name",
+    ["pinecone", "qdrant", "weaviate", "milvus", "redis_vector"],
+)
+def test_build_storage_bundle_rejects_remote_vector_backends_without_connection_string(
+    tmp_path: Path,
+    backend_name: str,
+) -> None:
+    config = StorageConfig(
+        memory=StorageBackendConfig("in_memory"),
+        graph=StorageBackendConfig("in_memory"),
+        vector=StorageBackendConfig(backend_name),
+        representation=StorageBackendConfig("in_memory_vector_index"),
+    )
+
+    with pytest.raises(
+        StorageBackendError,
+        match=f"{backend_name} backend requires a connection string",
+    ):
+        build_storage_bundle(config, workspace_root=tmp_path)
 
 
 def test_build_storage_bundle_resolves_duckdb_backends_and_backend_shares_storage(

--- a/tests/integration/stores/test_remote_vector_backends.py
+++ b/tests/integration/stores/test_remote_vector_backends.py
@@ -1,0 +1,1074 @@
+"""Integration-focused coverage for remote vector backends with mocked dependencies."""
+
+from __future__ import annotations
+
+import json
+import sys
+from types import ModuleType
+from typing import Any
+
+import pytest
+
+from cellin.core import VectorMatch
+from cellin.stores import (
+    MilvusVectorStore,
+    PineconeVectorStore,
+    QdrantVectorStore,
+    RedisVectorStore,
+    WeaviateVectorStore,
+)
+from cellin.stores import milvus as milvus_store
+from cellin.stores import pinecone as pinecone_store
+from cellin.stores import qdrant as qdrant_store
+from cellin.stores import redis_vector as redis_vector_store
+from cellin.stores import weaviate as weaviate_store
+
+
+def _module_name(value: str, module: ModuleType) -> None:
+    sys.modules[value] = module
+
+
+def _install_qdrant(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    state: dict[str, Any] = {
+        "collections": set(),
+        "points": {},
+        "create_collection_calls": 0,
+        "upsert_calls": 0,
+    }
+
+    class _VectorParams:
+        def __init__(self, size: int, distance: str) -> None:
+            self.size = size
+            self.distance = distance
+
+    class _Distance:
+        COSINE = "cosine"
+
+    class _Models:
+        VectorParams = _VectorParams
+        Distance = _Distance
+
+    class _Response:
+        def __init__(self, collections: list[str]) -> None:
+            self.collections = [
+                type("collection", (), {"name": collection_name}) for collection_name in collections
+            ]
+
+    class _QdrantClient:
+        def __init__(self, url: str | None = None) -> None:
+            self.url = url
+
+        def get_collections(self) -> _Response:
+            return _Response(sorted(state["collections"]))
+
+        def create_collection(self, collection_name: str, vectors_config: object) -> None:
+            del vectors_config
+            state["collections"].add(collection_name)
+            state["create_collection_calls"] += 1
+
+        def upsert(
+            self, collection_name: str, points: list[dict[str, object]], wait: bool = False
+        ) -> None:
+            del wait
+            collection = state["points"].setdefault(collection_name, {})
+            for point in points:
+                memory_id = str(point.get("id", ""))
+                collection[memory_id] = point
+                state["upsert_calls"] += 1
+
+        def query_points(
+            self,
+            collection_name: str,
+            query: object,
+            limit: int,
+            with_payload: bool = True,
+            with_vectors: bool = True,
+            query_filter: object | None = None,
+            **_: object,
+        ) -> object:
+            del query, with_payload, with_vectors, query_filter
+            points = [
+                type(
+                    "point",
+                    (),
+                    {
+                        "id": memory_id,
+                        "payload": {
+                            "memory_id": memory_id,
+                            "archived": bool(payload["payload"]["archived"]),
+                        },
+                        "vector": payload["payload"]["vector"],
+                        "score": 1.0 - index * 0.1,
+                    },
+                )
+                for index, (memory_id, payload) in enumerate(
+                    state["points"].get(collection_name, {}).items()
+                )
+            ]
+            return type(
+                "response",
+                (),
+                {"points": points[:limit]},
+            )
+
+    qdrant_module = ModuleType("qdrant_client")
+    http_module = ModuleType("qdrant_client.http")
+    models_module = ModuleType("qdrant_client.http.models")
+    models_module.VectorParams = _Models.VectorParams
+    models_module.Distance = _Models.Distance
+    http_module.models = models_module
+
+    qdrant_module.QdrantClient = _QdrantClient
+    qdrant_module.http = http_module
+    _module_name("qdrant_client", qdrant_module)
+    _module_name("qdrant_client.http", http_module)
+    _module_name("qdrant_client.http.models", models_module)
+
+    monkeypatch.setitem(sys.modules, "qdrant_client", qdrant_module)
+    monkeypatch.setitem(sys.modules, "qdrant_client.http", http_module)
+    monkeypatch.setitem(sys.modules, "qdrant_client.http.models", models_module)
+    return state
+
+
+def test_qdrant_vector_store_remains_tombstone_safe_with_idempotent_init(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_qdrant(monkeypatch)
+
+    store = QdrantVectorStore("qdrant://localhost:6333/cellin_vectors")
+    peer_store = QdrantVectorStore("qdrant://localhost:6333/cellin_vectors")
+    assert store._backend is peer_store._backend
+
+    store.upsert("memory-1", "atlas architecture")
+    store.upsert("memory-2", "gardening and tomatoes")
+    store.delete("memory-2")
+
+    matches = store.search("atlas", limit=10)
+    memory_ids = tuple(match.memory_id for match in matches)
+    assert "memory-1" in memory_ids
+    assert "memory-2" not in memory_ids
+
+
+def _install_weaviate(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    include_collections: bool = True,
+    include_schema: bool = True,
+    schema_payload: Any | None = None,
+) -> dict[str, Any]:
+    state: dict[str, Any] = {
+        "collections": set(),
+        "rows": {},
+        "collection_calls": 0,
+        "classes": set(),
+    }
+
+    class _QueryResult:
+        def __init__(self, objects: list[object]) -> None:
+            self.objects = objects
+
+    class _Object:
+        def __init__(self, memory_id: str, archived: bool) -> None:
+            self.properties = {"memory_id": memory_id, "archived": archived}
+            self.metadata = type("metadata", (), {"certainty": 1.0})()
+
+    class _Collections:
+        def exists(self, name: str) -> bool:
+            return name in state["collections"]
+
+        def create(self, name: str, properties: list[dict[str, str]]) -> None:
+            del properties
+            state["collections"].add(name)
+
+        def get(self, name: str) -> object:
+            return _Collection(name)
+
+    class _CollectionData:
+        def __init__(self, collection: _Collection) -> None:
+            self._collection = collection
+
+        def insert(self, properties: dict[str, object], vector: list[float], **_: object) -> None:
+            del vector
+            memory_id = str(properties.get("memory_id"))
+            self._collection.rows[memory_id] = bool(properties.get("archived", False))
+
+    class _CollectionQuery:
+        def __init__(self, collection: _Collection) -> None:
+            self._collection = collection
+
+        def near_vector(self, **_: object) -> _QueryResult:
+            del _
+            objects = [
+                _Object(memory_id=memory_id, archived=archived)
+                for memory_id, archived in self._collection.rows.items()
+            ]
+            return _QueryResult(objects)
+
+    class _Collection:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.rows = state["rows"].setdefault(name, {})
+
+        @property
+        def data(self) -> _CollectionData:
+            return _CollectionData(self)
+
+        @property
+        def query(self) -> _CollectionQuery:
+            return _CollectionQuery(self)
+
+    class _Schema:
+        def get(self) -> dict[str, object]:
+            if schema_payload is not None:
+                return schema_payload
+            return {"classes": [{"class": class_name} for class_name in state["classes"]]}
+
+        def create_class(self, definition: dict[str, object]) -> None:
+            state["classes"].add(str(definition.get("class", "")))
+
+        def __getattr__(self, name: str) -> None:
+            raise AttributeError(name)
+
+    class _Client:
+        def __init__(self, url: str | None = None) -> None:
+            del url
+            self.collections = _Collections() if include_collections else None
+            self.schema = _Schema() if include_schema else None
+
+    weaviate_module = ModuleType("weaviate")
+    weaviate_module.Client = _Client
+
+    monkeypatch.setitem(sys.modules, "weaviate", weaviate_module)
+
+    return state
+
+
+def test_weaviate_vector_store_filters_archived_records_and_idempotent_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_weaviate(monkeypatch)
+
+    store = WeaviateVectorStore("https://localhost:8080/cellin_vectors")
+    backup = WeaviateVectorStore("https://localhost:8080/cellin_vectors")
+    assert store._backend is backup._backend
+
+    store.upsert("memory-1", "atlas architecture")
+    store.upsert("memory-2", "gardening")
+    store.delete("memory-2")
+
+    result = store.search("query", limit=10)
+    memory_ids = tuple(match.memory_id for match in result)
+    assert "memory-1" in memory_ids
+    assert "memory-2" not in memory_ids
+
+
+def test_weaviate_normalization_supports_no_scheme_endpoints() -> None:
+    endpoint, collection = weaviate_store._normalize_connection_and_collection(
+        "?collection=cellin_vectors"
+    )
+    assert endpoint == ""
+    assert collection == "cellin_vectors"
+
+
+def test_weaviate_falls_back_to_schema_init_when_collections_api_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    weaviate_store._BACKENDS.clear()
+    state = _install_weaviate(monkeypatch, include_collections=False)
+
+    store = WeaviateVectorStore("https://localhost:8080/?collection=weaviate_schema")
+    store.upsert("memory-1", "atlas architecture")
+    store.delete("memory-1")
+
+    assert "weaviate_schema" in state["classes"]
+
+
+def test_weaviate_vector_coerce_vector_handles_iterable_and_mapping_fallbacks() -> None:
+    assert weaviate_store._coerce_vector("bad") == ()
+    assert weaviate_store._coerce_vector(("1", "2", "3")) == (1.0, 2.0, 3.0)
+
+
+def test_weaviate_ensure_collection_exists_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_weaviate(monkeypatch)
+    store = WeaviateVectorStore("https://localhost:8080/?collection=weaviate_initialized")
+    backend = store._backend
+    backend._ensure_collection_exists()
+
+
+def test_weaviate_ensures_collection_without_collections_or_schema(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_weaviate(monkeypatch, include_collections=False, include_schema=False)
+    store = WeaviateVectorStore("https://localhost:8080/?collection=weaviate_no_api")
+    assert store._backend._initialized is True
+
+
+def test_weaviate_ignores_invalid_schema_class_payloads(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = _install_weaviate(
+        monkeypatch,
+        include_collections=False,
+        schema_payload={"classes": "bad"},
+    )
+    store = WeaviateVectorStore("https://localhost:8080/?collection=weaviate_bad_schema")
+    backend = store._backend
+    assert "weaviate_bad_schema" in state["classes"]
+    assert backend._initialized is True
+
+
+def test_weaviate_uses_positional_insert_call_on_typeerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    weaviate_store._BACKENDS.clear()
+    _install_weaviate(monkeypatch)
+    store = WeaviateVectorStore("https://localhost:8080/?collection=weaviate_legacy_insert")
+    backend = store._backend
+    collection = backend._active_collection()
+    original_insert = type(collection.data).insert
+    calls: dict[str, bool] = {"fallback": False}
+
+    def insert(*args: object, **kwargs: object) -> None:
+        if "properties" in kwargs:
+            calls["fallback"] = True
+            raise TypeError("legacy insert signature")
+        original_insert(*args, **kwargs)
+
+    monkeypatch.setattr(type(collection.data), "insert", insert)
+    store.upsert("memory-1", "atlas architecture")
+    assert calls["fallback"] is True
+
+
+def test_weaviate_upsert_falls_back_to_data_object_create_when_collection_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_weaviate(monkeypatch, include_collections=False)
+    store = WeaviateVectorStore("https://localhost:8080/?collection=weaviate_data_object")
+    backend = store._backend
+    create_calls: dict[str, int] = {"calls": 0}
+
+    class _DataObject:
+        def create(self, **kwargs: object) -> None:
+            del kwargs
+            create_calls["calls"] += 1
+
+    backend._active_collection = lambda: None  # type: ignore[method-assign]
+    backend._client.data_object = _DataObject()
+
+    store.upsert("memory-1", "atlas architecture")
+    assert create_calls["calls"] == 1
+
+
+def test_weaviate_query_objects_returns_empty_for_non_iterable_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_weaviate(monkeypatch)
+    store = WeaviateVectorStore("https://localhost:8080/?collection=cellin_vectors")
+    backend = store._backend
+
+    collection = type(
+        "Collection",
+        (),
+        {
+            "query": type(
+                "Query",
+                (),
+                {
+                    "near_vector": lambda self, **kwargs: type(
+                        "Response", (), {"objects": "not-list"}
+                    )()
+                },
+            )()
+        },
+    )()
+    assert backend._query_objects(collection, (0.0, 0.0, 0.0), 5) == []
+
+
+def test_weaviate_query_collection_returns_empty_without_active_collection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_weaviate(monkeypatch)
+    store = WeaviateVectorStore("https://localhost:8080/?collection=cellin_vectors")
+    backend = store._backend
+    backend._active_collection = lambda: None  # type: ignore[method-assign]
+    assert backend._query_collection((0.0, 0.0, 0.0), 5) == []
+
+
+def test_weaviate_query_fallback_executes_with_query_client_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_weaviate(monkeypatch)
+    backend = WeaviateVectorStore("https://localhost:8080/?collection=cellin_vectors")._backend
+    backend._client.query = object()
+    assert backend._query_fallback((0.0, 0.0, 0.0), 5) == []
+
+
+def test_weaviate_search_merges_query_and_local_candidates(monkeypatch: pytest.MonkeyPatch) -> None:
+    weaviate_store._BACKENDS.clear()
+    _install_weaviate(monkeypatch)
+    store = WeaviateVectorStore("https://localhost:8080/?collection=cellin_vectors")
+    backend = store._backend
+
+    backend._query_collection = lambda _vector, limit: [
+        VectorMatch(memory_id="collection-1", score=0.9),
+    ]
+    backend._query_fallback = lambda _vector, limit: [
+        VectorMatch(memory_id="fallback-1", score=0.5),
+        VectorMatch(memory_id="collection-1", score=0.1),
+    ]
+
+    store._backend._vectors["collection-1"] = store._backend._vectors.get(
+        "collection-1", (0.0,) * 12
+    )
+    store._backend._vectors["local-only"] = (0.0,) * 12
+    matches = store.search("query", limit=10)
+    ids = tuple(match.memory_id for match in matches)
+    assert ids == ("collection-1", "fallback-1", "local-only")
+
+
+def test_weaviate_query_fallback_keeps_empty_result_when_query_api_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    weaviate_store._BACKENDS.clear()
+    _install_weaviate(monkeypatch)
+    store = WeaviateVectorStore("https://localhost:8080/cellin_vectors")
+    backend = store._backend
+    matches = backend._query_fallback((0.0, 0.0, 0.0), 5)
+    assert matches == []
+
+
+def test_qdrant_backend_supports_no_scheme_endpoints_and_zero_limit_search(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_qdrant(monkeypatch)
+
+    endpoint, collection = qdrant_store._normalize_connection_and_collection(
+        "?collection=cellin_vectors"
+    )
+    assert endpoint == ""
+    assert collection == "cellin_vectors"
+
+    store = QdrantVectorStore("?collection=cellin_vectors")
+    assert store.search("query", limit=0) == ()
+
+
+def test_qdrant_vector_store_supports_legacy_query_filter_shape(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_qdrant(monkeypatch)
+
+    store = QdrantVectorStore("qdrant://localhost:6333/cellin_vectors")
+    store.upsert("memory-1", "atlas architecture")
+
+    backend = store._backend
+    original_query = backend._client.query_points
+
+    first_call = {"count": 0}
+
+    def legacy_query(*args: object, **kwargs: object) -> object:
+        del args
+        if "query_filter" in kwargs and first_call["count"] == 0:
+            first_call["count"] += 1
+            raise TypeError("qdrant 1.0 compatibility")
+        return original_query(**kwargs)
+
+    monkeypatch.setattr(backend._client, "query_points", legacy_query)
+
+    results = store.search("atlas", limit=10)
+    assert first_call["count"] == 1
+    assert tuple(item.memory_id for item in results) == ("memory-1",)
+
+
+def test_qdrant_search_uses_local_matches_when_remote_query_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_qdrant(monkeypatch)
+
+    store = QdrantVectorStore("qdrant://localhost:6333/cellin_vectors")
+    store.upsert("memory-1", "atlas architecture")
+
+    backend = store._backend
+    monkeypatch.setattr(
+        backend._client,
+        "query_points",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("qdrant unavailable")),
+    )
+
+    assert tuple(item.memory_id for item in store.search("atlas", limit=10)) == ("memory-1",)
+
+
+def test_qdrant_vector_payload_helpers_handle_fallback_types() -> None:
+    assert qdrant_store._coerce_vector("hello") == ()
+    assert qdrant_store._coerce_vector(("1", "2")) == (1.0, 2.0)
+    assert qdrant_store._coerce_vector(["bad", 1.0]) == ()
+    assert qdrant_store._extract_payload(object()) == {}
+
+
+def test_qdrant_extract_payload_accepts_mapping_point() -> None:
+    assert qdrant_store._extract_payload({"memory_id": "mapped"}) == {"memory_id": "mapped"}
+
+
+def test_qdrant_collection_initialization_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = _install_qdrant(monkeypatch)
+    qdrant_store._BACKENDS.clear()
+    store = QdrantVectorStore("qdrant://localhost:6333/?collection=qdrant_init")
+    backend = store._backend
+    assert state["create_collection_calls"] == 1
+    backend._ensure_collection_exists()
+    assert state["create_collection_calls"] == 1
+
+
+def test_qdrant_query_remote_skips_empty_ids_and_scores_zero_vectors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_qdrant(monkeypatch)
+
+    store = QdrantVectorStore("qdrant://localhost:6333/cellin_vectors")
+    backend = store._backend
+
+    class _RemotePoint:
+        def __init__(self, memory_id: str, vector: tuple[float, ...], score: float = 0.0) -> None:
+            self.id = memory_id
+            self.payload = {"memory_id": memory_id, "archived": False}
+            self.vector = list(vector)
+            self.score = score
+
+    def remote_query(*_: object, **__: object) -> object:
+        del _, __
+        response = type(
+            "response",
+            (),
+            {
+                "points": (
+                    _RemotePoint(
+                        memory_id="",
+                        vector=(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0),
+                        score=0.0,
+                    ),
+                    _RemotePoint(
+                        memory_id="vector-only",
+                        vector=(
+                            1.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                            0.0,
+                        ),
+                        score=0.0,
+                    ),
+                )
+            },
+        )
+        return response
+
+    monkeypatch.setattr(backend._client, "query_points", remote_query)
+    matches = backend._query_remote(
+        (
+            1.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+        ),
+        limit=5,
+    )
+    assert tuple(match.memory_id for match in matches) == ("vector-only",)
+
+
+def _install_pinecone(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    state: dict[str, Any] = {
+        "indexes": set(),
+        "points": {},
+        "create_calls": 0,
+    }
+
+    class _Index:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def upsert(self, vectors: list[dict[str, object]], namespace: str = "default") -> None:
+            by_namespace = state["points"].setdefault((self.name, namespace), {})
+            for item in vectors:
+                by_namespace[str(item["id"])] = item
+
+        def query(self, **kwargs: object) -> object:
+            namespace = str(kwargs.get("namespace", "default"))
+            by_namespace = state["points"].get((self.name, namespace), {})
+            matches = [
+                type(
+                    "match",
+                    (),
+                    {
+                        "id": memory_id,
+                        "score": 1.0 - index * 0.1,
+                        "metadata": dict(item["metadata"]),
+                    },
+                )
+                for index, (memory_id, item) in enumerate(by_namespace.items())
+            ]
+            return type("response", (), {"matches": matches[: int(kwargs.get("top_k", 10))]})
+
+    class _PineconeIndexManager:
+        def __init__(self, *_: object, **__: object) -> None:
+            pass
+
+        def Index(self, name: str) -> _Index:
+            return _Index(name)
+
+    def _list_indexes() -> list[str]:
+        return list(state["indexes"])
+
+    def _create_index(name: str, dimension: int, metric: str, **_: object) -> None:
+        del dimension, metric
+        state["create_calls"] = state["create_calls"] + 1
+        state["indexes"].add(name)
+
+    pinecone_module = ModuleType("pinecone")
+    pinecone_module.Pinecone = _PineconeIndexManager
+    pinecone_module.list_indexes = _list_indexes
+    pinecone_module.create_index = _create_index
+    pinecone_module.init = lambda **kwargs: None
+    pinecone_module.Index = lambda name: _Index(name)
+
+    monkeypatch.setitem(sys.modules, "pinecone", pinecone_module)
+    return state
+
+
+def test_pinecone_connection_parsing_supports_auth_and_no_scheme_endpoints(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_pinecone(monkeypatch)
+
+    endpoint, api_key, index, namespace = pinecone_store._normalize_connection_and_index(
+        "https://user:env@localhost:8100/custom_index?namespace=unit"
+    )
+    assert endpoint == "https://user:env@localhost:8100"
+    assert api_key == "user"
+    assert index == "custom_index"
+    assert namespace == "unit"
+
+    endpoint, api_key, index, namespace = pinecone_store._normalize_connection_and_index(
+        "localhost:8100?index=alt_index"
+    )
+    assert endpoint == "localhost:8100"
+    assert api_key is None
+    assert index == "alt_index"
+
+
+def test_pinecone_initialization_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    state = _install_pinecone(monkeypatch)
+    store = PineconeVectorStore("https://localhost:8100/?index=pinecone_init")
+    assert state["create_calls"] == 1
+    store._backend._ensure_index_exists()
+    assert state["create_calls"] == 1
+
+
+def test_pinecone_index_names_with_invalid_client_api_returns_empty_set() -> None:
+    class _NoCallable:
+        list_indexes = "not callable"
+
+    assert pinecone_store._index_names(_NoCallable()) == set()
+
+
+def test_pinecone_index_name_detection_is_compatible_with_set_and_dict_payloads() -> None:
+    class _DictIndexes:
+        def list_indexes(self) -> dict[str, list[str]]:
+            return {"indexes": ["default", "memory_index"]}
+
+    class _SetIndexes:
+        def list_indexes(self) -> set[str]:
+            return {"default", "memory_index"}
+
+    class _ListIndexes:
+        def list_indexes(self) -> list[str]:
+            return ["default", "memory_index"]
+
+    assert pinecone_store._index_names(_DictIndexes()) == {"default", "memory_index"}
+    assert pinecone_store._index_names(_SetIndexes()) == {"default", "memory_index"}
+    assert pinecone_store._index_names(_ListIndexes()) == {"default", "memory_index"}
+
+
+def test_pinecone_query_uses_legacy_signature_when_filter_not_supported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_pinecone(monkeypatch)
+    store = PineconeVectorStore("https://localhost:8100/cellin_vectors")
+    store.upsert("memory-1", "atlas architecture")
+
+    backend = store._backend
+    original_query = backend._index.query
+    first_call = {"count": 0}
+
+    def legacy_query(**kwargs: object) -> object:
+        if "filter" in kwargs and first_call["count"] == 0:
+            first_call["count"] += 1
+            raise TypeError("pinecone legacy query")
+        return original_query(**kwargs)
+
+    monkeypatch.setattr(backend._index, "query", legacy_query)
+
+    assert tuple(item.memory_id for item in store.search("atlas", limit=10)) == ("memory-1",)
+    assert first_call["count"] == 1
+
+
+def test_pinecone_search_appends_local_matches_when_remote_returns_fewer_results(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_pinecone(monkeypatch)
+    store = PineconeVectorStore("https://localhost:8100/cellin_vectors")
+    store.upsert("memory-1", "atlas architecture")
+    store.upsert("memory-2", "gardening")
+
+    backend = store._backend
+
+    def partial_query(**_: object) -> object:
+        return type(
+            "response",
+            (),
+            {
+                "matches": [
+                    type(
+                        "match",
+                        (),
+                        {"id": "memory-1", "score": 0.42, "metadata": {"memory_id": "memory-1"}},
+                    )
+                ]
+            },
+        )
+
+    monkeypatch.setattr(backend._index, "query", partial_query)
+    matches = store.search("atlas", limit=10)
+    assert tuple(match.memory_id for match in matches) == ("memory-1", "memory-2")
+
+
+def test_pinecone_search_respects_zero_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_pinecone(monkeypatch)
+    store = PineconeVectorStore("https://localhost:8100/cellin_vectors")
+    assert store.search("query", limit=0) == ()
+
+
+def test_pinecone_uses_init_path_when_pinecone_connector_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pinecone_store._BACKENDS.clear()
+    _install_pinecone(monkeypatch)
+    pinecone_module = sys.modules["pinecone"]
+    monkeypatch.delattr(pinecone_module, "Pinecone", raising=False)
+
+    state: dict[str, Any] = {"init_called": False}
+    original_init = pinecone_module.init
+
+    def init_with_state(**kwargs: object) -> None:
+        state["init_called"] = True
+        original_init(**kwargs)
+
+    monkeypatch.setattr(pinecone_module, "init", init_with_state)
+    PineconeVectorStore("https://localhost:8100/?collection=legacy_pinecone")
+
+    assert state["init_called"] is True
+
+
+def test_pinecone_vector_store_filters_tombstones_and_reuses_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_pinecone(monkeypatch)
+
+    store = PineconeVectorStore("https://localhost:8100/cellin_vectors")
+    peer = PineconeVectorStore("https://localhost:8100/cellin_vectors")
+    assert store._backend is peer._backend
+
+    store.upsert("memory-1", "atlas architecture")
+    store.upsert("memory-2", "gardening")
+    store.delete("memory-2")
+
+    result = store.search("query", limit=10)
+    memory_ids = tuple(match.memory_id for match in result)
+    assert "memory-1" in memory_ids
+    assert "memory-2" not in memory_ids
+
+
+def _install_milvus(monkeypatch: pytest.MonkeyPatch) -> None:
+    state: dict[str, Any] = {
+        "collections": set(),
+        "rows": {},
+    }
+
+    class _FakeDataType:
+        VARCHAR = "varchar"
+        FLOAT_VECTOR = "float_vector"
+        BOOL = "bool"
+
+    class _FieldSchema:
+        def __init__(self, **kwargs: object) -> None:
+            del kwargs
+
+    class _CollectionSchema:
+        def __init__(self, fields: tuple[object, ...]) -> None:
+            del fields
+
+    class _Match:
+        def __init__(self, memory_id: str, archived: bool, score: float) -> None:
+            self.id = memory_id
+            self.score = score
+            self.entity = {"memory_id": memory_id, "archived": archived}
+
+    class _Collection:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+        def insert(self, rows: list[object]) -> None:
+            ids = rows[0]
+            vectors = rows[1]
+            archived = rows[2]
+            for index, memory_id in enumerate(ids):
+                memory = str(memory_id)
+                state["rows"].setdefault(self.name, {})[memory] = (
+                    vectors[index],
+                    bool(archived[index]),
+                )
+
+        def search(self, **kwargs: object) -> list[list[_Match]]:
+            del kwargs
+            collection_rows = state["rows"].get(self.name, {})
+            return [
+                [
+                    _Match(memory_id, archived, 1.0 - index * 0.1)
+                    for index, (memory_id, (_, archived)) in enumerate(collection_rows.items())
+                ]
+            ]
+
+    class _ConnectionManager:
+        def connect(self, uri: str) -> None:
+            del uri
+
+    def _has_collection(name: str) -> bool:
+        return name in state["collections"]
+
+    def _factory_connection(collection_name: str, **_: object) -> _Collection:
+        return _Collection(collection_name)
+
+    def _factory_collection(name: str, schema: _CollectionSchema | None = None) -> _Collection:
+        state["collections"].add(name)
+        del schema
+        return _Collection(name)
+
+    milvus_module = ModuleType("pymilvus")
+    milvus_module.Collection = _factory_connection
+    milvus_module.CollectionSchema = _CollectionSchema
+    milvus_module.DataType = _FakeDataType
+    milvus_module.FieldSchema = _FieldSchema
+    milvus_module.connections = _ConnectionManager()
+    milvus_module.utility = type("util", (), {"has_collection": staticmethod(_has_collection)})()
+
+    monkeypatch.setitem(sys.modules, "pymilvus", milvus_module)
+
+
+def test_milvus_normalization_supports_no_scheme_endpoints() -> None:
+    endpoint, collection = milvus_store._normalize_connection_and_collection(
+        "?collection=cellin_vectors"
+    )
+    assert endpoint == ""
+    assert collection == "cellin_vectors"
+
+
+def test_milvus_vector_store_supports_upsert_search_delete_and_shared_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_milvus(monkeypatch)
+
+    store = MilvusVectorStore("https://localhost:19530/cellin_vectors")
+    peer = MilvusVectorStore("https://localhost:19530/cellin_vectors")
+    assert store._backend is peer._backend
+
+    store.upsert("memory-1", "atlas architecture")
+    store.upsert("memory-2", "gardening")
+    store.delete("memory-2")
+
+    memory_ids = tuple(item.memory_id for item in store.search("query", limit=10))
+    assert "memory-1" in memory_ids
+    assert "memory-2" not in memory_ids
+
+
+def test_milvus_row_entities_falls_back_when_hit_entity_payload_is_uncoercible() -> None:
+    class _Hit:
+        pass
+
+    hit = _Hit()
+    hit.entity = object()
+    hit.memory_id = "fallback-memory"
+
+    memory_id, archived = milvus_store._row_entities(hit)
+    assert memory_id == "fallback-memory"
+    assert archived is False
+
+
+def test_milvus_collection_initialization_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_milvus(monkeypatch)
+    store = MilvusVectorStore("https://localhost:19530/cellin_vectors")
+    backend = store._backend
+    backend._ensure_collection_exists()
+
+
+def test_milvus_search_remote_ignores_non_sequence_hit_groups(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    milvus_store._BACKENDS.clear()
+    _install_milvus(monkeypatch)
+    store = MilvusVectorStore("https://localhost:19530/cellin_vectors")
+
+    class _Collection:
+        def search(self, **_: object) -> list[object]:
+            return [1]
+
+    def _collection() -> _Collection:
+        return _Collection()
+
+    store._backend._collection = _collection  # type: ignore[method-assign]
+    assert store._backend._search_remote((0.0,) * 12, limit=10) == []
+
+
+def test_milvus_search_falls_back_to_local_when_remote_search_raises_type_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    milvus_store._BACKENDS.clear()
+    _install_milvus(monkeypatch)
+    store = MilvusVectorStore("https://localhost:19530/cellin_vectors")
+    store.upsert("memory-1", "atlas architecture")
+
+    def search_raises_type_error(**_: object) -> list[list[object]]:
+        raise TypeError("unsupported arg signature")
+
+    def collection() -> Any:
+        return type(
+            "Collection",
+            (),
+            {"search": staticmethod(search_raises_type_error)},
+        )()
+
+    store._backend._collection = collection  # type: ignore[method-assign]
+    assert tuple(item.memory_id for item in store.search("query", limit=10)) == ("memory-1",)
+
+
+def test_milvus_search_respects_zero_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_milvus(monkeypatch)
+    store = MilvusVectorStore("https://localhost:19530/cellin_vectors")
+    assert store.search("query", limit=0) == ()
+
+
+def test_milvus_search_uses_empty_remote_results_on_general_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    milvus_store._BACKENDS.clear()
+    _install_milvus(monkeypatch)
+    store = MilvusVectorStore("https://localhost:19530/cellin_vectors")
+    store.upsert("memory-1", "atlas architecture")
+
+    def search_raises_general_failure(**_: object) -> list[list[object]]:
+        raise RuntimeError("milvus down")
+
+    def collection() -> Any:
+        return type(
+            "Collection",
+            (),
+            {"search": staticmethod(search_raises_general_failure)},
+        )()
+
+    store._backend._collection = collection  # type: ignore[method-assign]
+    assert tuple(item.memory_id for item in store.search("query", limit=10)) == ("memory-1",)
+
+
+def _install_redis_vector(monkeypatch: pytest.MonkeyPatch) -> None:
+    state: dict[str, object] = {}
+
+    class _RedisClient:
+        def set(self, key: object, value: object, nx: bool = False) -> None | str:
+            str_key = str(key)
+            if nx and str_key in state:
+                return None
+            state[str_key] = value
+            return "OK"
+
+        def get(self, key: object) -> object | None:
+            return state.get(str(key))
+
+        def scan_iter(self, match: str) -> list[str]:
+            pattern = match.replace("*", "")
+            return [key for key in state if str(key).startswith(pattern)]
+
+    class _RedisLib:
+        @classmethod
+        def from_url(cls, url: str, decode_responses: bool = True) -> _RedisClient:
+            del decode_responses
+            state["__url"] = url
+            return _RedisClient()
+
+    redis_module = ModuleType("redis")
+    redis_module.Redis = _RedisLib
+    monkeypatch.setitem(sys.modules, "redis", redis_module)
+
+
+def test_redis_vector_store_reuses_collection_state_and_filters_archived_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_redis_vector(monkeypatch)
+
+    store = RedisVectorStore("redis://localhost:6379/0?collection=cellin_vectors")
+    mirror = RedisVectorStore("redis://localhost:6379/0?collection=cellin_vectors")
+    assert store._backend is mirror._backend
+
+    store.upsert("memory-1", "atlas architecture")
+    store.upsert("memory-2", "gardening")
+    store.delete("memory-2")
+
+    memory_ids = tuple(item.memory_id for item in store.search("query", limit=10))
+    assert "memory-1" in memory_ids
+    assert "memory-2" not in memory_ids
+
+
+def test_redis_backend_normalization_default_collection_and_zero_limit() -> None:
+    namespace, collection = redis_vector_store._parse_namespace("redis://localhost:6379/0")
+    assert namespace == "cellin:0"
+    assert collection == "cellin_vectors"
+
+
+def test_redis_vector_store_handles_invalid_payloads_and_missing_vectors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_redis_vector(monkeypatch)
+
+    store = RedisVectorStore("redis://localhost:6379/0?collection=cellin_vectors")
+    backend = store._backend
+    store.upsert("memory-1", "atlas architecture")
+    backend._client.set(backend._key("bad-memory"), "{invalid-json}")
+    backend._client.set(
+        backend._key("empty-vector"),
+        json.dumps({"memory_id": "empty-vector", "vector": []}),
+    )
+    backend._client.set(
+        backend._key("archived-memory"),
+        json.dumps({"memory_id": "archived-memory", "archived": True, "vector": [0.1]}),
+    )
+
+    assert tuple(item.memory_id for item in store.search("query", limit=10)) == ("memory-1",)
+    assert store.search("query", limit=0) == ()
+
+
+def test_redis_vector_store_does_not_remarshal_collection_initialization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_redis_vector(monkeypatch)
+    store = RedisVectorStore("redis://localhost:6379/0?collection=cellin_vectors")
+    store._backend._initialize_collection()
+    assert store._backend._initialized is True


### PR DESCRIPTION
## Issue
Closes #78: add first-party remote vector backends for semantic retrieval.

## Root cause
Remote vector systems were not yet implemented behind the shared vector contract in first-party code, so retrieval remained local-database centric and tombstone/collection lifecycle behavior was inconsistent for remote stores.

## Fix
- Implemented concrete `QdrantVectorStore`, `WeaviateVectorStore`, `PineconeVectorStore`, `MilvusVectorStore`, and `RedisVectorStore` in `src/cellin/stores`.
- Wired backend registration/builders in `src/cellin/stores/__init__.py` and `src/cellin/runtime/storage.py`.
- Added explicit, idempotent collection/index initialization and backend configuration for each remote service.
- Added tombstone/delete semantics so archived memories are excluded from vector search.
- Added stable mocked integration coverage for remote backends in `tests/integration/stores/test_remote_vector_backends.py` and updated vector contract coverage.

## Validation
- `make release-smoke`
- Pre-push hook run on branch push executed full checks and tests (`195 passed`).

Closes #78
