### PR TITLE
fix(sonar): prevent workflow input script injection (#115)

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -48,6 +48,8 @@ jobs:
       - name: Resolve package version
         id: version
         shell: bash
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
             resolved_version="$(python -m uv run python scripts/release/resolve_preview_version.py \
@@ -59,7 +61,7 @@ jobs:
               --expect-version "${resolved_version}" \
               --release-kind preview
           else
-            resolved_version="${{ inputs.version }}"
+            resolved_version="${RELEASE_VERSION}"
             if [ -z "${resolved_version}" ]; then
               echo "workflow_dispatch requires a release-candidate version input" >&2
               exit 1


### PR DESCRIPTION
Fixes #115.

Summary:
- Moves `inputs.version` out of the inline Bash script and into a step environment variable before it is consumed.
- Keeps the manual prerelease path behavior the same while removing the workflow script-injection surface Sonar flagged.

Validation:
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY` on `.github/workflows/rolling-release.yml` succeeded.
- Confirmed there are no remaining inline `${{ inputs.version }}` references in the shell script body.
