### PR TITLE
Use collision-safe edge identifiers for sqlite graphs

### DIFF
--- a/src/cellin/ingest/pipeline.py
+++ b/src/cellin/ingest/pipeline.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
+from urllib.parse import quote
 
 from cellin.core import (
     Artifact,
@@ -20,6 +21,12 @@ from cellin.core import (
 )
 from cellin.ingest.adapters import EnvelopeAdapter, built_in_adapters
 from cellin.ingest.envelope import ArtifactEnvelope, IngestionBatchResult
+
+
+def _collision_free_edge_id(*, kind: EdgeKind, source_id: str, target_id: str) -> str:
+    """Build an edge identifier that cannot collide when IDs contain delimiters."""
+
+    return f"{kind.value}:{quote(source_id, safe='')}:{quote(target_id, safe='')}"
 
 
 @dataclass(slots=True)
@@ -185,7 +192,11 @@ class CanonicalIngestor:
         label: str,
     ) -> MemoryEdge:
         return MemoryEdge(
-            edge_id=f"{kind.value}:{source_id}:{target_id}",
+            edge_id=_collision_free_edge_id(
+                kind=kind,
+                source_id=source_id,
+                target_id=target_id,
+            ),
             source_id=source_id,
             target_id=target_id,
             kind=kind,

--- a/tests/integration/ingest/test_pipeline.py
+++ b/tests/integration/ingest/test_pipeline.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from datetime import datetime
+from datetime import UTC, datetime
+from urllib.parse import quote
 
 from cellin.core import Modality
 from cellin.ingest import ArtifactEnvelope, CanonicalIngestor
@@ -27,6 +28,23 @@ def _load_fixture() -> tuple[ArtifactEnvelope, ...]:
             metadata=item["metadata"],
         )
         for item in raw_dataset
+    )
+
+
+def _build_envelope(
+    envelope_id: str,
+    *,
+    observed_at: datetime,
+    topic: str,
+) -> ArtifactEnvelope:
+    return ArtifactEnvelope(
+        envelope_id=envelope_id,
+        modality=Modality.TEXT,
+        payload=envelope_id,
+        source_id=f"source-{envelope_id}",
+        source_type="fixture",
+        observed_at=observed_at,
+        metadata={"topic": topic},
     )
 
 
@@ -90,3 +108,34 @@ def test_ingestion_pipeline_batches_sqlite_writes_for_shared_store(tmp_path, mon
 
     assert len(result.memories) == 4
     assert connect_calls == 2
+
+
+def test_ingestion_pipeline_uses_collision_safe_sqlite_edge_ids(tmp_path) -> None:
+    database_path = tmp_path / "cellin.sqlite"
+    graph_store = SQLiteGraphStore(str(database_path))
+    memory_store = SQLiteMemoryStore(str(database_path))
+    vector_index = InMemoryVectorIndex()
+    ingestor = CanonicalIngestor.with_built_in_adapters(
+        graph_store=graph_store,
+        memory_store=memory_store,
+        vector_store=vector_index,
+    )
+    observed_at = datetime(2026, 4, 5, tzinfo=UTC)
+
+    result = ingestor.ingest_envelopes(
+        (
+            _build_envelope("a:b", observed_at=observed_at, topic="topic-a"),
+            _build_envelope("c", observed_at=observed_at, topic="topic-a"),
+            _build_envelope("a", observed_at=observed_at, topic="topic-b"),
+            _build_envelope("b:c", observed_at=observed_at, topic="topic-b"),
+        )
+    )
+
+    edges = graph_store.list_edges()
+    assert len(result.edges) == 2
+    assert len(edges) == 2
+    assert {(edge.source_id, edge.target_id) for edge in edges} == {("a:b", "c"), ("a", "b:c")}
+    assert {edge.edge_id for edge in edges} == {
+        f"supports:{quote('a:b', safe='')}:{quote('c', safe='')}",
+        f"supports:{quote('a', safe='')}:{quote('b:c', safe='')}",
+    }


### PR DESCRIPTION
Fixes #136 by making ingest edge IDs resistant to delimiter collisions when source/target IDs include separators.\n\n- encode edge ID components before composing final ID\n- add regression test in sqlite pipeline path for colon-containing memory IDs\n\ncloses #136