### PR TITLE
chore(storage): fix redis cache key, sql private imports, and execute-many batching

### DIFF
--- a/src/cellin/stores/redis_vector.py
+++ b/src/cellin/stores/redis_vector.py
@@ -99,12 +99,12 @@ class _RedisVectorBackend:
         return tuple(ordered[:limit])
 
 
-_BACKENDS: dict[tuple[str, str], _RedisVectorBackend] = {}
+_BACKENDS: dict[tuple[str, str, str], _RedisVectorBackend] = {}
 
 
 def _backend_for(connection_string: str) -> _RedisVectorBackend:
     namespace, collection = _parse_namespace(connection_string)
-    key = (namespace, collection)
+    key = (connection_string, namespace, collection)
     backend = _BACKENDS.get(key)
     if backend is None:
         backend = _RedisVectorBackend(connection_string)

--- a/src/cellin/stores/sql_backends.py
+++ b/src/cellin/stores/sql_backends.py
@@ -9,7 +9,13 @@ from typing import Any, Protocol, cast
 from urllib.parse import unquote, urlparse
 
 from cellin.core import MemoryAtom, MemoryEdge, MemoryStore
-from cellin.stores.sqlite import _dump_edge, _dump_memory, _edge_archived, _load_edge, _load_memory
+from cellin.stores._graph_serialization import (
+    dump_edge,
+    dump_memory,
+    edge_is_archived,
+    load_edge,
+    load_memory,
+)
 
 
 class _MissingDuckDBDependencyError(RuntimeError):
@@ -30,6 +36,8 @@ class _QueryResult(Protocol):
 
 class _ExecutableConnection(Protocol):
     def execute(self, query: str, parameters: Sequence[object] | None = None) -> _QueryResult: ...
+
+    def executemany(self, query: str, rows: Sequence[tuple[object, ...]]) -> None: ...
 
     def __enter__(self) -> _ExecutableConnection: ...
 
@@ -119,10 +127,7 @@ class _RelationalBackend:
             return
 
         with self._connect() as connection:
-            for row in rows:
-                result = self._execute(connection, query, row)
-                if result is not None:
-                    self._consume_result(result)
+            connection.executemany(query, rows)
 
     def _ensure_schema(self) -> None:
         """Initialize schema exactly once per backend key."""
@@ -158,7 +163,7 @@ class _RelationalBackend:
         if not memories:
             return
 
