### PR TITLE
feat(features): add registry resolver

### DIFF
--- a/src/cellin/__about__.py
+++ b/src/cellin/__about__.py
@@ -1,5 +1,10 @@
-"""Single-source package version metadata."""
+"""Single-source package metadata."""
 
-__all__ = ["__version__"]
+from __future__ import annotations
 
+import os
+
+__all__ = ["__channel__", "__version__"]
+
+__channel__ = os.getenv("CELLIN_RELEASE_CHANNEL", "release")
 __version__ = "0.4.0"  # x-release-please-version

--- a/src/cellin/features/__init__.py
+++ b/src/cellin/features/__init__.py
@@ -1,0 +1,14 @@
+"""Feature registry and resolution helpers."""
+
+from cellin.features.registry import REGISTRY, FeatureFlag, Lifecycle, validate_registry
+from cellin.features.resolver import ReleaseChannel, load_release_lock, resolve_features
+
+__all__ = [
+    "FeatureFlag",
+    "Lifecycle",
+    "REGISTRY",
+    "ReleaseChannel",
+    "load_release_lock",
+    "resolve_features",
+    "validate_registry",
+]

--- a/src/cellin/features/registry.py
+++ b/src/cellin/features/registry.py
@@ -1,0 +1,48 @@
+"""Feature flag registry primitives."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, Literal
+
+type Lifecycle = Literal["preview", "stable", "done"]
+
+_VALID_LIFECYCLES: Final[frozenset[str]] = frozenset({"preview", "stable", "done"})
+
+
+@dataclass(frozen=True, slots=True)
+class FeatureFlag:
+    """Typed feature flag metadata."""
+
+    code: str
+    name: str
+    description: str
+    lifecycle: Lifecycle
+
+
+REGISTRY: tuple[FeatureFlag, ...] = ()
+
+
+def validate_registry(registry: tuple[FeatureFlag, ...] = REGISTRY) -> None:
+    """Validate registry invariants."""
+
+    seen_codes: set[str] = set()
+    seen_active_names: set[str] = set()
+
+    for feature in registry:
+        if not feature.code:
+            raise ValueError("Feature flags must define a non-empty code.")
+        if feature.lifecycle not in _VALID_LIFECYCLES:
+            raise ValueError(
+                f"Feature `{feature.code}` has invalid lifecycle `{feature.lifecycle}`."
+            )
+        if feature.code in seen_codes:
+            raise ValueError(f"Feature code `{feature.code}` is registered more than once.")
+        seen_codes.add(feature.code)
+
+        if feature.lifecycle == "done":
+            continue
+
+        if feature.name in seen_active_names:
+            raise ValueError(f"Feature name `{feature.name}` is already used by an active feature.")
+        seen_active_names.add(feature.name)

--- a/src/cellin/features/resolver.py
+++ b/src/cellin/features/resolver.py
@@ -1,0 +1,124 @@
+"""Pure feature resolution helpers."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Final, Literal
+
+from cellin.features.registry import REGISTRY, FeatureFlag, validate_registry
+
+type ReleaseChannel = Literal["release", "dev", "rolling"]
+
+_STABLE_LIFECYCLES: Final[frozenset[str]] = frozenset({"stable", "done"})
+
+
+def resolve_features(
+    registry: tuple[FeatureFlag, ...],
+    channel: ReleaseChannel,
+    lock: Mapping[str, bool] | None,
+    enable: Iterable[str],
+    disable: Iterable[str],
+) -> dict[str, bool]:
+    """Resolve feature states for a release channel."""
+
+    validate_registry(registry)
+
+    features_by_code = {feature.code: feature for feature in registry}
+    names_to_codes: dict[str, list[str]] = {}
+    for feature in registry:
+        names_to_codes.setdefault(feature.name, []).append(feature.code)
+
+    enabled_names = set(enable)
+    disabled_names = set(disable)
+    known_names = set(names_to_codes)
+    unknown_names = sorted((enabled_names | disabled_names) - known_names)
+    if unknown_names:
+        raise ValueError(f"Unknown feature names: {', '.join(unknown_names)}")
+
+    conflicts = sorted(enabled_names & disabled_names)
+    if conflicts:
+        raise ValueError(
+            f"Feature names cannot be both enabled and disabled: {', '.join(conflicts)}"
+        )
+
+    ambiguous_names = sorted(
+        name for name in (enabled_names | disabled_names) if len(names_to_codes[name]) > 1
+    )
+    if ambiguous_names:
+        raise ValueError(f"Feature names are ambiguous: {', '.join(ambiguous_names)}")
+
+    normalized_lock = dict(lock or {})
+    known_codes = set(features_by_code)
+    unknown_codes = sorted(set(normalized_lock) - known_codes)
+    if unknown_codes:
+        raise ValueError(f"Unknown feature lock codes: {', '.join(unknown_codes)}")
+
+    non_preview_codes = sorted(
+        code
+        for code, enabled in normalized_lock.items()
+        if enabled and features_by_code[code].lifecycle != "preview"
+    )
+    if non_preview_codes:
+        raise ValueError(
+            f"Release lock can only enable preview features: {', '.join(non_preview_codes)}"
+        )
+
+    if channel == "rolling":
+        resolved = {feature.code: True for feature in registry}
+    elif channel in {"release", "dev"}:
+        resolved = {feature.code: feature.lifecycle in _STABLE_LIFECYCLES for feature in registry}
+    else:
+        raise ValueError(f"Unknown release channel `{channel}`.")
+
+    if channel != "rolling":
+        for code, enabled in normalized_lock.items():
+            if enabled:
+                resolved[code] = True
+
+    for name in enabled_names:
+        resolved[names_to_codes[name][0]] = True
+
+    for name in disabled_names:
+        resolved[names_to_codes[name][0]] = False
+
+    return resolved
+
+
+def load_release_lock(path: str | Path) -> dict[str, bool]:
+    """Parse and validate a release lock file."""
+
+    validate_registry(REGISTRY)
+
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError("Release lock must be a JSON object.")
+
+    features = raw.get("features")
+    if not isinstance(features, list):
+        raise ValueError("Release lock must define a `features` list.")
+
+    codes: list[str] = []
+    for entry in features:
+        if not isinstance(entry, str) or not entry:
+            raise ValueError("Release lock feature codes must be non-empty strings.")
+        codes.append(entry)
+
+    if len(codes) != len(set(codes)):
+        raise ValueError("Release lock contains duplicate feature codes.")
+
+    features_by_code = {feature.code: feature for feature in REGISTRY}
+    unknown_codes = sorted(set(codes) - set(features_by_code))
+    if unknown_codes:
+        raise ValueError(f"Unknown feature lock codes: {', '.join(unknown_codes)}")
+
+    non_preview_codes = sorted(
+        code for code in codes if features_by_code[code].lifecycle != "preview"
+    )
+    if non_preview_codes:
+        raise ValueError(
+            f"Release lock can only enable preview features: {', '.join(non_preview_codes)}"
+        )
+
+    return {code: True for code in codes}

