### PR TITLE
feat(mcp): add subject routing registry

### DIFF
--- a/src/cellin/mcp/__init__.py
+++ b/src/cellin/mcp/__init__.py
@@ -1,0 +1,5 @@
+"""MCP-facing subject routing helpers."""
+
+from cellin.mcp.subjects import SubjectRegistry, SubjectSummary, validate_subject_id
+
+__all__ = ["SubjectRegistry", "SubjectSummary", "validate_subject_id"]

--- a/src/cellin/mcp/subjects.py
+++ b/src/cellin/mcp/subjects.py
@@ -1,0 +1,255 @@
+"""Subject-aware storage routing for the future MCP server."""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+from cellin.runtime.storage import (
+    StorageBackendConfig,
+    StorageBundle,
+    StorageConfig,
+    build_storage_bundle,
+)
+from cellin.stores import sql_backends
+from cellin.stores import sqlite as sqlite_stores
+
+_SUBJECT_ID_RE: Final[re.Pattern[str]] = re.compile(r"^[a-z0-9_-]+$", re.ASCII)
+_SUBJECT_COLLECTION_PREFIX: Final[str] = "cellin_"
+_SUBJECT_INDEX_FILENAME: Final[str] = "subjects.json"
+
+
+@dataclass(frozen=True, slots=True)
+class SubjectSummary:
+    """Current storage counts for a known subject."""
+
+    subject_id: str
+    memory_count: int
+    edge_count: int
+
+
+def validate_subject_id(subject_id: str) -> str:
+    """Validate and normalize a slug-safe subject identifier."""
+
+    normalized = subject_id.strip()
+    if not normalized:
+        raise ValueError("Subject ID must be a non-empty slug-safe string matching `[a-z0-9_-]+`.")
+    if _SUBJECT_ID_RE.fullmatch(normalized) is None:
+        raise ValueError(
+            f"Invalid subject ID `{subject_id}`. Subject IDs must match `[a-z0-9_-]+`."
+        )
+    return normalized
+
+
+class SubjectRegistry:
+    """Lazily provisions isolated storage bundles per subject ID."""
+
+    def __init__(
+        self,
+        *,
+        workspace_root: Path | str,
+        storage_config: StorageConfig | None = None,
+        data_directory: Path | str = "data",
+    ) -> None:
+        self.workspace_root = Path(workspace_root).resolve()
+        self.data_directory = self._resolve_data_directory(data_directory)
+        self._base_storage_config = storage_config or StorageConfig.with_sqlite_preset(
+            "cellin.sqlite"
+        )
+        self._bundles: dict[str, StorageBundle] = {}
+        self._known_subject_ids = self._load_known_subject_ids()
+
+    def get_or_create(self, subject_id: str) -> StorageBundle:
+        """Return an existing bundle or provision an isolated bundle for subject_id."""
+
+        normalized = validate_subject_id(subject_id)
+        bundle = self._bundles.get(normalized)
+        if bundle is not None:
+            return bundle
+
+        subject_storage = self.storage_config_for(normalized)
+        bundle = build_storage_bundle(subject_storage, workspace_root=self.workspace_root)
+        self._bundles[normalized] = bundle
+        if normalized not in self._known_subject_ids:
+            self._known_subject_ids.add(normalized)
+            self._persist_known_subject_ids()
+        return bundle
+
+    def storage_config_for(self, subject_id: str) -> StorageConfig:
+        """Return the subject-scoped storage config derived from the base config."""
+
+        normalized = validate_subject_id(subject_id)
+        return StorageConfig(
+            memory=self._route_backend(self._base_storage_config.memory, subject_id=normalized),
+            graph=self._route_backend(self._base_storage_config.graph, subject_id=normalized),
+            vector=self._route_backend(self._base_storage_config.vector, subject_id=normalized),
+            representation=self._route_backend(
+                self._base_storage_config.representation,
+                subject_id=normalized,
+            ),
+        )
+
+    def list_subjects(self) -> tuple[SubjectSummary, ...]:
+        """Return known subject IDs with current memory and edge counts."""
+
+        summaries: list[SubjectSummary] = []
+        for subject_id in sorted(self._known_subject_ids):
+            bundle = self.get_or_create(subject_id)
+            summaries.append(
+                SubjectSummary(
+                    subject_id=subject_id,
+                    memory_count=len(bundle.memory_store.list()),
+                    edge_count=len(bundle.graph_store.list_edges()),
+                )
+            )
+        return tuple(summaries)
+
+    def delete_subject(self, subject_id: str, *, confirm: bool = False) -> bool:
+        """Delete all known local storage for subject_id when confirmation is explicit."""
+
+        normalized = validate_subject_id(subject_id)
+        if not confirm:
+            raise ValueError(f"Refusing to delete subject `{normalized}` without `confirm=True`.")
+        if normalized not in self._known_subject_ids:
+            self._bundles.pop(normalized, None)
+            return False
+
+        subject_storage = self.storage_config_for(normalized)
+        local_paths = self._subject_local_paths(subject_storage)
+        if not local_paths and not self._uses_only_ephemeral_backends(subject_storage):
+            raise NotImplementedError(
+                f"Subject deletion for `{normalized}` is not supported for the configured "
+                "remote backend mix."
+            )
+
+        removed_any = False
+        for path in local_paths:
+            self._clear_local_backend_caches(path)
+            if path.exists():
+                path.unlink()
+                removed_any = True
+
+        self._bundles.pop(normalized, None)
+        self._known_subject_ids.remove(normalized)
+        self._persist_known_subject_ids()
+        return removed_any or self._uses_only_ephemeral_backends(subject_storage)
+
+    def _resolve_data_directory(self, data_directory: Path | str) -> Path:
+        configured = Path(data_directory)
+        resolved = configured if configured.is_absolute() else self.workspace_root / configured
+        resolved.mkdir(parents=True, exist_ok=True)
+        return resolved.resolve()
+
+    def _load_known_subject_ids(self) -> set[str]:
+        if not self._subject_index_path.exists():
+            return set()
+
+        raw = json.loads(self._subject_index_path.read_text(encoding="utf-8"))
+        if not isinstance(raw, list):
+            raise ValueError("Subject index must be a JSON array of subject IDs.")
+        return {validate_subject_id(str(subject_id)) for subject_id in raw}
+
+    def _persist_known_subject_ids(self) -> None:
+        payload = json.dumps(sorted(self._known_subject_ids), indent=2)
+        self._subject_index_path.write_text(payload + "\n", encoding="utf-8")
+
+    @property
+    def _subject_index_path(self) -> Path:
+        return self.data_directory / _SUBJECT_INDEX_FILENAME
+
+    def _route_backend(
+        self,
+        config: StorageBackendConfig,
+        *,
+        subject_id: str,
+    ) -> StorageBackendConfig:
+        database_path = config.database_path
+        if config.backend in {"sqlite", "sqlite_vec"}:
+            return StorageBackendConfig(config.backend, self._subject_sqlite_path(subject_id))
+        if config.backend == "duckdb":
+            return StorageBackendConfig(config.backend, self._subject_duckdb_path(subject_id))
+        if database_path is None:
+            return config
+        if config.backend == "mongodb":
+            return StorageBackendConfig(
+                config.backend,
+                _replace_url_path(database_path, f"/{_SUBJECT_COLLECTION_PREFIX}{subject_id}"),
+            )
+        if config.backend == "pinecone":
+            return StorageBackendConfig(
+                config.backend,
+                _replace_query_value(database_path, namespace=subject_id),
+            )
+        if config.backend in {"milvus", "qdrant", "redis_vector", "weaviate"}:
+            return StorageBackendConfig(
+                config.backend,
+                _replace_query_value(
+                    database_path,
+                    collection=f"{_SUBJECT_COLLECTION_PREFIX}{subject_id}",
+                ),
+            )
+        return config
+
+    def _subject_local_paths(self, storage: StorageConfig) -> tuple[Path, ...]:
+        paths: set[Path] = set()
+        for config in (
+            storage.memory,
+            storage.graph,
+            storage.vector,
+            storage.representation,
+        ):
+            database_path = config.database_path
+            if database_path is None or database_path == ":memory:":
+                continue
+            if config.backend not in {"duckdb", "sqlite", "sqlite_vec"}:
+                continue
+            paths.add(self._resolve_storage_path(database_path))
+        return tuple(sorted(paths))
+
+    def _resolve_storage_path(self, database_path: str) -> Path:
+        configured = Path(database_path)
+        resolved = configured if configured.is_absolute() else self.workspace_root / configured
+        return resolved.resolve()
+
+    def _subject_sqlite_path(self, subject_id: str) -> str:
+        return str((self.data_directory / f"{_SUBJECT_COLLECTION_PREFIX}{subject_id}.db").resolve())
+
+    def _subject_duckdb_path(self, subject_id: str) -> str:
+        return str(
+            (self.data_directory / f"{_SUBJECT_COLLECTION_PREFIX}{subject_id}.duckdb").resolve()
+        )
+
+    def _uses_only_ephemeral_backends(self, storage: StorageConfig) -> bool:
+        ephemeral = {"in_memory", "in_memory_vector_index"}
+        return all(
+            config.backend in ephemeral
+            for config in (
+                storage.memory,
+                storage.graph,
+                storage.vector,
+                storage.representation,
+            )
+        )
+
+    def _clear_local_backend_caches(self, path: Path) -> None:
+        resolved_path = str(path.resolve())
+
+        sqlite_stores._BACKENDS.pop(resolved_path, None)
+        sql_backends._BACKENDS.pop(("duckdb", resolved_path), None)
+
+
+def _replace_query_value(connection_string: str, **updates: str) -> str:
+    parsed = urlparse(connection_string)
+    query = parse_qs(parsed.query, keep_blank_values=True)
+    for key, value in updates.items():
+        query[key] = [value]
+    return urlunparse(parsed._replace(query=urlencode(query, doseq=True)))
+
+
+def _replace_url_path(connection_string: str, path: str) -> str:
+    parsed = urlparse(connection_string)
+    return urlunparse(parsed._replace(path=path))

