### PR TITLE
feat(features): wire release channel reporting

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,9 +28,102 @@ jobs:
 
       - name: Run release-please
         if: ${{ env.RELEASE_PLEASE_TOKEN != '' }}
+        id: release
         uses: googleapis/release-please-action@v5
         with:
           token: ${{ env.RELEASE_PLEASE_TOKEN }}
           target-branch: main
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Checkout
+        if: ${{ env.RELEASE_PLEASE_TOKEN != '' }}
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        if: ${{ env.RELEASE_PLEASE_TOKEN != '' }}
+        uses: actions/setup-python@v6
+        with:
+          python-version-file: .python-version
+
+      - name: Install uv
+        if: ${{ env.RELEASE_PLEASE_TOKEN != '' }}
+        run: python -m pip install uv
+
+      - name: Sync dependencies
+        if: ${{ env.RELEASE_PLEASE_TOKEN != '' }}
+        run: python -m uv sync --dev --frozen
+
+      - name: Update release PR feature flag report
+        if: ${{ env.RELEASE_PLEASE_TOKEN != '' }}
+        env:
+          GH_TOKEN: ${{ env.RELEASE_PLEASE_TOKEN }}
+          PR_JSON: ${{ steps.release.outputs.pr }}
+        shell: bash
+        run: |
+          report_file="$(mktemp)"
+          python -m uv run python scripts/generate_feature_report.py \
+            --channel release \
+            --lock features.release.lock.json > "${report_file}"
+
+          if [ -z "${PR_JSON}" ] || [ "${PR_JSON}" = "null" ]; then
+            echo "No release PR created or updated; skipping feature flag report."
+            exit 0
+          fi
+
+          pr_number="$(python - <<'PY'
+          import json
+          import os
+
+          payload = os.environ.get("PR_JSON", "").strip()
+          if not payload or payload == "null":
+              raise SystemExit(0)
+
+          data = json.loads(payload)
+          number = data.get("number")
+          if not isinstance(number, int):
+              raise SystemExit(0)
+
+          print(number)
+          PY
+          )"
+
+          if [ -z "${pr_number}" ]; then
+            echo "Release Please did not return a release PR number; skipping feature flag report."
+            exit 0
+          fi
+
+          body_file="$(mktemp)"
+          gh pr view "${pr_number}" --json body --jq .body > "${body_file}"
+
+          python - "${body_file}" "${report_file}" <<'PY'
+          from pathlib import Path
+          import re
+          import sys
+
+          body_path = Path(sys.argv[1])
+          report_path = Path(sys.argv[2])
+          start_marker = "<!-- cellin-feature-flags:start -->"
+          end_marker = "<!-- cellin-feature-flags:end -->"
+          report_block = (
+              f"{start_marker}\n{report_path.read_text(encoding='utf-8').rstrip()}\n{end_marker}"
+          )
+          body = body_path.read_text(encoding="utf-8")
+          pattern = re.compile(
+              r"<!-- cellin-feature-flags:start -->.*?<!-- cellin-feature-flags:end -->",
+              re.DOTALL,
+          )
+
+          if pattern.search(body):
+              updated = pattern.sub(report_block, body).strip()
+          elif body.strip():
+              updated = f"{body.rstrip()}\n\n{report_block}"
+          else:
+              updated = report_block
+
+          body_path.write_text(f"{updated}\n", encoding="utf-8")
+          PY
+
+          gh pr edit "${pr_number}" --body-file "${body_file}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      CELLIN_RELEASE_CHANNEL: release
     outputs:
       package_version: ${{ steps.version.outputs.package_version }}
 

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      CELLIN_RELEASE_CHANNEL: rolling
     outputs:
       package_version: ${{ steps.version.outputs.package_version }}
 

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -36,6 +36,15 @@ jobs:
       - name: Sync dependencies
         run: python -m uv sync --dev --frozen
 
+      - name: Validate feature release lock
+        run: |
+          python -m uv run python - <<'PY'
+          from cellin.features.resolver import read_release_lock_document
+
+          document = read_release_lock_document("features.release.lock.json")
+          print(f"validated_feature_lock={len(document['defaultOn'])}")
+          PY
+
       - name: Run CI target (verify + docs + version-check)
         run: make ci
 

--- a/features.release.lock.json
+++ b/features.release.lock.json
@@ -1,0 +1,1 @@
+{ "release": null, "defaultOn": [], "notes": {} }