--- a/tests/unit/test_features_registry.py
+++ b/tests/unit/test_features_registry.py
@@ -1,0 +1,100 @@
+"""Unit tests for feature registry validation."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from cellin.features import FeatureFlag, validate_registry
+
+
+def test_validate_registry_accepts_empty_registry() -> None:
+    validate_registry(())
+
+
+def test_validate_registry_rejects_missing_code() -> None:
+    registry = (
+        FeatureFlag(
+            code="",
+            name="preview-search",
+            description="Preview search",
+            lifecycle="preview",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="non-empty code"):
+        validate_registry(registry)
+
+
+def test_validate_registry_rejects_duplicate_codes() -> None:
+    registry = (
+        FeatureFlag(
+            code="preview_search",
+            name="preview-search",
+            description="Preview search",
+            lifecycle="preview",
+        ),
+        FeatureFlag(
+            code="preview_search",
+            name="stable-search",
+            description="Stable search",
+            lifecycle="stable",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="registered more than once"):
+        validate_registry(registry)
+
+
+def test_validate_registry_rejects_duplicate_active_names() -> None:
+    registry = (
+        FeatureFlag(
+            code="preview_search",
+            name="shared-name",
+            description="Preview search",
+            lifecycle="preview",
+        ),
+        FeatureFlag(
+            code="stable_search",
+            name="shared-name",
+            description="Stable search",
+            lifecycle="stable",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="active feature"):
+        validate_registry(registry)
+
+
+def test_validate_registry_allows_duplicate_done_names() -> None:
+    registry = (
+        FeatureFlag(
+            code="legacy_search_one",
+            name="legacy-search",
+            description="Legacy search rollout one",
+            lifecycle="done",
+        ),
+        FeatureFlag(
+            code="legacy_search_two",
+            name="legacy-search",
+            description="Legacy search rollout two",
+            lifecycle="done",
+        ),
+    )
+
+    validate_registry(registry)
+
+
+def test_validate_registry_rejects_invalid_lifecycle() -> None:
+    registry = (
+        FeatureFlag(
+            code="preview_search",
+            name="preview-search",
+            description="Preview search",
+            lifecycle=cast(Any, "beta"),
+        ),
+    )
+
+    with pytest.raises(ValueError, match="invalid lifecycle"):
+        validate_registry(registry)

--- a/tests/unit/test_features_resolver.py
+++ b/tests/unit/test_features_resolver.py
@@ -1,0 +1,225 @@
+"""Unit tests for feature resolution."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import pytest
+
+from cellin.features import FeatureFlag, load_release_lock, resolve_features
+from cellin.features import resolver as resolver_module
+
+TEST_REGISTRY = (
+    FeatureFlag(
+        code="preview_search",
+        name="preview-search",
+        description="Preview search",
+        lifecycle="preview",
+    ),
+    FeatureFlag(
+        code="stable_cache",
+        name="stable-cache",
+        description="Stable cache",
+        lifecycle="stable",
+    ),
+    FeatureFlag(
+        code="done_ingest",
+        name="done-ingest",
+        description="Done ingest",
+        lifecycle="done",
+    ),
+)
+
+
+def test_release_channel_defaults_to_stable_and_done() -> None:
+    resolved = resolve_features(TEST_REGISTRY, "release", {}, (), ())
+
+    assert resolved == {
+        "preview_search": False,
+        "stable_cache": True,
+        "done_ingest": True,
+    }
+
+
+def test_dev_channel_matches_release_defaults() -> None:
+    resolved = resolve_features(TEST_REGISTRY, "dev", {}, (), ())
+
+    assert resolved == {
+        "preview_search": False,
+        "stable_cache": True,
+        "done_ingest": True,
+    }
+
+
+def test_rolling_channel_enables_all_features_and_ignores_lock() -> None:
+    resolved = resolve_features(
+        TEST_REGISTRY,
+        "rolling",
+        {"preview_search": False},
+        (),
+        ("stable-cache",),
+    )
+
+    assert resolved == {
+        "preview_search": True,
+        "stable_cache": False,
+        "done_ingest": True,
+    }
+
+
+def test_release_lock_defaults_preview_feature_on() -> None:
+    resolved = resolve_features(TEST_REGISTRY, "release", {"preview_search": True}, (), ())
+
+    assert resolved["preview_search"] is True
+
+
+def test_explicit_opt_in_overrides_release_defaults() -> None:
+    resolved = resolve_features(TEST_REGISTRY, "release", {}, ("preview-search",), ())
+
+    assert resolved["preview_search"] is True
+
+
+def test_explicit_opt_out_overrides_opt_in_and_release_lock() -> None:
+    with pytest.raises(ValueError, match="both enabled and disabled"):
+        resolve_features(
+            TEST_REGISTRY,
+            "release",
+            {"preview_search": True},
+            ("preview-search", "stable-cache"),
+            ("preview-search", "stable-cache"),
+        )
+
+
+def test_explicit_opt_out_overrides_channel_defaults() -> None:
+    resolved = resolve_features(
+        TEST_REGISTRY,
+        "release",
+        {"preview_search": True},
+        (),
+        ("preview-search", "stable-cache"),
+    )
+
+    assert resolved == {
+        "preview_search": False,
+        "stable_cache": False,
+        "done_ingest": True,
+    }
+
+
+def test_unknown_feature_names_are_rejected() -> None:
+    with pytest.raises(ValueError, match="Unknown feature names"):
+        resolve_features(TEST_REGISTRY, "release", {}, ("unknown-feature",), ())
+
+
+def test_ambiguous_feature_names_are_rejected() -> None:
+    registry = (
+        *TEST_REGISTRY,
+        FeatureFlag(
+            code="preview_search_v2",
+            name="preview-search",
+            description="Second preview search",
+            lifecycle="done",
+        ),
+    )
+
+    with pytest.raises(ValueError, match="Feature names are ambiguous: preview-search"):
+        resolve_features(registry, "release", {}, ("preview-search",), ())
+
+
+def test_conflicting_feature_names_are_rejected() -> None:
+    with pytest.raises(ValueError, match="both enabled and disabled"):
+        resolve_features(TEST_REGISTRY, "release", {}, ("preview-search",), ("preview-search",))
+
+
+def test_unknown_release_channel_is_rejected() -> None:
+    with pytest.raises(ValueError, match="Unknown release channel"):
+        resolve_features(TEST_REGISTRY, "beta", {}, (), ())  # type: ignore[arg-type]
+
+
+def test_unknown_release_lock_codes_are_rejected() -> None:
+    with pytest.raises(ValueError, match="Unknown feature lock codes"):
+        resolve_features(TEST_REGISTRY, "release", {"unknown_code": True}, (), ())
+
+
+def test_release_lock_rejects_non_preview_features() -> None:
+    with pytest.raises(ValueError, match="only enable preview features"):
+        resolve_features(TEST_REGISTRY, "release", {"stable_cache": True}, (), ())
+
+
+def test_load_release_lock_parses_and_validates_registry_codes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    lock_path = tmp_path / "features.release.lock.json"
+    lock_path.write_text(json.dumps({"features": ["preview_search"]}), encoding="utf-8")
+    monkeypatch.setattr(resolver_module, "REGISTRY", TEST_REGISTRY)
+
+    assert load_release_lock(lock_path) == {"preview_search": True}
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    (
+        ([], "JSON object"),
+        ({"features": "preview_search"}, "`features` list"),
+        ({"features": ["preview_search", "preview_search"]}, "duplicate feature codes"),
+        ({"features": [""]}, "non-empty strings"),
+        ({"features": [7]}, "non-empty strings"),
+    ),
+)
+def test_load_release_lock_rejects_malformed_payloads(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    payload: object,
+    message: str,
+) -> None:
+    lock_path = tmp_path / "features.release.lock.json"
+    lock_path.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr(resolver_module, "REGISTRY", TEST_REGISTRY)
+
+    with pytest.raises(ValueError, match=message):
+        load_release_lock(lock_path)
+
+
+def test_load_release_lock_rejects_unknown_registry_codes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    lock_path = tmp_path / "features.release.lock.json"
+    lock_path.write_text(json.dumps({"features": ["unknown_code"]}), encoding="utf-8")
+    monkeypatch.setattr(resolver_module, "REGISTRY", TEST_REGISTRY)
+
+    with pytest.raises(ValueError, match="Unknown feature lock codes"):
+        load_release_lock(lock_path)
+
+
+def test_load_release_lock_rejects_non_preview_registry_codes(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    lock_path = tmp_path / "features.release.lock.json"
+    lock_path.write_text(json.dumps({"features": ["stable_cache"]}), encoding="utf-8")
+    monkeypatch.setattr(resolver_module, "REGISTRY", TEST_REGISTRY)
+
+    with pytest.raises(ValueError, match="only enable preview features"):
+        load_release_lock(lock_path)
+
+
+@pytest.mark.parametrize(
+    ("channel_env", "expected"),
+    [
+        (None, "release"),
+        ("rolling", "rolling"),
+    ],
+)
+def test_channel_metadata_uses_environment_override(
+    monkeypatch: pytest.MonkeyPatch, channel_env: str | None, expected: str
+) -> None:
+    if channel_env is None:
+        monkeypatch.delenv("CELLIN_RELEASE_CHANNEL", raising=False)
+    else:
+        monkeypatch.setenv("CELLIN_RELEASE_CHANNEL", channel_env)
+
+    module = importlib.import_module("cellin.__about__")
+    module = importlib.reload(module)
+
+    assert module.__channel__ == expected


### PR DESCRIPTION
Closes #184.

Adds the typed feature registry, channel resolver, release-lock parsing, and unit coverage for registry invariants and channel defaults.