### PR TITLE
Fix sql and document vector backend hardening

### DIFF
--- a/src/cellin/stores/pgvector.py
+++ b/src/cellin/stores/pgvector.py
@@ -13,7 +13,7 @@ class _MissingPgVectorDependencyError(RuntimeError):
     """Raised when pgvector is unavailable from runtime dependencies."""
 
 
-_TABLE_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_TABLE_NAME_RE = re.compile(r"^[A-Za-z_]\w*$", re.ASCII)
 
 
 def _quote_identifier(value: str) -> str:

--- a/src/cellin/stores/pgvector.py
+++ b/src/cellin/stores/pgvector.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from cellin.core import VectorMatch
@@ -10,6 +11,19 @@ from cellin.stores.vector_utils import vectorize
 
 class _MissingPgVectorDependencyError(RuntimeError):
     """Raised when pgvector is unavailable from runtime dependencies."""
+
+
+_TABLE_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _quote_identifier(value: str) -> str:
+    return '"' + value.replace('"', '""') + '"'
+
+
+def _require_valid_table_name(table_name: str) -> str:
+    if _TABLE_NAME_RE.fullmatch(table_name) is None:
+        raise ValueError("pgvector table name must be a safe SQL identifier")
+    return _quote_identifier(table_name)
 
 
 class PGVectorStore:
@@ -29,7 +43,7 @@ class PGVectorStore:
 
         self._psycopg = psycopg
         self._connection_string = connection_string
-        self._table_name = table_name
+        self._table_name = _require_valid_table_name(table_name)
         self._initialized = False
         self._ensure_schema()
 

--- a/src/cellin/stores/redis_vector.py
+++ b/src/cellin/stores/redis_vector.py
@@ -13,6 +13,13 @@ class _MissingRedisDependencyError(RuntimeError):
     """Raised when Redis dependencies are unavailable."""
 
 
+def _escape_scan_match(value: str) -> str:
+    escaped = value
+    for pattern_char in ("\\", "*", "?", "[", "]"):
+        escaped = escaped.replace(pattern_char, "\\" + pattern_char)
+    return escaped
+
+
 def _parse_namespace(connection_string: str) -> tuple[str, str]:
     parsed = urlparse(connection_string)
     query = parse_qs(parsed.query)
@@ -68,7 +75,7 @@ class _RedisVectorBackend:
 
         query_vector = vectorize(query)
         matches: list[VectorMatch] = []
-        pattern = f"{self._namespace}:vector:{self._collection}:*"
+        pattern = f"{self._namespace}:vector:{_escape_scan_match(self._collection)}:*"
         for key in self._client.scan_iter(match=pattern):
             payload = self._client.get(key)
             if payload is None:

--- a/tests/integration/stores/test_remote_vector_backends.py
+++ b/tests/integration/stores/test_remote_vector_backends.py
@@ -1097,6 +1097,28 @@ def test_redis_vector_store_handles_invalid_payloads_and_missing_vectors(
     assert store.search("query", limit=0) == ()
 
 
+def test_redis_vector_store_escapes_pattern_characters_in_collection_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_redis_vector(monkeypatch)
+
+    store = RedisVectorStore("redis://localhost:6379/0?collection=cell[in]?*v")
+    backend = store._backend
+    observed: dict[str, str | None] = {"match": None}
+
+    def capture_scan_match(match: str) -> list[str]:
+        observed["match"] = match
+        return []
+
+    monkeypatch.setattr(backend._client, "scan_iter", capture_scan_match)
+    assert store.search("query", limit=10) == ()
+    assert observed["match"] == "cellin:0:vector:cell\\[in\\]\\?\\*v:*"
+
+
+def test_redis_escape_scan_match() -> None:
+    assert redis_vector_store._escape_scan_match("cell[in]?*v") == r"cell\[in\]\?\*v"
+
+
 def test_redis_vector_store_does_not_remarshal_collection_initialization(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/integration/stores/test_sqlite_and_vector_index.py
+++ b/tests/integration/stores/test_sqlite_and_vector_index.py
@@ -308,8 +308,8 @@ def test_pgvector_store_creates_schema_upserts_and_searches(
 
     assert fake_psycopg.connection_strings == ["postgresql://cellin/test"] * 3
     queries = [query for query, _ in fake_psycopg.calls]
-    assert any("CREATE TABLE IF NOT EXISTS cellin_vectors_test" in query for query in queries)
-    assert any("INSERT INTO cellin_vectors_test" in query for query in queries)
+    assert any('CREATE TABLE IF NOT EXISTS "cellin_vectors_test"' in query for query in queries)
+    assert any('INSERT INTO "cellin_vectors_test"' in query for query in queries)
     assert any("SELECT memory_id, vector <=> %s AS distance" in query for query in queries)
     assert tuple(result.memory_id for result in results) == ("m1", "m2")
     assert results[0].score == pytest.approx(0.9)
@@ -324,6 +324,29 @@ def test_pgvector_store_limit_zero_short_circuits(monkeypatch: pytest.MonkeyPatc
 
     assert vector_store.search("atlas graph", limit=0) == ()
     assert len(fake_psycopg.calls) == 1
+
+
+def test_pgvector_store_rejects_unsafe_table_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_psycopg = _FakePsycopg([])
+    monkeypatch.setitem(sys.modules, "psycopg", fake_psycopg)
+
+    with pytest.raises(ValueError, match="safe SQL identifier"):
+        PGVectorStore("postgresql://cellin/test", table_name='cellin_vectors";DROP TABLE')
+
+    assert fake_psycopg.calls == []
+
+
+def test_pgvector_store_quotes_identifier_in_queries(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_psycopg = _FakePsycopg([("m1", 0.1)])
+    monkeypatch.setitem(sys.modules, "psycopg", fake_psycopg)
+
+    vector_store = PGVectorStore("postgresql://cellin/test", table_name="cellin_vectors_safe")
+    vector_store.search("query", limit=10)
+
+    queries = [query for query, _ in fake_psycopg.calls]
+    assert any('"cellin_vectors_safe"' in query for query in queries)
+    assert any("SELECT memory_id, vector <=> %s AS distance" in query for query in queries)
+    assert any("CREATE TABLE IF NOT EXISTS" in query for query in queries)
 
 
 def test_in_memory_vector_index_respects_search_limit_zero() -> None:


### PR DESCRIPTION
## Summary
- Hardened pgvector table identifier handling with strict validation and SQL identifier quoting.
- Escaped Redis vector collection names before building SCAN patterns.
- Added regression tests for unsafe pgvector identifiers and Redis scan pattern escaping.

Closes #138