### PR TITLE
Fix remote backend cache keys and remote error handling

### DIFF
--- a/src/cellin/stores/graph_backends.py
+++ b/src/cellin/stores/graph_backends.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from itertools import chain
+from urllib.parse import quote, urlparse
 from typing import Protocol, cast
-from urllib.parse import urlparse
 
 from cellin.core import GraphStore, MemoryAtom, MemoryEdge
 from cellin.stores._graph_serialization import (
@@ -76,6 +77,8 @@ class _ArangoCollection(Protocol):
 
     def all(self) -> list[dict[str, object]]: ...
 
+    def find(self, filters: dict[str, object] | None = None) -> list[dict[str, object]]: ...
+
 
 class _ArangoDatabase(Protocol):
     def has_collection(self, name: str) -> bool: ...
@@ -125,6 +128,10 @@ def _load_optional_payload(payload: object) -> MemoryAtom | None:
     if not isinstance(payload, str):
         raise TypeError("graph backend payloads must be strings")
     return load_memory(payload)
+
+
+def _arangodb_key(value: str) -> str:
+    return quote(value, safe="")
 
 
 class _CypherGraphBackend:
@@ -232,17 +239,57 @@ class _ArangoGraphBackend:
         if not self._database.has_collection("cellin_edges"):
             self._database.create_collection("cellin_edges", edge=True)
 
+    def _find_edge_documents(self, filters: dict[str, object] | None = None) -> list[dict[str, object]]:
+        finder = getattr(self._edge_collection, "find", None)
+        if callable(finder):
+            found_with_find = True
+            try:
+                if filters is None:
+                    documents = finder()
+                else:
+                    documents = finder(filters)
+            except TypeError:
+                found_with_find = False
+                try:
+                    documents = finder(filters=filters)
+                    found_with_find = True
+                except Exception:
+                    found_with_find = False
+                    documents = ()
+            except Exception:
+                found_with_find = False
+                documents = ()
+            else:
+                found_with_find = True
+                return [dict(document) for document in documents]
+            if found_with_find:
+                return [dict(document) for document in documents]
+
+        edges = self._edge_collection.all()
+        if not filters:
+            return [dict(document) for document in edges]
+
+        def matches(document: dict[str, object], filters: dict[str, object]) -> bool:
+            for name, value in filters.items():
+                if document.get(name) != value:
+                    return False
+            return True
+
+        return [dict(document) for document in edges if matches(document, filters)]
+
     def _ensure_memory_placeholder(self, memory_id: str) -> None:
-        if self._memory_collection.get(memory_id) is None:
+        key = _arangodb_key(memory_id)
+        if self._memory_collection.get(key) is None:
             self._memory_collection.insert(
-                {"_key": memory_id, "memory_id": memory_id, "payload": None},
+                {"_key": key, "memory_id": memory_id, "payload": None},
                 overwrite=True,
             )
 
     def upsert_memory(self, memory: MemoryAtom) -> None:
+        key = _arangodb_key(memory.memory_id)
         self._memory_collection.insert(
             {
-                "_key": memory.memory_id,
+                "_key": key,
                 "memory_id": memory.memory_id,
                 "payload": dump_memory(memory),
                 "archived": memory.decay.archived,
@@ -251,7 +298,8 @@ class _ArangoGraphBackend:
         )
 
     def get_memory(self, memory_id: str) -> MemoryAtom | None:
-        document = self._memory_collection.get(memory_id)
+        key = _arangodb_key(memory_id)
+        document = self._memory_collection.get(key)
         if document is None:
             return None
         return _load_optional_payload(document.get("payload"))
@@ -259,11 +307,13 @@ class _ArangoGraphBackend:
     def upsert_edge(self, edge: MemoryEdge) -> None:
         self._ensure_memory_placeholder(edge.source_id)
         self._ensure_memory_placeholder(edge.target_id)
+        source_key = _arangodb_key(edge.source_id)
+        target_key = _arangodb_key(edge.target_id)
         self._edge_collection.insert(
             {
                 "_key": edge.edge_id,
-                "_from": f"cellin_memories/{edge.source_id}",
-                "_to": f"cellin_memories/{edge.target_id}",
+                "_from": f"cellin_memories/{source_key}",
+                "_to": f"cellin_memories/{target_key}",
                 "payload": dump_edge(edge),
                 "archived": edge_is_archived(edge),
             },
@@ -271,21 +321,30 @@ class _ArangoGraphBackend:
         )
 
     def neighbors(self, memory_id: str) -> tuple[MemoryEdge, ...]:
+        memory_key = _arangodb_key(memory_id)
+        source_handle = f"cellin_memories/{memory_key}"
+        target_handle = f"cellin_memories/{memory_key}"
+        source_edges = self._find_edge_documents({"_from": source_handle, "archived": False})
+        target_edges = self._find_edge_documents({"_to": target_handle, "archived": False})
+        seen: set[str] = set()
         edges = []
-        for document in self._edge_collection.all():
+        for document in chain(source_edges, target_edges):
+            edge_key = str(document.get("_key", ""))
+            if edge_key in seen:
+                continue
+            seen.add(edge_key)
             payload = document.get("payload")
             if not isinstance(payload, str):
                 continue
             edge = load_edge(payload)
             if edge_is_archived(edge):
                 continue
-            if edge.source_id == memory_id or edge.target_id == memory_id:
-                edges.append(edge)
+            edges.append(edge)
         return tuple(sorted(edges, key=lambda edge: edge.edge_id))
 
     def list_edges(self) -> tuple[MemoryEdge, ...]:
         edges = []
-        for document in self._edge_collection.all():
+        for document in self._find_edge_documents({"archived": False}):
             payload = document.get("payload")
             if not isinstance(payload, str):
                 continue

--- a/src/cellin/stores/graph_backends.py
+++ b/src/cellin/stores/graph_backends.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from itertools import chain
-from urllib.parse import quote, urlparse
 from typing import Protocol, cast
+from urllib.parse import quote, urlparse
 
 from cellin.core import GraphStore, MemoryAtom, MemoryEdge
 from cellin.stores._graph_serialization import (
@@ -239,31 +239,30 @@ class _ArangoGraphBackend:
         if not self._database.has_collection("cellin_edges"):
             self._database.create_collection("cellin_edges", edge=True)
 
-    def _find_edge_documents(self, filters: dict[str, object] | None = None) -> list[dict[str, object]]:
+    def _find_edge_documents(
+        self, filters: dict[str, object] | None = None
+    ) -> list[dict[str, object]]:
         finder = getattr(self._edge_collection, "find", None)
         if callable(finder):
-            found_with_find = True
-            try:
-                if filters is None:
-                    documents = finder()
-                else:
-                    documents = finder(filters)
-            except TypeError:
-                found_with_find = False
+
+            def _find_documents() -> list[dict[str, object]] | None:
                 try:
-                    documents = finder(filters=filters)
-                    found_with_find = True
+                    if filters is None:
+                        return list(finder())
+                    return list(finder(filters))
+                except TypeError:
+                    if filters is None:
+                        return None
+                    try:
+                        return list(finder(filters=filters))
+                    except Exception:
+                        return None
                 except Exception:
-                    found_with_find = False
-                    documents = ()
-            except Exception:
-                found_with_find = False
-                documents = ()
-            else:
-                found_with_find = True
-                return [dict(document) for document in documents]
-            if found_with_find:
-                return [dict(document) for document in documents]
+                    return None
+
+            documents = _find_documents()
+            if documents is not None:
+                return documents
 
         edges = self._edge_collection.all()
         if not filters:

--- a/src/cellin/stores/milvus.py
+++ b/src/cellin/stores/milvus.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 import warnings
+from collections.abc import Sequence
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 

--- a/src/cellin/stores/milvus.py
+++ b/src/cellin/stores/milvus.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+import warnings
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
@@ -12,6 +13,10 @@ from cellin.stores.vector_utils import cosine_similarity, vectorize
 
 class _MissingMilvusDependencyError(RuntimeError):
     """Raised when Milvus dependencies are unavailable."""
+
+
+class _MilvusRemoteSearchError(RuntimeError):
+    """Raised when Milvus remote search fails unexpectedly."""
 
 
 def _normalize_connection_and_collection(connection_string: str) -> tuple[str, str]:
@@ -151,8 +156,8 @@ class _MilvusBackend:
                     )
         except TypeError:
             pass
-        except Exception:
-            return []
+        except Exception as exc:
+            raise _MilvusRemoteSearchError("milvus remote search failed") from exc
         return results
 
     def _search_local(self, query_vector: tuple[float, ...]) -> list[VectorMatch]:
@@ -170,7 +175,11 @@ class _MilvusBackend:
             return ()
 
         query_vector = vectorize(query)
-        matches = self._search_remote(query_vector, limit)
+        try:
+            matches = self._search_remote(query_vector, limit)
+        except _MilvusRemoteSearchError as exc:
+            warnings.warn(f"{exc}", RuntimeWarning, stacklevel=2)
+            matches = []
         if len(matches) < limit:
             existing = {result.memory_id for result in matches}
             for local in self._search_local(query_vector):

--- a/src/cellin/stores/pinecone.py
+++ b/src/cellin/stores/pinecone.py
@@ -172,12 +172,12 @@ class _PineconeBackend:
         return tuple(ordered[:limit])
 
 
-_BACKENDS: dict[tuple[str, str, str], _PineconeBackend] = {}
+_BACKENDS: dict[tuple[str, str, str, str], _PineconeBackend] = {}
 
 
 def _backend_for(connection_string: str) -> _PineconeBackend:
-    _, api_key, index_name, namespace = _normalize_connection_and_index(connection_string)
-    key = (api_key or "", index_name, namespace)
+    endpoint, api_key, index_name, namespace = _normalize_connection_and_index(connection_string)
+    key = (endpoint, api_key or "", index_name, namespace)
     backend = _BACKENDS.get(key)
     if backend is None:
         backend = _PineconeBackend(connection_string)

--- a/src/cellin/stores/qdrant.py
+++ b/src/cellin/stores/qdrant.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
+import warnings
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
@@ -12,6 +13,10 @@ from cellin.stores.vector_utils import cosine_similarity, vectorize
 
 class _MissingQdrantDependencyError(RuntimeError):
     """Raised when Qdrant dependencies are unavailable."""
+
+
+class _QdrantRemoteQueryError(RuntimeError):
+    """Raised when qdrant remote query fails unexpectedly."""
 
 
 def _normalize_connection_and_collection(connection_string: str) -> tuple[str, str]:
@@ -158,8 +163,8 @@ class _QdrantBackend:
                 with_vectors=True,
             )
             raw_points = getattr(response, "points", ())
-        except Exception:
-            return []
+        except Exception as exc:
+            raise _QdrantRemoteQueryError("qdrant remote query failed") from exc
 
         for raw_point in raw_points:
             memory_id, vector, archived = self._extract_point(raw_point)
@@ -190,8 +195,11 @@ class _QdrantBackend:
 
         query_vector = vectorize(query)
         merged: dict[str, VectorMatch] = {}
-        for match in self._query_remote(query_vector, limit=limit):
-            merged[match.memory_id] = match
+        try:
+            for match in self._query_remote(query_vector, limit=limit):
+                merged[match.memory_id] = match
+        except _QdrantRemoteQueryError as exc:
+            warnings.warn(f"{exc}", RuntimeWarning, stacklevel=2)
         for match in self._local_matches(query_vector):
             if match.memory_id in self._tombstones or match.memory_id in merged:
                 continue

--- a/src/cellin/stores/qdrant.py
+++ b/src/cellin/stores/qdrant.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
 import warnings
+from collections.abc import Iterable, Mapping
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 

--- a/tests/integration/stores/test_graph_backends.py
+++ b/tests/integration/stores/test_graph_backends.py
@@ -153,6 +153,15 @@ class _FakeArangoCollection:
     def all(self) -> list[dict[str, object]]:
         return [dict(document) for _, document in sorted(self._documents.items())]
 
+    def find(self, filters: dict[str, object] | None = None) -> list[dict[str, object]]:
+        if not filters:
+            return [dict(document) for _, document in sorted(self._documents.items())]
+        return [
+            dict(document)
+            for _, document in sorted(self._documents.items())
+            if all(str(document.get(name, "")) == str(value) for name, value in filters.items())
+        ]
+
 
 class _FakeArangoDatabase:
     def __init__(self) -> None:
@@ -262,6 +271,60 @@ def test_graph_native_backends_filter_archived_edges_and_share_state(
     assert graph_store.get_memory("missing-memory") is None
     assert graph_store.neighbors("memory-1") == (active,)
     assert graph_store.list_edges() == (active,)
+
+
+def test_arangodb_backend_encodes_memory_ids_in_document_handles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph_backends._ARANGO_BACKENDS.clear()
+    _install_fake_arango(monkeypatch)
+
+    source_id = "memory/with/slash"
+    target_id = "neighbor:with:colon"
+    graph_store = ArangoDBGraphStore("arangodb://root:test@localhost:8529/cellin")
+    edge = _edge("edge-1", source_id, target_id, archived=False)
+
+    graph_store.upsert_memory(_memory(source_id, "Source"))
+    graph_store.upsert_memory(_memory(target_id, "Target"))
+    graph_store.upsert_edge(edge)
+
+    backend = graph_store._backend
+    assert backend._memory_collection.get("memory%2Fwith%2Fslash") is not None
+    assert backend._memory_collection.get(source_id) is None
+    assert (
+        backend._edge_collection._documents["edge-1"]["_from"]
+        == "cellin_memories/memory%2Fwith%2Fslash"
+    )
+    assert (
+        backend._edge_collection._documents["edge-1"]["_to"]
+        == "cellin_memories/neighbor%3Awith%3Acolon"
+    )
+    assert graph_store.get_memory(source_id) == _memory(source_id, "Source")
+    assert graph_store.neighbors(source_id) == (edge,)
+    assert graph_store.list_edges() == (edge,)
+
+
+def test_arangodb_backend_neighbors_and_list_edges_do_not_full_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph_backends._ARANGO_BACKENDS.clear()
+    _install_fake_arango(monkeypatch)
+
+    edge = _edge("edge-2", "memory-1", "memory-2", archived=False)
+    graph_store = ArangoDBGraphStore("arangodb://root:test@localhost:8529/cellin")
+    graph_store.upsert_memory(_memory("memory-1", "Atlas"))
+    graph_store.upsert_memory(_memory("memory-2", "Another"))
+    graph_store.upsert_edge(edge)
+
+    backend = graph_store._backend
+
+    def scan_not_expected() -> list[dict[str, object]]:
+        raise AssertionError("Edge scan should be filtered, not full-scan")
+
+    monkeypatch.setattr(backend._edge_collection, "all", scan_not_expected)
+
+    assert graph_store.neighbors("memory-1") == (edge,)
+    assert graph_store.list_edges() == (edge,)
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/stores/test_graph_backends.py
+++ b/tests/integration/stores/test_graph_backends.py
@@ -327,6 +327,99 @@ def test_arangodb_backend_neighbors_and_list_edges_do_not_full_scan(
     assert graph_store.list_edges() == (edge,)
 
 
+def test_arangodb_backend_find_edge_documents_falls_back_across_find_variants(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph_backends._ARANGO_BACKENDS.clear()
+    _install_fake_arango(monkeypatch)
+
+    graph_store = ArangoDBGraphStore("arangodb://root:test@localhost:8529/cellin")
+    backend = graph_store._backend
+    document = {
+        "_key": "edge-find",
+        "_from": "cellin_memories/memory-1",
+        "_to": "cellin_memories/memory-2",
+        "payload": graph_backends.dump_edge(
+            _edge("edge-find", "memory-1", "memory-2", archived=False)
+        ),
+        "archived": False,
+    }
+    backend._edge_collection.insert(document, overwrite=True)
+
+    def positional_find(filters: dict[str, object] | None = None) -> list[dict[str, object]]:
+        if filters is None:
+            return [document]
+        raise TypeError("filters must be passed by keyword")
+
+    monkeypatch.setattr(backend._edge_collection, "find", positional_find)
+    assert backend._find_edge_documents() == [document]
+
+    def keyword_only_find(*args: object, **kwargs: object) -> list[dict[str, object]]:
+        assert args == ()
+        assert kwargs == {"filters": {"archived": False}}
+        return [document]
+
+    monkeypatch.setattr(backend._edge_collection, "find", keyword_only_find)
+    assert backend._find_edge_documents({"archived": False}) == [document]
+
+    def broken_find(*args: object, **kwargs: object) -> list[dict[str, object]]:
+        del args, kwargs
+        raise TypeError("fallback to scan")
+
+    monkeypatch.setattr(backend._edge_collection, "find", broken_find)
+    assert backend._find_edge_documents() == [document]
+    assert backend._find_edge_documents({"archived": False}) == [document]
+
+
+def test_arangodb_backend_filters_duplicate_invalid_and_archived_edge_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    graph_backends._ARANGO_BACKENDS.clear()
+    _install_fake_arango(monkeypatch)
+
+    graph_store = ArangoDBGraphStore("arangodb://root:test@localhost:8529/cellin")
+    graph_store.upsert_memory(_memory("memory-1", "Atlas"))
+    graph_store.upsert_memory(_memory("memory-2", "Neighbor"))
+    backend = graph_store._backend
+
+    duplicate_edge = _edge("edge-self", "memory-1", "memory-1", archived=False)
+    archived_edge = _edge("edge-archived", "memory-1", "memory-2", archived=True)
+
+    backend._edge_collection.insert(
+        {
+            "_key": duplicate_edge.edge_id,
+            "_from": "cellin_memories/memory-1",
+            "_to": "cellin_memories/memory-1",
+            "payload": graph_backends.dump_edge(duplicate_edge),
+            "archived": False,
+        },
+        overwrite=True,
+    )
+    backend._edge_collection.insert(
+        {
+            "_key": "edge-invalid",
+            "_from": "cellin_memories/memory-1",
+            "_to": "cellin_memories/memory-2",
+            "payload": {"unexpected": True},
+            "archived": False,
+        },
+        overwrite=True,
+    )
+    backend._edge_collection.insert(
+        {
+            "_key": archived_edge.edge_id,
+            "_from": "cellin_memories/memory-1",
+            "_to": "cellin_memories/memory-2",
+            "payload": graph_backends.dump_edge(archived_edge),
+            "archived": False,
+        },
+        overwrite=True,
+    )
+
+    assert graph_store.neighbors("memory-1") == (duplicate_edge,)
+    assert graph_store.list_edges() == (duplicate_edge,)
+
+
 @pytest.mark.parametrize(
     "graph_cls,connection_string,install_backend,clear_backends",
     [

--- a/tests/integration/stores/test_remote_vector_backends.py
+++ b/tests/integration/stores/test_remote_vector_backends.py
@@ -494,7 +494,8 @@ def test_qdrant_search_uses_local_matches_when_remote_query_errors(
 
     monkeypatch.setattr(backend._client, "query_points", query_points)
 
-    assert tuple(item.memory_id for item in store.search("atlas", limit=10)) == ("memory-1",)
+    with pytest.warns(RuntimeWarning, match="qdrant remote query failed"):
+        assert tuple(item.memory_id for item in store.search("atlas", limit=10)) == ("memory-1",)
 
 
 def test_qdrant_vector_payload_helpers_handle_fallback_types() -> None:
@@ -802,6 +803,19 @@ def test_pinecone_uses_init_path_when_pinecone_connector_is_unavailable(
     assert state["init_called"] is True
 
 
+def test_pinecone_cache_key_includes_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    pinecone_store._BACKENDS.clear()
+    _install_pinecone(monkeypatch)
+
+    store = PineconeVectorStore("https://localhost:8100/cellin_vectors")
+    other_host_store = PineconeVectorStore("https://other-host:8100/cellin_vectors")
+
+    assert store._backend is not other_host_store._backend
+
+    peer = PineconeVectorStore("https://other-host:8100/cellin_vectors")
+    assert other_host_store._backend is peer._backend
+
+
 def test_pinecone_vector_store_filters_tombstones_and_reuses_backend(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1003,7 +1017,8 @@ def test_milvus_search_uses_empty_remote_results_on_general_failure(
         )()
 
     store._backend._collection = collection  # type: ignore[method-assign]
-    assert tuple(item.memory_id for item in store.search("query", limit=10)) == ("memory-1",)
+    with pytest.warns(RuntimeWarning, match="milvus remote search failed"):
+        assert tuple(item.memory_id for item in store.search("query", limit=10)) == ("memory-1",)
 
 
 def _install_redis_vector(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Closes #139

## Summary
- Fix Pinecone backend cache-keying to include endpoint in cache key.
- Harden Qdrant and Milvus remote query/search error paths so local fallback is still returned and an explicit warning is emitted.
- Handle Arango document handle encoding for memory IDs containing reserved URL characters and avoid full-edge scans in neighbor/edge list operations.
- Add regression tests for all three areas.,