### PR TITLE
chore(release): add refactor to changelog-sections and clarify commit type guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ python3 -m uv run lefthook run pre-commit
 - Stable releases are initiated by `release-please` from merged conventional commits on `main`.
 - Pushes to `main` automatically publish `.devN` preview builds from the next inferred stable version.
 - Release PRs carry the version bump, changelog update, and tag metadata for the next stable cut.
-- Release PR summaries are grouped from parsed Conventional Commit types such as `feat`, `fix`, `docs`, `refactor`, and `perf`. Issue labels like `bug`, `retrieval`, or `release-candidate` do not drive those sections.
+- Release PR summaries are grouped from parsed Conventional Commit types: `feat` (Features), `fix` (Bug Fixes), `perf` (Performance Improvements), `refactor` (Refactors), `docs` (Documentation), and `revert` (Reverts). Issue labels like `bug`, `retrieval`, or `release-candidate` do not drive those sections. `chore`, `test`, and `style` commits do not appear in the changelog and do not affect the version.
 - Preview versions use PEP 440 development syntax such as `0.2.1.dev123456701`.
 - Release-candidate versions use PEP 440 syntax such as `0.2.1rc1`.
 - Manual release candidates are created through the GitHub Actions `rolling-release` workflow.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,6 +11,14 @@
       "changelog-path": "CHANGELOG.md",
       "extra-files": [
         "src/cellin/__about__.py"
+      ],
+      "changelog-sections": [
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "perf", "section": "Performance Improvements"},
+        {"type": "revert", "section": "Reverts"},
+        {"type": "docs", "section": "Documentation"},
+        {"type": "refactor", "section": "Refactors"}
       ]
     }
   }


### PR DESCRIPTION
## Problem

release-please uses the angular default changelog sections when `changelog-sections` is absent. The angular defaults omit `refactor:`, so refactoring commits were silently dropped from the changelog. CONTRIBUTING.md listed `refactor` as a tracked type but the config did not back that up.

## Changes

**`release-please-config.json`** — adds explicit `changelog-sections` that preserve all existing behaviour (Features, Bug Fixes, Performance Improvements, Reverts, Documentation) and adds a **Refactors** section so `refactor:` commits appear in release notes going forward.

**`CONTRIBUTING.md`** — replaces the vague "such as feat, fix, docs, refactor, and perf" sentence with a precise type→section mapping and calls out that `chore`, `test`, and `style` do not appear in the changelog and do not affect the version.

## No version bump

This is a `chore:` commit — no semver effect, does not appear in the changelog itself.