### PR TITLE
fix(sonar): resolve retrieval test placeholder issues (#111 #112)

### DIFF
--- a/tests/integration/retrieval/test_candidate_generation.py
+++ b/tests/integration/retrieval/test_candidate_generation.py
@@ -85,7 +85,8 @@ class _FakeVectorStore(VectorStore):
         self._matches = tuple(matches)
 
     def upsert(self, memory_id: str, text: str) -> None:
-        pass
+        # No-op: this fake vector store only needs to satisfy the interface.
+        del memory_id, text
 
     def search(self, query: str, *, limit: int = 5) -> tuple[VectorMatch, ...]:
         del query

--- a/tests/integration/retrieval/test_weighted_retriever.py
+++ b/tests/integration/retrieval/test_weighted_retriever.py
@@ -156,7 +156,8 @@ class _FakeVectorStore(VectorStore):
         self._matches = tuple(matches)
 
     def upsert(self, memory_id: str, text: str) -> None:
-        pass
+        # No-op: this fake vector store only needs to satisfy the interface.
+        del memory_id, text
 
     def search(self, query: str, *, limit: int = 5) -> tuple[VectorMatch, ...]:
         del query


### PR DESCRIPTION
Fixes #111
Fixes #112

Summary:
- Replaced empty `upsert` stubs in the retrieval test vector-store fakes with explicit no-op implementations.
- Added nested explanatory comments so the intent of the test doubles is clear while satisfying Sonar's empty-method rule.

Validation:
- `python3 -m ruff check tests/integration/retrieval/test_candidate_generation.py tests/integration/retrieval/test_weighted_retriever.py` ✅
- `python3 -m pytest tests/integration/retrieval/test_candidate_generation.py tests/integration/retrieval/test_weighted_retriever.py` ⚠️ blocked in this environment because Python 3.11 cannot import project code that requires Python 3.12 syntax (`type` aliases in `src/cellin/core/models.py`)
