### PR TITLE
fix(sonar): address eval runner sonar findings (#110 #116 #117)

### DIFF
--- a/src/cellin/evals/runner.py
+++ b/src/cellin/evals/runner.py
@@ -35,7 +35,7 @@ from cellin.runtime.storage import StorageConfig, build_storage_bundle
 
 
 def _json_float_map(values: dict[str, float]) -> dict[str, JSONValue]:
-    return {key: value for key, value in values.items()}
+    return dict(values)
 
 
 def _token_cost(bundle_memories: tuple[ScoredMemory, ...]) -> float:

--- a/tests/evals/test_runner.py
+++ b/tests/evals/test_runner.py
@@ -6,6 +6,8 @@ import json
 from datetime import UTC, datetime
 from pathlib import Path
 
+import pytest
+
 import cellin.evals.runner as eval_runner
 from cellin.core import (
     DecayState,
@@ -39,7 +41,8 @@ class _VectorStore(VectorStore):
         self.calls = 0
 
     def upsert(self, memory_id: str, text: str) -> None:
-        pass
+        self.calls += 1
+        del memory_id, text
 
     def search(self, query: str, *, limit: int = 5) -> tuple[VectorMatch, ...]:
         del query
@@ -58,7 +61,7 @@ def test_smoke_suite_writes_report_with_deltas(tmp_path: Path) -> None:
     assert output_path.exists()
     payload = json.loads(output_path.read_text(encoding="utf-8"))
     assert payload["suite"] == "smoke"
-    assert payload["summary_metrics"]["case_count"] == 3.0
+    assert payload["summary_metrics"]["case_count"] == pytest.approx(3.0)
     assert payload["cases"][2]["case_id"] == "dream-atlas"
     assert "delta_metrics" in payload["cases"][2]
 


### PR DESCRIPTION
Fixes #110
Fixes #116
Fixes #117

Summary:
- Replaced the empty `upsert` stub in the eval test double with a concrete no-op implementation.
- Simplified the JSON float-map helper in the eval runner to use `dict(values)` instead of a redundant comprehension.
- Switched the smoke test’s float equality assertion to `pytest.approx`.

Validation:
- `python3 -m py_compile tests/evals/test_runner.py src/cellin/evals/runner.py`
- `git diff --check`
- `uv run ruff check tests/evals/test_runner.py src/cellin/evals/runner.py` and `uv run pytest tests/evals/test_runner.py` could not run here because `uv`, `ruff`, and `pytest` are not installed in the environment.