--- a/scripts/generate_feature_report.py
+++ b/scripts/generate_feature_report.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Generate a markdown feature flag report for release automation."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Final, cast
+
+from cellin.features.registry import REGISTRY, FeatureFlag, Lifecycle, validate_registry
+from cellin.features.resolver import ReleaseChannel, ReleaseLockDocument, read_release_lock_document
+
+_STABLE_LIFECYCLES: Final[frozenset[str]] = frozenset({"stable", "done"})
+_STABLE_TAG_PATTERN: Final[re.Pattern[str]] = re.compile(r"^v\d+\.\d+\.\d+$")
+
+
+def format_feature(feature: FeatureFlag, note: str | None = None) -> str:
+    """Format one feature row for markdown output."""
+
+    line = f"- `{feature.code}` (`{feature.name}`): {feature.description}"
+    if note:
+        line = f"{line} Note: {note}"
+    return line
+
+
+def render_section(
+    title: str,
+    features: list[FeatureFlag],
+    notes: dict[str, str] | None = None,
+) -> list[str]:
+    """Render a single feature report section."""
+
+    lines = [f"### {title}"]
+    if not features:
+        lines.append("- None.")
+        return lines
+
+    section_notes = notes or {}
+    for feature in features:
+        lines.append(format_feature(feature, section_notes.get(feature.code)))
+    return lines
+
+
+def build_feature_report(
+    registry: tuple[FeatureFlag, ...],
+    lock: ReleaseLockDocument,
+    channel: ReleaseChannel,
+    previous_registry: tuple[FeatureFlag, ...],
+) -> str:
+    """Build the markdown feature report for the requested release channel."""
+
+    validate_registry(registry)
+    validate_registry(previous_registry)
+
+    locked_codes = set(lock["defaultOn"]) if channel != "rolling" else set()
+    previous_preview_codes = {
+        feature.code for feature in previous_registry if feature.lifecycle == "preview"
+    }
+
+    stable_default = [feature for feature in registry if feature.lifecycle in _STABLE_LIFECYCLES]
+    preview_opt_in = [
+        feature
+        for feature in registry
+        if feature.lifecycle == "preview" and feature.code not in locked_codes
+    ]
+    preview_locked = [
+        feature
+        for feature in registry
+        if feature.lifecycle == "preview" and feature.code in locked_codes
+    ]
+    new_preview = [
+        feature
+        for feature in registry
+        if feature.lifecycle == "preview" and feature.code not in previous_preview_codes
+    ]
+
+    sections = [
+        render_section("Stable by default", stable_default),
+        render_section("Preview available by opt-in", preview_opt_in),
+        render_section("Preview locked default-on for this release", preview_locked, lock["notes"]),
+        render_section("Newly added preview flags since previous release", new_preview),
+    ]
+
+    lines = ["## Feature flags", ""]
+    for index, section in enumerate(sections):
+        if index:
+            lines.append("")
+        lines.extend(section)
+    return "\n".join(lines)
+
+
+def git_stdout(args: list[str], cwd: Path) -> str:
+    """Run git and return decoded stdout."""
+
+    result = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def list_stable_tags(repo_root: Path) -> list[str]:
+    """Return stable release tags sorted from newest to oldest."""
+
+    try:
+        tags = git_stdout(["tag", "--sort=-version:refname"], repo_root).splitlines()
+    except (OSError, subprocess.CalledProcessError):
+        return []
+
+    return [tag for tag in tags if _STABLE_TAG_PATTERN.match(tag)]
+
+
+def _find_registry_tuple(module: ast.Module) -> ast.Tuple:
+    for node in module.body:
+        value: ast.expr | None = None
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "REGISTRY"
+        ):
+            value = node.value
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "REGISTRY":
+                    value = node.value
+                    break
+
+        if value is None:
+            continue
+        if not isinstance(value, ast.Tuple):
+            raise ValueError("Registry snapshot must define REGISTRY as a tuple literal.")
+        return value
+
+    raise ValueError("Registry snapshot must define REGISTRY.")
+
+
+def _feature_keyword(node: ast.Call, field_name: str) -> str:
+    for keyword in node.keywords:
+        if keyword.arg != field_name:
+            continue
+        value = keyword.value
+        if isinstance(value, ast.Constant) and isinstance(value.value, str):
+            return value.value
+        raise ValueError(f"Registry snapshot `{field_name}` values must be string literals.")
+    raise ValueError(f"Registry snapshot entries must define `{field_name}`.")
+
+
+def _parse_feature_entry(node: ast.expr) -> FeatureFlag:
+    if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+        raise ValueError("Registry snapshot entries must be FeatureFlag(...) calls.")
+    if node.func.id != "FeatureFlag":
+        raise ValueError("Registry snapshot entries must be FeatureFlag(...) calls.")
+
+    return FeatureFlag(
+        code=_feature_keyword(node, "code"),
+        name=_feature_keyword(node, "name"),
+        description=_feature_keyword(node, "description"),
+        lifecycle=cast(Lifecycle, _feature_keyword(node, "lifecycle")),
+    )
+
+
+def load_registry_from_source(source: str) -> tuple[FeatureFlag, ...]:
+    """Parse a registry module source snapshot into feature metadata."""
+
+    registry_tuple = _find_registry_tuple(ast.parse(source))
+    normalized = tuple(_parse_feature_entry(entry) for entry in registry_tuple.elts)
+    validate_registry(normalized)
+    return normalized
+
+
+def load_registry_from_ref(repo_root: Path, ref: str) -> tuple[FeatureFlag, ...]:
+    """Load the feature registry from a git ref, or return an empty registry if unavailable."""
+
+    try:
+        source = git_stdout(["show", f"{ref}:src/cellin/features/registry.py"], repo_root)
+    except (OSError, subprocess.CalledProcessError):
+        return ()
+    return load_registry_from_source(source)
+
+
+def detect_previous_release_tag(repo_root: Path) -> str | None:
+    """Find the previous stable release tag, skipping tags attached to HEAD."""
+
+    tags = list_stable_tags(repo_root)
+    if not tags:
+        return None
+
+    try:
+        head_tags = set(git_stdout(["tag", "--points-at", "HEAD"], repo_root).splitlines())
+    except (OSError, subprocess.CalledProcessError):
+        head_tags = set()
+
+    for tag in tags:
+        if tag not in head_tags:
+            return tag
+    return None
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+
+    parser = argparse.ArgumentParser(description="Generate a markdown feature flag report.")
+    parser.add_argument(
+        "--channel",
+        choices=("release", "dev", "rolling"),
+        required=True,
+        help="Release channel to report for.",
+    )
+    parser.add_argument(
+        "--lock",
+        required=True,
+        help="Path to features.release.lock.json.",
+    )
+    parser.add_argument(
+        "--previous-ref",
+        help="Optional git ref to compare preview flags against instead of auto-detecting.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """CLI entrypoint."""
+
+    args = parse_args()
+    lock_path = Path(args.lock)
+    repo_root = Path.cwd()
+    lock = read_release_lock_document(lock_path)
+
+    previous_ref = args.previous_ref or detect_previous_release_tag(repo_root)
+    previous_registry = load_registry_from_ref(repo_root, previous_ref) if previous_ref else ()
+
+    print(build_feature_report(REGISTRY, lock, args.channel, previous_registry))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/src/cellin/features/resolver.py
+++ b/src/cellin/features/resolver.py
@@ -5,13 +5,22 @@ from __future__ import annotations
 import json
 from collections.abc import Iterable, Mapping
 from pathlib import Path
-from typing import Final, Literal
+from typing import Final, Literal, TypedDict
 
 from cellin.features.registry import REGISTRY, FeatureFlag, validate_registry
 
 type ReleaseChannel = Literal["release", "dev", "rolling"]
 
 _STABLE_LIFECYCLES: Final[frozenset[str]] = frozenset({"stable", "done"})
+_RELEASE_LOCK_KEYS: Final[frozenset[str]] = frozenset({"release", "defaultOn", "notes"})
+
+
+class ReleaseLockDocument(TypedDict):
+    """Validated release lock payload."""
+
+    release: str | None
+    defaultOn: list[str]
+    notes: dict[str, str]
 
 
 def resolve_features(
@@ -86,21 +95,36 @@ def resolve_features(
     return resolved
 
 
-def load_release_lock(path: str | Path) -> dict[str, bool]:
-    """Parse and validate a release lock file."""
+def parse_release_lock_document(
+    raw: object,
+    registry: tuple[FeatureFlag, ...] | None = None,
+) -> ReleaseLockDocument:
+    """Validate the raw release lock payload against the feature registry."""
 
-    validate_registry(REGISTRY)
+    active_registry = REGISTRY if registry is None else registry
+    validate_registry(active_registry)
 
-    raw = json.loads(Path(path).read_text(encoding="utf-8"))
     if not isinstance(raw, dict):
         raise ValueError("Release lock must be a JSON object.")
 
-    features = raw.get("features")
-    if not isinstance(features, list):
-        raise ValueError("Release lock must define a `features` list.")
+    unknown_keys = sorted(set(raw) - _RELEASE_LOCK_KEYS)
+    if unknown_keys:
+        raise ValueError(f"Release lock contains unknown keys: {', '.join(unknown_keys)}")
+
+    missing_keys = sorted(_RELEASE_LOCK_KEYS - set(raw))
+    if missing_keys:
+        raise ValueError(f"Release lock is missing keys: {', '.join(missing_keys)}")
+
+    release = raw["release"]
+    if release is not None and not isinstance(release, str):
+        raise ValueError("Release lock `release` must be a string or null.")
+
+    default_on = raw["defaultOn"]
+    if not isinstance(default_on, list):
+        raise ValueError("Release lock must define a `defaultOn` list.")
 
     codes: list[str] = []
-    for entry in features:
+    for entry in default_on:
         if not isinstance(entry, str) or not entry:
             raise ValueError("Release lock feature codes must be non-empty strings.")
         codes.append(entry)
@@ -108,8 +132,22 @@ def load_release_lock(path: str | Path) -> dict[str, bool]:
     if len(codes) != len(set(codes)):
         raise ValueError("Release lock contains duplicate feature codes.")
 
-    features_by_code = {feature.code: feature for feature in REGISTRY}
+    notes_raw = raw["notes"]
+    if not isinstance(notes_raw, dict):
+        raise ValueError("Release lock `notes` must be a JSON object.")
+
+    notes: dict[str, str] = {}
+    for code, note in notes_raw.items():
+        if not isinstance(code, str) or not code:
+            raise ValueError("Release lock note keys must be non-empty strings.")
+        if not isinstance(note, str):
+            raise ValueError("Release lock note values must be strings.")
+        notes[code] = note
+
+    features_by_code = {feature.code: feature for feature in active_registry}
     unknown_codes = sorted(set(codes) - set(features_by_code))
+    unknown_note_codes = sorted(set(notes) - set(features_by_code))
+    unknown_codes.extend(code for code in unknown_note_codes if code not in unknown_codes)
     if unknown_codes:
         raise ValueError(f"Unknown feature lock codes: {', '.join(unknown_codes)}")
 
@@ -121,4 +159,22 @@ def load_release_lock(path: str | Path) -> dict[str, bool]:
             f"Release lock can only enable preview features: {', '.join(non_preview_codes)}"
         )
 
-    return {code: True for code in codes}
+    return {
+        "release": release,
+        "defaultOn": codes,
+        "notes": notes,
+    }
+
+
+def read_release_lock_document(path: str | Path) -> ReleaseLockDocument:
+    """Parse and validate a release lock file."""
+
+    raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    return parse_release_lock_document(raw)
+
+
+def load_release_lock(path: str | Path) -> dict[str, bool]:
+    """Load the release lock as an effective code-to-enabled mapping."""
+
+    document = read_release_lock_document(path)
+    return {code: True for code in document["defaultOn"]}

--- a/tests/unit/test_feature_report.py
+++ b/tests/unit/test_feature_report.py
@@ -1,0 +1,175 @@
+"""Unit tests for the feature report generator."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from cellin.features import FeatureFlag
+
+
+def load_report_module():
+    script_path = Path(__file__).resolve().parents[2] / "scripts" / "generate_feature_report.py"
+    spec = importlib.util.spec_from_file_location("generate_feature_report", script_path)
+    if spec is None or spec.loader is None:
+        raise AssertionError("Could not load feature report module.")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+report_module = load_report_module()
+
+TEST_REGISTRY = (
+    FeatureFlag(
+        code="preview_search",
+        name="preview-search",
+        description="Preview search",
+        lifecycle="preview",
+    ),
+    FeatureFlag(
+        code="preview_index",
+        name="preview-index",
+        description="Preview index",
+        lifecycle="preview",
+    ),
+    FeatureFlag(
+        code="stable_cache",
+        name="stable-cache",
+        description="Stable cache",
+        lifecycle="stable",
+    ),
+    FeatureFlag(
+        code="done_ingest",
+        name="done-ingest",
+        description="Done ingest",
+        lifecycle="done",
+    ),
+)
+
+
+def test_build_feature_report_handles_empty_registry() -> None:
+    report = report_module.build_feature_report(
+        (),
+        {"release": None, "defaultOn": [], "notes": {}},
+        "release",
+        (),
+    )
+
+    assert report == "\n".join(
+        [
+            "## Feature flags",
+            "",
+            "### Stable by default",
+            "- None.",
+            "",
+            "### Preview available by opt-in",
+            "- None.",
+            "",
+            "### Preview locked default-on for this release",
+            "- None.",
+            "",
+            "### Newly added preview flags since previous release",
+            "- None.",
+        ]
+    )
+
+
+def test_build_feature_report_splits_mixed_feature_states() -> None:
+    report = report_module.build_feature_report(
+        TEST_REGISTRY,
+        {
+            "release": "v0.5.0",
+            "defaultOn": ["preview_search"],
+            "notes": {"preview_search": "Keep enabled while cache rollout settles."},
+        },
+        "release",
+        (
+            FeatureFlag(
+                code="preview_search",
+                name="preview-search",
+                description="Preview search",
+                lifecycle="preview",
+            ),
+        ),
+    )
+
+    assert "### Stable by default\n- `stable_cache` (`stable-cache`): Stable cache" in report
+    assert "- `done_ingest` (`done-ingest`): Done ingest" in report
+    assert (
+        "### Preview available by opt-in\n- `preview_index` (`preview-index`): Preview index"
+    ) in report
+    assert (
+        "### Preview locked default-on for this release\n"
+        "- `preview_search` (`preview-search`): Preview search "
+        "Note: Keep enabled while cache rollout settles."
+    ) in report
+    assert (
+        "### Newly added preview flags since previous release\n"
+        "- `preview_index` (`preview-index`): Preview index"
+    ) in report
+
+
+def test_build_feature_report_ignores_lock_for_rolling_channel() -> None:
+    report = report_module.build_feature_report(
+        TEST_REGISTRY,
+        {
+            "release": "v0.5.0",
+            "defaultOn": ["preview_search"],
+            "notes": {"preview_search": "Only for stable release artifacts."},
+        },
+        "rolling",
+        (),
+    )
+
+    assert "### Preview locked default-on for this release\n- None." in report
+    assert "- `preview_search` (`preview-search`): Preview search" in report
+
+
+def test_load_registry_from_source_parses_literal_feature_flags() -> None:
+    registry = report_module.load_registry_from_source(
+        """
+from cellin.features.registry import FeatureFlag
+
+REGISTRY: tuple[FeatureFlag, ...] = (
+    FeatureFlag(
+        code="preview_search",
+        name="preview-search",
+        description="Preview search",
+        lifecycle="preview",
+    ),
+)
+"""
+    )
+
+    assert registry == (
+        FeatureFlag(
+            code="preview_search",
+            name="preview-search",
+            description="Preview search",
+            lifecycle="preview",
+        ),
+    )
+
+
+def test_load_registry_from_source_rejects_nonliteral_entries() -> None:
+    source = """
+from cellin.features.registry import FeatureFlag
+
+description = "Preview search"
+REGISTRY = (
+    FeatureFlag(
+        code="preview_search",
+        name="preview-search",
+        description=description,
+        lifecycle="preview",
+    ),
+)
+"""
+
+    try:
+        report_module.load_registry_from_source(source)
+    except ValueError as exc:
+        assert "description" in str(exc)
+    else:
+        raise AssertionError("Expected nonliteral registry source to fail.")

--- a/tests/unit/test_features_resolver.py
+++ b/tests/unit/test_features_resolver.py
@@ -152,7 +152,16 @@ def test_load_release_lock_parses_and_validates_registry_codes(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     lock_path = tmp_path / "features.release.lock.json"
-    lock_path.write_text(json.dumps({"features": ["preview_search"]}), encoding="utf-8")
+    lock_path.write_text(
+        json.dumps(
+            {
+                "release": "v0.4.0",
+                "defaultOn": ["preview_search"],
+                "notes": {"preview_search": "Hold preview on during rollout."},
+            }
+        ),
+        encoding="utf-8",
+    )
     monkeypatch.setattr(resolver_module, "REGISTRY", TEST_REGISTRY)
 
     assert load_release_lock(lock_path) == {"preview_search": True}
@@ -162,10 +171,16 @@ def test_load_release_lock_parses_and_validates_registry_codes(
     ("payload", "message"),
     (
         ([], "JSON object"),
-        ({"features": "preview_search"}, "`features` list"),
-        ({"features": ["preview_search", "preview_search"]}, "duplicate feature codes"),
-        ({"features": [""]}, "non-empty strings"),
-        ({"features": [7]}, "non-empty strings"),
+        (
+            {"release": None, "defaultOn": "preview_search", "notes": {}},
+            "`defaultOn` list",
+        ),
+        (
+            {"release": None, "defaultOn": ["preview_search", "preview_search"], "notes": {}},
+            "duplicate feature codes",
+        ),
+        ({"release": None, "defaultOn": [""], "notes": {}}, "non-empty strings"),
+        ({"release": None, "defaultOn": [7], "notes": {}}, "non-empty strings"),
     ),
 )
 def test_load_release_lock_rejects_malformed_payloads(
@@ -186,7 +201,10 @@ def test_load_release_lock_rejects_unknown_registry_codes(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     lock_path = tmp_path / "features.release.lock.json"
-    lock_path.write_text(json.dumps({"features": ["unknown_code"]}), encoding="utf-8")
+    lock_path.write_text(
+        json.dumps({"release": None, "defaultOn": ["unknown_code"], "notes": {}}),
+        encoding="utf-8",
+    )
     monkeypatch.setattr(resolver_module, "REGISTRY", TEST_REGISTRY)
 
     with pytest.raises(ValueError, match="Unknown feature lock codes"):
@@ -197,11 +215,67 @@ def test_load_release_lock_rejects_non_preview_registry_codes(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     lock_path = tmp_path / "features.release.lock.json"
-    lock_path.write_text(json.dumps({"features": ["stable_cache"]}), encoding="utf-8")
+    lock_path.write_text(
+        json.dumps({"release": None, "defaultOn": ["stable_cache"], "notes": {}}),
+        encoding="utf-8",
+    )
     monkeypatch.setattr(resolver_module, "REGISTRY", TEST_REGISTRY)
 
     with pytest.raises(ValueError, match="only enable preview features"):
         load_release_lock(lock_path)
+
+
+def test_load_release_lock_rejects_unknown_top_level_keys(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    lock_path = tmp_path / "features.release.lock.json"
+    lock_path.write_text(
+        json.dumps(
+            {
+                "release": None,
+                "defaultOn": ["preview_search"],
+                "notes": {},
+                "features": ["preview_search"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(resolver_module, "REGISTRY", TEST_REGISTRY)
+
+    with pytest.raises(ValueError, match="unknown keys"):
+        load_release_lock(lock_path)
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    (
+        ([], "JSON object"),
+        ({"defaultOn": [], "notes": {}}, "missing keys: release"),
+        ({"release": 42, "defaultOn": [], "notes": {}}, "`release` must be a string"),
+        ({"release": None, "defaultOn": "preview_search", "notes": {}}, "`defaultOn` list"),
+        ({"release": None, "defaultOn": [""], "notes": {}}, "non-empty strings"),
+        ({"release": None, "defaultOn": [7], "notes": {}}, "non-empty strings"),
+        (
+            {"release": None, "defaultOn": ["preview_search", "preview_search"], "notes": {}},
+            "duplicate feature codes",
+        ),
+        ({"release": None, "defaultOn": [], "notes": []}, "`notes` must be a JSON object"),
+        (
+            {"release": None, "defaultOn": [], "notes": {"": "missing code"}},
+            "note keys must be non-empty strings",
+        ),
+        (
+            {"release": None, "defaultOn": [], "notes": {"preview_search": 7}},
+            "note values must be strings",
+        ),
+    ),
+)
+def test_parse_release_lock_document_rejects_malformed_payloads(
+    payload: object,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        resolver_module.parse_release_lock_document(payload, registry=TEST_REGISTRY)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #186.

Depends on #184.

Adds release-channel env wiring, the release lock file and validation, feature flag reporting, and release-please PR body updates.