--- a/tests/integration/mcp/test_subject_routing.py
+++ b/tests/integration/mcp/test_subject_routing.py
@@ -1,0 +1,82 @@
+"""Integration tests for subject-scoped MCP storage routing."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
+
+from cellin.core import Artifact, Modality, Provenance
+from cellin.ingest.pipeline import CanonicalIngestor
+from cellin.mcp import SubjectRegistry
+from cellin.ranking.profiles import get_weight_profile
+from cellin.ranking.weighted import WeightedRanker
+from cellin.retrieval import RetrievalCandidateGenerator, WeightedRetriever
+
+_NOW = datetime(2026, 6, 11, tzinfo=UTC)
+
+
+def _artifact(artifact_id: str, text: str, *, topic: str) -> Artifact:
+    return Artifact(
+        artifact_id=artifact_id,
+        modality=Modality.TEXT,
+        content=text,
+        provenance=Provenance(source_id=artifact_id, source_type="fixture"),
+        created_at=_NOW,
+        metadata={"topic": topic},
+    )
+
+
+def _ingest_subject_memory(
+    registry: SubjectRegistry,
+    subject_id: str,
+    *,
+    artifact_id: str,
+    text: str,
+    topic: str,
+) -> None:
+    bundle = registry.get_or_create(subject_id)
+    ingestor = CanonicalIngestor.with_built_in_adapters(
+        graph_store=bundle.graph_store,
+        memory_store=bundle.memory_store,
+        vector_store=bundle.vector_store,
+        representation_store=bundle.representation_store,
+    )
+    ingestor.ingest((_artifact(artifact_id, text, topic=topic),))
+
+
+def _retriever_for_subject(registry: SubjectRegistry, subject_id: str) -> WeightedRetriever:
+    bundle = registry.get_or_create(subject_id)
+    profile = replace(get_weight_profile("balanced"), candidate_limit=4, token_budget=100)
+    return WeightedRetriever(
+        candidate_generator=RetrievalCandidateGenerator(
+            memory_store=bundle.memory_store,
+            graph_store=bundle.graph_store,
+            vector_store=bundle.vector_store,
+        ),
+        ranker=WeightedRanker(profile=profile, now_provider=lambda: _NOW),
+        profile=profile,
+        memory_store=bundle.memory_store,
+        representation_store=bundle.representation_store,
+    )
+
+
+def test_subject_routing_keeps_same_topic_isolated_across_subjects(tmp_path: Path) -> None:
+    registry = SubjectRegistry(workspace_root=tmp_path)
+    _ingest_subject_memory(
+        registry,
+        "subject-a",
+        artifact_id="artifact-a",
+        text="Roadmap notes for the atlas launch sequence.",
+        topic="launch-plan",
+    )
+
+    subject_a_bundle = registry.get_or_create("subject-a")
+    subject_b_bundle = registry.get_or_create("subject-b")
+    subject_b_retriever = _retriever_for_subject(registry, "subject-b")
+    subject_b_results = subject_b_retriever.retrieve("atlas launch roadmap", top_k=5)
+
+    assert len(subject_a_bundle.memory_store.list()) == 1
+    assert subject_b_bundle.memory_store.list() == ()
+    assert subject_b_bundle.graph_store.list_edges() == ()
+    assert subject_b_results.memories == ()

--- a/tests/unit/test_mcp_subject_registry.py
+++ b/tests/unit/test_mcp_subject_registry.py
@@ -1,0 +1,206 @@
+"""Unit tests for MCP subject routing."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from cellin.core import Artifact, Modality, Provenance
+from cellin.ingest.pipeline import CanonicalIngestor
+from cellin.mcp import SubjectRegistry
+from cellin.runtime.storage import StorageBackendConfig, StorageConfig
+
+_NOW = datetime(2026, 6, 11, tzinfo=UTC)
+
+
+def _artifact(artifact_id: str, text: str, *, topic: str) -> Artifact:
+    return Artifact(
+        artifact_id=artifact_id,
+        modality=Modality.TEXT,
+        content=text,
+        provenance=Provenance(source_id=artifact_id, source_type="fixture"),
+        created_at=_NOW,
+        metadata={"topic": topic},
+    )
+
+
+def _ingest_topic(
+    registry: SubjectRegistry,
+    subject_id: str,
+    *,
+    artifact_id: str,
+    topic: str,
+) -> None:
+    bundle = registry.get_or_create(subject_id)
+    ingestor = CanonicalIngestor.with_built_in_adapters(
+        graph_store=bundle.graph_store,
+        memory_store=bundle.memory_store,
+        vector_store=bundle.vector_store,
+        representation_store=bundle.representation_store,
+    )
+    ingestor.ingest((_artifact(artifact_id, f"{topic} notes for {subject_id}", topic=topic),))
+
+
+def test_get_or_create_reuses_existing_bundle(tmp_path: Path) -> None:
+    registry = SubjectRegistry(workspace_root=tmp_path)
+
+    first = registry.get_or_create("alpha")
+    second = registry.get_or_create("alpha")
+
+    assert first is second
+
+
+@pytest.mark.parametrize("subject_id", ["", "Alpha", "alpha beta", "../alpha", "alpha!"])
+def test_invalid_subject_ids_raise_descriptive_error(tmp_path: Path, subject_id: str) -> None:
+    registry = SubjectRegistry(workspace_root=tmp_path)
+
+    with pytest.raises(ValueError, match=r"\[a-z0-9_-\]\+"):
+        registry.get_or_create(subject_id)
+
+
+def test_storage_config_for_sqlite_is_subject_scoped_and_deterministic(tmp_path: Path) -> None:
+    registry = SubjectRegistry(workspace_root=tmp_path, data_directory="subject-data")
+
+    alpha = registry.storage_config_for("alpha")
+    alpha_again = registry.storage_config_for("alpha")
+    beta = registry.storage_config_for("beta")
+
+    assert alpha == alpha_again
+    assert alpha.memory.database_path == str(
+        (tmp_path / "subject-data" / "cellin_alpha.db").resolve()
+    )
+    assert alpha.graph.database_path == alpha.memory.database_path
+    assert alpha.vector.backend == "in_memory_vector_index"
+    assert beta.memory.database_path == str(
+        (tmp_path / "subject-data" / "cellin_beta.db").resolve()
+    )
+
+
+def test_storage_config_for_remote_backends_adds_subject_namespace_when_supported(
+    tmp_path: Path,
+) -> None:
+    registry = SubjectRegistry(
+        workspace_root=tmp_path,
+        storage_config=StorageConfig(
+            memory=StorageBackendConfig("mongodb", "mongodb://localhost:27017/cellin"),
+            graph=StorageBackendConfig("mongodb", "mongodb://localhost:27017/cellin"),
+            vector=StorageBackendConfig("pinecone", "https://example.pinecone.io/main"),
+            representation=StorageBackendConfig("qdrant", "http://localhost:6333?collection=main"),
+        ),
+    )
+
+    config = registry.storage_config_for("atlas")
+
+    assert config.memory.database_path == "mongodb://localhost:27017/cellin_atlas"
+    assert config.graph.database_path == "mongodb://localhost:27017/cellin_atlas"
+    assert config.vector.database_path == "https://example.pinecone.io/main?namespace=atlas"
+    assert config.representation.database_path == "http://localhost:6333?collection=cellin_atlas"
+
+
+def test_storage_config_for_duckdb_and_unscoped_backends(tmp_path: Path) -> None:
+    registry = SubjectRegistry(
+        workspace_root=tmp_path,
+        storage_config=StorageConfig(
+            memory=StorageBackendConfig("duckdb", "main.duckdb"),
+            graph=StorageBackendConfig("mongodb"),
+            vector=StorageBackendConfig("custom_vector", "custom://shared"),
+            representation=StorageBackendConfig("weaviate", "http://localhost:8080"),
+        ),
+    )
+
+    config = registry.storage_config_for("atlas")
+
+    assert config.memory.database_path == str((tmp_path / "data" / "cellin_atlas.duckdb").resolve())
+    assert config.graph == StorageBackendConfig("mongodb")
+    assert config.vector == StorageBackendConfig("custom_vector", "custom://shared")
+    assert config.representation.database_path == "http://localhost:8080?collection=cellin_atlas"
+
+
+def test_list_subjects_reports_isolated_counts_for_same_topic(tmp_path: Path) -> None:
+    registry = SubjectRegistry(workspace_root=tmp_path)
+    _ingest_topic(registry, "subject-a", artifact_id="a-1", topic="release-plan")
+
+    registry.get_or_create("subject-b")
+    summaries = {summary.subject_id: summary for summary in registry.list_subjects()}
+
+    assert summaries["subject-a"].memory_count == 1
+    assert summaries["subject-a"].edge_count == 0
+    assert summaries["subject-b"].memory_count == 0
+    assert summaries["subject-b"].edge_count == 0
+
+
+def test_subject_state_persists_across_registry_restart(tmp_path: Path) -> None:
+    first_registry = SubjectRegistry(workspace_root=tmp_path)
+    _ingest_topic(first_registry, "subject-a", artifact_id="a-1", topic="design-review")
+
+    second_registry = SubjectRegistry(workspace_root=tmp_path)
+    summary = second_registry.list_subjects()
+    bundle = second_registry.get_or_create("subject-a")
+
+    assert [item.subject_id for item in summary] == ["subject-a"]
+    assert len(bundle.memory_store.list()) == 1
+
+
+def test_delete_subject_requires_confirmation_and_removes_local_storage(tmp_path: Path) -> None:
+    registry = SubjectRegistry(workspace_root=tmp_path)
+    _ingest_topic(registry, "subject-a", artifact_id="a-1", topic="cleanup")
+    database_path = Path(registry.storage_config_for("subject-a").memory.database_path or "")
+
+    with pytest.raises(ValueError, match="confirm=True"):
+        registry.delete_subject("subject-a")
+
+    assert database_path.exists()
+    assert registry.delete_subject("subject-a", confirm=True) is True
+    assert not database_path.exists()
+    assert registry.list_subjects() == ()
+
+
+def test_subject_index_rejects_non_list_payload(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    (data_dir / "subjects.json").write_text('{"subject": "alpha"}', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="JSON array"):
+        SubjectRegistry(workspace_root=tmp_path)
+
+
+def test_delete_unknown_subject_returns_false_and_clears_cached_bundle(tmp_path: Path) -> None:
+    registry = SubjectRegistry(workspace_root=tmp_path)
+    cached_bundle = registry.get_or_create("orphan")
+    registry._known_subject_ids.remove("orphan")
+    registry._persist_known_subject_ids()
+
+    assert registry.delete_subject("orphan", confirm=True) is False
+    assert registry._bundles.get("orphan") is None
+    assert cached_bundle is not registry.get_or_create("orphan")
+
+
+def test_delete_subject_rejects_remote_backend_mix_without_local_paths(tmp_path: Path) -> None:
+    registry = SubjectRegistry(
+        workspace_root=tmp_path,
+        storage_config=StorageConfig(
+            memory=StorageBackendConfig("mongodb", "mongodb://localhost:27017/cellin"),
+            graph=StorageBackendConfig("mongodb", "mongodb://localhost:27017/cellin"),
+            vector=StorageBackendConfig("pinecone", "https://example.pinecone.io/main"),
+            representation=StorageBackendConfig("qdrant", "http://localhost:6333?collection=main"),
+        ),
+    )
+    registry._known_subject_ids.add("remote")
+    registry._persist_known_subject_ids()
+
+    with pytest.raises(NotImplementedError, match="remote backend mix"):
+        registry.delete_subject("remote", confirm=True)
+
+
+def test_delete_ephemeral_subject_reports_removed_without_files(tmp_path: Path) -> None:
+    registry = SubjectRegistry(
+        workspace_root=tmp_path,
+        storage_config=StorageConfig.with_in_memory_preset(),
+    )
+    registry._known_subject_ids.add("scratch")
+    registry._persist_known_subject_ids()
+
+    assert registry.delete_subject("scratch", confirm=True) is True
+    assert registry.list_subjects() == ()


### PR DESCRIPTION
Closes #175.

Adds isolated subject routing for MCP storage bundles, with SQLite path derivation, remote namespace rewriting, persistence, list/delete operations, and unit/integration coverage.