-        rows = tuple((memory.memory_id, _dump_memory(memory)) for memory in memories)
+        rows = tuple((memory.memory_id, dump_memory(memory)) for memory in memories)
         self._execute_many(
             self._parametrize(self._spec.upsert_memory_sql, self._spec.parameter_style),
             rows,
@@ -168,18 +173,18 @@ class _RelationalBackend:
         row = self._fetch_one(self._MEMORY_GET_SQL, (memory_id,))
         if row is None:
             return None
-        return _load_memory(row[0])
+        return load_memory(row[0])
 
     def list_memories(self) -> tuple[MemoryAtom, ...]:
         rows = self._fetch_all(self._MEMORY_LIST_SQL)
-        return tuple(_load_memory(row[0]) for row in rows)
+        return tuple(load_memory(row[0]) for row in rows)
 
     def upsert_edges(self, edges: Sequence[MemoryEdge]) -> None:
         if not edges:
             return
 
         rows = tuple(
-            (edge.edge_id, edge.source_id, edge.target_id, _dump_edge(edge)) for edge in edges
+            (edge.edge_id, edge.source_id, edge.target_id, dump_edge(edge)) for edge in edges
         )
         self._execute_many(
             self._parametrize(self._spec.upsert_edge_sql, self._spec.parameter_style),
@@ -191,8 +196,8 @@ class _RelationalBackend:
         return tuple(
             edge
             for row in rows
-            if not _edge_archived(
-                edge := _load_edge(row[0]),
+            if not edge_is_archived(
+                edge := load_edge(row[0]),
             )
         )
 
@@ -201,8 +206,8 @@ class _RelationalBackend:
         return tuple(
             edge
             for row in rows
-            if not _edge_archived(
-                edge := _load_edge(row[0]),
+            if not edge_is_archived(
+                edge := load_edge(row[0]),
             )
         )
 
@@ -320,6 +325,11 @@ class _MySQLConnection:
         cursor = self._connection.cursor()
         cursor.execute(query, tuple(parameters) if parameters else ())
         return _MySQLCursor(cursor)
+
+    def executemany(self, query: str, rows: Sequence[tuple[object, ...]]) -> None:
+        cursor = self._connection.cursor()
+        cursor.executemany(query, list(rows))
+        cursor.close()
 
 
 def _build_mysql_connection(connection_string: str) -> Callable[[], _ExecutableConnection]:

--- a/src/cellin/stores/sqlite.py
+++ b/src/cellin/stores/sqlite.py
@@ -9,32 +9,20 @@ from pathlib import Path
 
 from cellin.core import MemoryAtom, MemoryEdge, MemoryStore
 from cellin.stores._graph_serialization import (
-    dump_edge,
-    dump_memory,
-    edge_is_archived,
-    load_edge,
-    load_memory,
+    dump_edge as _dump_edge,
 )
-
-
-def _edge_archived(edge: MemoryEdge) -> bool:
-    return edge_is_archived(edge)
-
-
-def _dump_memory(memory: MemoryAtom) -> str:
-    return dump_memory(memory)
-
-
-def _load_memory(payload: str) -> MemoryAtom:
-    return load_memory(payload)
-
-
-def _dump_edge(edge: MemoryEdge) -> str:
-    return dump_edge(edge)
-
-
-def _load_edge(payload: str) -> MemoryEdge:
-    return load_edge(payload)
+from cellin.stores._graph_serialization import (
+    dump_memory as _dump_memory,
+)
+from cellin.stores._graph_serialization import (
+    edge_is_archived as _edge_archived,
+)
+from cellin.stores._graph_serialization import (
+    load_edge as _load_edge,
+)
+from cellin.stores._graph_serialization import (
+    load_memory as _load_memory,
+)
 
 
 class _SQLiteBackend:

--- a/tests/integration/stores/test_sql_backends.py
+++ b/tests/integration/stores/test_sql_backends.py
@@ -169,6 +169,10 @@ class _FakeSQLConnection:
         rows = self._engine.execute(query, params)
         return _FakeSQLResult(rows)
 
+    def executemany(self, query: str, rows: Sequence[tuple[object, ...]]) -> None:
+        for row in rows:
+            self._engine.execute(query, row)
+
 
 class _FakeMySQLCursor:
     def __init__(self, engine: _FakeSQLEngine) -> None:
@@ -178,6 +182,10 @@ class _FakeMySQLCursor:
     def execute(self, query: str, params: Sequence[object] = ()) -> _FakeMySQLCursor:
         self._rows = self._engine.execute(query, params)
         return self
+
+    def executemany(self, query: str, rows: Sequence[tuple[object, ...]]) -> None:
+        for row in rows:
+            self._engine.execute(query, row)
 
     def fetchall(self) -> list[tuple[object, ...]]:
         return list(self._rows)


### PR DESCRIPTION
## Summary

- **#150**: Fix `RedisVectorStore._backend_for()` singleton cache key to include `connection_string` — previously keyed by `(namespace, collection)` only, causing two stores pointing at different Redis hosts with the same DB+collection to silently share the wrong backend. Now keyed by `(connection_string, namespace, collection)`, matching the pattern used by all other backends.
- **#153**: Replace the five private `_dump_memory`, `_load_memory`, `_dump_edge`, `_load_edge`, `_edge_archived` wrappers in `sqlite.py` and the stale `from cellin.stores.sqlite import ...` in `sql_backends.py` with direct aliased imports from the canonical `_graph_serialization` module.
- **#154**: Replace the per-row `execute()` loop in `_RelationalBackend._execute_many()` with a single `connection.executemany()` call. Also adds `executemany` to the `_ExecutableConnection` protocol and to the `_MySQLConnection` wrapper (and the corresponding test fake).

## Test plan

- [x] `python3 -m uv run pytest` — 260 passed
- [x] `python3 -m uv run ruff check src tests` — no issues
- [x] Pre-commit hooks (ruff format, ruff check, mypy, pytest, coverage, smoke eval, mkdocs build) all passed
- [x] Pre-push hooks (pytest + smoke eval) passed