### PR TITLE
docs(contrib): add fallback lefthook install command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,12 @@ make release-smoke
 ```
 
 `make bootstrap` installs the local git hooks through `lefthook`.
+If `lefthook` is unavailable in your environment, install hooks with:
+
+```bash
+npx @evilmartians/lefthook install
+```
+
 `make release-smoke` is the canonical local release gate. It runs formatting checks,
 linting, type-checking, tests, eval smoke coverage, docs validation, version checks,
 and package smoke validation.


### PR DESCRIPTION
## Summary
Added a fallback setup path to the contribution guide for environments where `lefthook` is not available on PATH.

## Problem
Contributors following `make bootstrap` for hook setup could be blocked when their environment lacks `lefthook`/`uv` tooling, and there was no explicit fallback command to wire hooks.

## Root cause
`CONTRIBUTING.md` only referenced `make bootstrap` and did not document a direct `lefthook` install command usable with `npx` in constrained environments.

## Fix
Updated `CONTRIBUTING.md` under Development Setup to add:
- `npx @evilmartians/lefthook install`
- a short note explaining this is the fallback when `lefthook` is unavailable.

## Validation
- Confirmed local hook scripts are configured in `.git/hooks` via `npx @evilmartians/lefthook install`.
- Confirmed branch contains only the docs update and was pushed to `feat/install-local-hooks`.
