### PR TITLE
fix(sonar): clean up SQL integration test issues (#108 #113 #114)

### DIFF
--- a/tests/integration/stores/test_sql_backends.py
+++ b/tests/integration/stores/test_sql_backends.py
@@ -81,11 +81,30 @@ class _FakeSQLEngine:
         params = tuple(parameters)
         self.queries.append((query, params))
 
-        if "create table if not exists memories" in normalized_query:
-            return []
-        if "create table if not exists edges" in normalized_query:
+        if self._is_schema_query(normalized_query):
             return []
 
+        memory_rows = self._handle_memory_query(normalized_query, params)
+        if memory_rows is not None:
+            return memory_rows
+
+        edge_rows = self._handle_edge_query(normalized_query, params)
+        if edge_rows is not None:
+            return edge_rows
+
+        return []
+
+    def _is_schema_query(self, normalized_query: str) -> bool:
+        return (
+            "create table if not exists memories" in normalized_query
+            or "create table if not exists edges" in normalized_query
+        )
+
+    def _handle_memory_query(
+        self,
+        normalized_query: str,
+        params: tuple[object, ...],
+    ) -> list[tuple[object, ...]] | None:
         if "insert into memories" in normalized_query:
             memory_id = str(params[0])
             payload = str(params[1])
@@ -100,6 +119,13 @@ class _FakeSQLEngine:
         if "select payload from memories order by memory_id" in normalized_query:
             return [(payload,) for _, payload in sorted(self.memories.items())]
 
+        return None
+
+    def _handle_edge_query(
+        self,
+        normalized_query: str,
+        params: tuple[object, ...],
+    ) -> list[tuple[object, ...]] | None:
         if "insert into edges" in normalized_query:
             edge_id = str(params[0])
             source_id = str(params[1])
@@ -108,7 +134,7 @@ class _FakeSQLEngine:
             self.edges[edge_id] = (source_id, target_id, payload)
             return []
 
-        if "from edges" in normalized_query and "where source_id" in normalized_query:
+        if self._is_edge_neighbor_query(normalized_query):
             memory_id = str(params[0])
             rows = []
             for _, (source_id, target_id, payload) in sorted(self.edges.items()):
@@ -119,7 +145,10 @@ class _FakeSQLEngine:
         if "from edges order by edge_id" in normalized_query:
             return [(payload,) for _, (_, _, payload) in sorted(self.edges.items())]
 
-        return []
+        return None
+
+    def _is_edge_neighbor_query(self, normalized_query: str) -> bool:
+        return "from edges" in normalized_query and "where source_id" in normalized_query
 
 
 class _FakeSQLConnection:

--- a/tests/integration/stores/test_sqlite_and_vector_index.py
+++ b/tests/integration/stores/test_sqlite_and_vector_index.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import builtins
+import math
 import sys
 from datetime import UTC, datetime
 
@@ -91,7 +92,7 @@ def test_sqlite_store_filters_archived_edges_and_vector_index_handles_empty_text
     vector_index = InMemoryVectorIndex()
     vector_index.upsert("blank", "")
 
-    assert vector_index.search("", limit=1)[0].score == pytest.approx(0.0)
+    assert math.isclose(vector_index.search("", limit=1)[0].score, 0.0, abs_tol=1e-12)
 
 
 def test_sqlite_vec_store_persists_vectors_and_supports_similarity_ranking(tmp_path) -> None:
@@ -235,5 +236,5 @@ def test_in_memory_vector_index_respects_search_limit_zero() -> None:
 
 
 def test_cosine_similarity_returns_zero_for_empty_vectors() -> None:
-    assert cosine_similarity((), ()) == 0.0
-    assert cosine_similarity((), (1.0, 0.0)) == 0.0
+    assert math.isclose(cosine_similarity((), ()), 0.0, abs_tol=1e-12)
+    assert math.isclose(cosine_similarity((), (1.0, 0.0)), 0.0, abs_tol=1e-12)


### PR DESCRIPTION
Fixes #108
Fixes #113
Fixes #114

Summary:
- Split the SQL fake engine query dispatcher into small helpers so `_FakeSQLEngine.execute` stays below the Sonar cognitive-complexity threshold.
- Replaced exact float assertions in the SQLite/vector coverage with `math.isclose(...)` so the checks are tolerant and no longer use direct float equality.

Validation:
- `python3 -m ruff check tests/integration/stores/test_sql_backends.py tests/integration/stores/test_sqlite_and_vector_index.py` ✅
- `python3 -m pytest tests/integration/stores/test_sql_backends.py tests/integration/stores/test_sqlite_and_vector_index.py` blocked in this shell because the default Python is 3.11, while `src/cellin/core/models.py` uses PEP 695 `type` alias syntax.
