### PR TITLE
fix(dreaming): close trust, dedup, graph, and tokenize follow-ups

### DIFF
--- a/src/cellin/dreaming/strategies.py
+++ b/src/cellin/dreaming/strategies.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from collections.abc import Sequence
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from typing import cast
@@ -20,7 +21,7 @@ from cellin.core import (
 )
 from cellin.core.models import JSONValue
 from cellin.dreaming.models import DreamDiff, DreamEdgeChange, DreamMemoryChange, DreamRunResult
-from cellin.stores.vector_utils import _tokenize
+from cellin.stores.vector_utils import tokenize
 
 NEGATION_MARKERS = {
     "cancelled",
@@ -36,16 +37,16 @@ SUCCESS_MARKERS = {"completed", "green", "released", "shipped", "stable", "activ
 
 
 def _similarity(left: MemoryAtom, right: MemoryAtom) -> float:
-    left_tokens = set(_tokenize(left.text))
-    right_tokens = set(_tokenize(right.text))
+    left_tokens = tokenize(left.text)
+    right_tokens = tokenize(right.text)
     if not left_tokens or not right_tokens:
         return 0.0
     return len(left_tokens & right_tokens) / len(left_tokens | right_tokens)
 
 
 def _contains_conflict(left: MemoryAtom, right: MemoryAtom) -> bool:
-    left_tokens = set(_tokenize(left.text))
-    right_tokens = set(_tokenize(right.text))
+    left_tokens = tokenize(left.text)
+    right_tokens = tokenize(right.text)
     left_negative = bool(left_tokens & NEGATION_MARKERS)
     right_negative = bool(right_tokens & NEGATION_MARKERS)
     left_positive = bool(left_tokens & SUCCESS_MARKERS)
@@ -93,8 +94,12 @@ def _string_list(value: JSONValue) -> list[str]:
 
 
 def _group_active_memories_by_topic(memory_store: MemoryStore) -> dict[str, list[MemoryAtom]]:
+    return _group_memories_by_topic(memory_store.list_by(archived=False))
+
+
+def _group_memories_by_topic(memories: Sequence[MemoryAtom]) -> dict[str, list[MemoryAtom]]:
     topic_groups: dict[str, list[MemoryAtom]] = defaultdict(list)
-    for memory in memory_store.list_by(archived=False):
+    for memory in memories:
         topic = memory.metadata.get("topic")
         if isinstance(topic, str):
             topic_groups[topic].append(memory)
@@ -144,13 +149,23 @@ def _apply_memory_updates(
     before_after: tuple[tuple[MemoryAtom, MemoryAtom], ...],
 ) -> list[DreamMemoryChange]:
     changes: list[DreamMemoryChange] = []
+    should_upsert_graph_memory = _graph_requires_memory_upserts(
+        graph_store=graph_store,
+        memory_store=memory_store,
+    )
     for before, after in before_after:
         memory_store.put(after)
-        _shares = getattr(graph_store, "shares_memory_store", None)
-        if not callable(_shares) or not _shares(memory_store):
+        if should_upsert_graph_memory:
             graph_store.upsert_memory(after)
         changes.append(DreamMemoryChange(before.memory_id, before, after))
     return changes
+
+
+def _graph_requires_memory_upserts(*, graph_store: GraphStore, memory_store: MemoryStore) -> bool:
+    shares_memory_store = getattr(graph_store, "shares_memory_store", None)
+    if callable(shares_memory_store):
+        return not bool(shares_memory_store(memory_store))
+    return True
 
 
 @dataclass(slots=True)
@@ -180,10 +195,12 @@ class DeduplicationDreamStrategy:
     ) -> DreamRunResult | None:
         when = at or datetime.now(UTC)
         outcome = _MutationOutcome.empty()
-        topic_groups = _group_active_memories_by_topic(memory_store)
-        memory_index: dict[str, MemoryAtom] = {
-            m.memory_id: m for members in topic_groups.values() for m in members
-        }
+        active_memories = tuple(
+            memory for memory in memory_store.list() if not memory.decay.archived
+        )
+        topic_groups = _group_memories_by_topic(active_memories)
+        # Each pair resolves current state from this index in O(1) without extra store.get() I/O.
+        memory_index = {memory.memory_id: memory for memory in active_memories}
         for members in topic_groups.values():
             self._merge_topic_members(
                 members=members,

--- a/src/cellin/ranking/weighted.py
+++ b/src/cellin/ranking/weighted.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -10,17 +9,12 @@ from math import log1p
 
 from cellin.core import FactorScore, MemoryAtom, Modality, ScoredMemory
 from cellin.ranking.profiles import WeightProfile
-
-TOKEN_RE = re.compile(r"[a-z0-9]+")
-
-
-def _tokenize(text: str) -> set[str]:
-    return set(TOKEN_RE.findall(text.lower()))
+from cellin.stores.vector_utils import tokenize
 
 
 def _semantic_similarity(query: str, memory: MemoryAtom) -> float:
-    query_tokens = _tokenize(query)
-    memory_tokens = _tokenize(memory.text)
+    query_tokens = tokenize(query)
+    memory_tokens = tokenize(memory.text)
     if not query_tokens or not memory_tokens:
         return 0.0
 

--- a/src/cellin/retrieval/candidate_generation.py
+++ b/src/cellin/retrieval/candidate_generation.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 
 from cellin.core import GraphStore, MemoryAtom, MemoryEdge, MemoryStore, VectorStore
-from cellin.stores.vector_utils import _tokenize
+from cellin.stores.vector_utils import tokenize
 
 
 def _lexical_seed_score(query: str, memory: MemoryAtom) -> float:
-    query_tokens = set(_tokenize(query))
-    memory_tokens = set(_tokenize(memory.text))
+    query_tokens = tokenize(query)
+    memory_tokens = tokenize(memory.text)
     if not query_tokens or not memory_tokens:
         return 0.0
 

--- a/src/cellin/stores/graph_backends.py
+++ b/src/cellin/stores/graph_backends.py
@@ -7,7 +7,7 @@ from itertools import chain
 from typing import Protocol, cast
 from urllib.parse import quote, urlparse
 
-from cellin.core import GraphStore, MemoryAtom, MemoryEdge
+from cellin.core import GraphStore, MemoryAtom, MemoryEdge, MemoryStore
 from cellin.stores._graph_serialization import (
     dump_edge,
     dump_memory,
@@ -134,6 +134,11 @@ def _arangodb_key(value: str) -> str:
     return quote(value, safe="")
 
 
+def _backend_share_targets(memory_store: MemoryStore) -> tuple[object, object | None]:
+    memory_backend = getattr(memory_store, "_backend", None)
+    return (memory_store, memory_backend)
+
+
 class _CypherGraphBackend:
     """Shared Neo4j/Memgraph graph operations."""
 
@@ -156,6 +161,8 @@ class _CypherGraphBackend:
         if parsed.username is not None:
             auth = (parsed.username, parsed.password or "")
 
+        self._backend_url = uri
+        self._connection_identity = (uri, auth)
         self._driver = cast(_Neo4jDriver, GraphDatabase.driver(uri, auth=auth))
         self._ensure_schema()
 
@@ -206,6 +213,18 @@ class _CypherGraphBackend:
             if (edge := load_edge(cast(str, row["payload"]))) and not edge_is_archived(edge)
         )
 
+    def shares_memory_store(self, memory_store: MemoryStore) -> bool:
+        for target in _backend_share_targets(memory_store):
+            if target is self:
+                return True
+            if getattr(target, "_driver", None) is self._driver:
+                return True
+            if getattr(target, "_connection_identity", None) == self._connection_identity:
+                return True
+            if getattr(target, "_backend_url", None) == self._backend_url:
+                return True
+        return False
+
 
 class _ArangoGraphBackend:
     """ArangoDB graph operations using document and edge collections."""
@@ -228,6 +247,8 @@ class _ArangoGraphBackend:
                 password=connection.password,
             ),
         )
+        self._connection_info = connection
+        self._connection_identity = connection
         self._database = database
         self._ensure_collections()
         self._memory_collection = database.collection("cellin_memories")
@@ -352,6 +373,18 @@ class _ArangoGraphBackend:
                 edges.append(edge)
         return tuple(sorted(edges, key=lambda edge: edge.edge_id))
 
+    def shares_memory_store(self, memory_store: MemoryStore) -> bool:
+        for target in _backend_share_targets(memory_store):
+            if target is self:
+                return True
+            if getattr(target, "_database", None) is self._database:
+                return True
+            if getattr(target, "_connection_identity", None) == self._connection_identity:
+                return True
+            if getattr(target, "_connection_info", None) == self._connection_info:
+                return True
+        return False
+
 
 _NEO4J_BACKENDS: dict[str, _CypherGraphBackend] = {}
 _MEMGRAPH_BACKENDS: dict[str, _CypherGraphBackend] = {}
@@ -388,6 +421,7 @@ class _GraphBackend(Protocol):
     def get_memory(self, memory_id: str) -> MemoryAtom | None: ...
     def neighbors(self, memory_id: str) -> tuple[MemoryEdge, ...]: ...
     def list_edges(self) -> tuple[MemoryEdge, ...]: ...
+    def shares_memory_store(self, memory_store: MemoryStore) -> bool: ...
 
 
 class _BackendGraphStore(GraphStore):
@@ -408,6 +442,12 @@ class _BackendGraphStore(GraphStore):
     def upsert_edges(self, edges: tuple[MemoryEdge, ...]) -> None:
         for edge in edges:
             self._backend.upsert_edge(edge)
+
+    def shares_memory_store(self, memory_store: MemoryStore) -> bool:
+        shares_memory_store = getattr(self._backend, "shares_memory_store", None)
+        if callable(shares_memory_store):
+            return bool(shares_memory_store(memory_store))
+        return getattr(memory_store, "_backend", None) is self._backend
 
     def get_memory(self, memory_id: str) -> MemoryAtom | None:
         return self._backend.get_memory(memory_id)

--- a/src/cellin/stores/vector_utils.py
+++ b/src/cellin/stores/vector_utils.py
@@ -10,13 +10,18 @@ TOKEN_RE = re.compile(r"[a-z0-9]+")
 VECTOR_SIZE = 12
 
 
-def _tokenize(text: str) -> list[str]:
-    return TOKEN_RE.findall(text.lower())
+def tokenize(text: str) -> frozenset[str]:
+    """Return canonical lowercase token set semantics for lexical matching."""
+
+    return frozenset(TOKEN_RE.findall(text.lower()))
+
+
+_tokenize = tokenize
 
 
 def vectorize(text: str) -> tuple[float, ...]:
     buckets = [0.0] * VECTOR_SIZE
-    for token in _tokenize(text):
+    for token in sorted(tokenize(text)):
         digest = hashlib.sha256(token.encode("utf-8")).digest()
         bucket_index = int.from_bytes(digest[:4], byteorder="big") % VECTOR_SIZE
         buckets[bucket_index] += 1.0

--- a/tests/integration/dreaming/test_strategy_edge_cases.py
+++ b/tests/integration/dreaming/test_strategy_edge_cases.py
@@ -163,6 +163,40 @@ def test_deduplication_skips_members_archived_earlier_in_same_run() -> None:
     assert outcome.pairs == [("duplicate", "canonical")]
 
 
+def test_deduplication_uses_prebuilt_index_without_store_gets() -> None:
+    now = datetime(2026, 4, 5, tzinfo=UTC)
+    canonical = _memory("canonical", "atlas alpha beta", topic="atlas", observed_at=now, trust=1.0)
+    duplicate = _memory("duplicate", "atlas alpha beta", topic="atlas", observed_at=now, trust=0.9)
+
+    class _CountingMemoryStore(InMemoryMemoryStore):
+        def __init__(self, memories: tuple[MemoryAtom, ...]) -> None:
+            super().__init__(memories)
+            self.get_calls = 0
+            self.list_calls = 0
+
+        def get(self, memory_id: str) -> MemoryAtom | None:
+            self.get_calls += 1
+            return super().get(memory_id)
+
+        def list(self) -> tuple[MemoryAtom, ...]:
+            self.list_calls += 1
+            return super().list()
+
+    memory_store = _CountingMemoryStore((canonical, duplicate))
+    graph_store = InMemoryGraphStore((canonical, duplicate))
+
+    result = DeduplicationDreamStrategy(similarity_threshold=0.5).execute(
+        graph_store,
+        memory_store,
+        at=now,
+    )
+
+    assert result is not None
+    assert memory_store.list_calls == 1
+    # Pair resolution stays O(1) via the prebuilt memory_index instead of store.get() I/O.
+    assert memory_store.get_calls == 0
+
+
 def test_contradiction_repair_skips_non_conflicts_and_existing_edges() -> None:
     now = datetime(2026, 4, 5, tzinfo=UTC)
     strategy = ContradictionRepairDreamStrategy()
@@ -260,6 +294,99 @@ def test_contradiction_repair_iterates_only_forward_unique_pairs() -> None:
     )
 
     assert calls == [("first", "second"), ("first", "third"), ("second", "third")]
+
+
+def test_contradiction_repair_applies_cumulative_decay_and_diff_snapshots() -> None:
+    now = datetime(2026, 4, 5, tzinfo=UTC)
+    older = _memory(
+        "atlas-green",
+        "Atlas rollout is green and stable in staging.",
+        topic="atlas-rollout",
+        observed_at=now,
+        trust=0.9,
+    )
+    newer_first = _memory(
+        "atlas-rollback",
+        "Atlas rollout was rolled back after failures in staging.",
+        topic="atlas-rollout",
+        observed_at=now.replace(day=6),
+        trust=0.9,
+    )
+    newer_second = _memory(
+        "atlas-disabled",
+        "Atlas rollout is not active in staging.",
+        topic="atlas-rollout",
+        observed_at=now.replace(day=7),
+        trust=0.9,
+    )
+    memory_store = InMemoryMemoryStore((older, newer_first, newer_second))
+    graph_store = InMemoryGraphStore((older, newer_first, newer_second))
+
+    result = ContradictionRepairDreamStrategy().execute(graph_store, memory_store, at=now)
+
+    assert result is not None
+    repaired_older = memory_store.get("atlas-green")
+    assert repaired_older is not None
+    assert repaired_older.trust_score == pytest.approx(0.4)
+
+    older_changes = [
+        change for change in result.diff.memory_changes if change.memory_id == older.memory_id
+    ]
+    assert len(older_changes) == 2
+    assert older_changes[0].before is not None
+    assert older_changes[0].after is not None
+    assert older_changes[0].before.trust_score == pytest.approx(0.9)
+    assert older_changes[0].after.trust_score == pytest.approx(0.65)
+    assert older_changes[1].before is not None
+    assert older_changes[1].after is not None
+    assert older_changes[1].before.trust_score == pytest.approx(0.65)
+    assert older_changes[1].after.trust_score == pytest.approx(0.4)
+
+
+@pytest.mark.parametrize(
+    ("shared_backend", "expected_graph_memory_upserts"),
+    [(True, 0), (False, 2)],
+)
+def test_contradiction_repair_respects_shared_graph_memory_backends(
+    shared_backend: bool,
+    expected_graph_memory_upserts: int,
+) -> None:
+    now = datetime(2026, 4, 5, tzinfo=UTC)
+    older = _memory(
+        "atlas-green",
+        "Atlas rollout is green and stable in staging.",
+        topic="atlas-rollout",
+        observed_at=now,
+    )
+    newer = _memory(
+        "atlas-rollback",
+        "Atlas rollout was rolled back after failures in staging.",
+        topic="atlas-rollout",
+        observed_at=now.replace(day=6),
+    )
+
+    class _CountingGraphStore(InMemoryGraphStore):
+        def __init__(self, memories: tuple[MemoryAtom, ...], *, shared: bool) -> None:
+            self.memory_upserts = 0
+            self._shared = shared
+            super().__init__(memories)
+            self.memory_upserts = 0
+
+        def shares_memory_store(self, memory_store: MemoryStore) -> bool:
+            del memory_store
+            return self._shared
+
+        def upsert_memory(self, memory: MemoryAtom) -> None:
+            self.memory_upserts += 1
+            super().upsert_memory(memory)
+
+    memory_store = InMemoryMemoryStore((older, newer))
+    graph_store = _CountingGraphStore((older, newer), shared=shared_backend)
+
+    result = ContradictionRepairDreamStrategy().execute(graph_store, memory_store, at=now)
+
+    assert result is not None
+    assert graph_store.memory_upserts == expected_graph_memory_upserts
 
 
 def test_abstraction_returns_none_when_topics_do_not_qualify() -> None:

--- a/tests/integration/ingest/test_pipeline.py
+++ b/tests/integration/ingest/test_pipeline.py
@@ -7,7 +7,7 @@ import sqlite3
 from datetime import UTC, datetime
 from urllib.parse import quote
 
-from cellin.core import Modality
+from cellin.core import Artifact, MemoryAtom, MemoryEdge, Modality, Provenance
 from cellin.ingest import ArtifactEnvelope, CanonicalIngestor
 from cellin.stores import InMemoryVectorIndex, SQLiteGraphStore, SQLiteMemoryStore
 from cellin.stores import sqlite as sqlite_module
@@ -43,6 +43,18 @@ def _build_envelope(
         payload=envelope_id,
         source_id=f"source-{envelope_id}",
         source_type="fixture",
+        observed_at=observed_at,
+        metadata={"topic": topic},
+    )
+
+
+def _artifact(artifact_id: str, *, observed_at: datetime, topic: str) -> Artifact:
+    return Artifact(
+        artifact_id=artifact_id,
+        modality=Modality.TEXT,
+        content=f"{artifact_id} content",
+        provenance=Provenance(source_id=artifact_id, source_type="fixture"),
+        created_at=observed_at,
         observed_at=observed_at,
         metadata={"topic": topic},
     )
@@ -139,3 +151,88 @@ def test_ingestion_pipeline_uses_collision_safe_sqlite_edge_ids(tmp_path) -> Non
         f"supports:{quote('a:b', safe='')}:{quote('c', safe='')}",
         f"supports:{quote('a', safe='')}:{quote('b:c', safe='')}",
     }
+
+
+def test_ingestion_pipeline_avoids_duplicate_graph_memory_writes_for_shared_backends() -> None:
+    now = datetime(2026, 4, 5, tzinfo=UTC)
+
+    class _CountingMemoryStore:
+        def __init__(self) -> None:
+            self._memories: dict[str, MemoryAtom] = {}
+            self.put_many_calls = 0
+
+        def put(self, memory: MemoryAtom) -> None:
+            self.put_many((memory,))
+
+        def put_many(self, memories: tuple[MemoryAtom, ...]) -> None:
+            self.put_many_calls += 1
+            for memory in memories:
+                self._memories[memory.memory_id] = memory
+
+        def get(self, memory_id: str) -> MemoryAtom | None:
+            return self._memories.get(memory_id)
+
+        def list(self) -> tuple[MemoryAtom, ...]:
+            return tuple(self._memories.values())
+
+    class _CountingGraphStore:
+        def __init__(self, *, shared: bool) -> None:
+            self._shared = shared
+            self.memory_upsert_calls = 0
+
+        def upsert_memory(self, memory: MemoryAtom) -> None:
+            del memory
+            self.memory_upsert_calls += 1
+
+        def upsert_memories(self, memories: tuple[MemoryAtom, ...]) -> None:
+            self.memory_upsert_calls += len(memories)
+
+        def upsert_edge(self, edge: MemoryEdge) -> None:
+            del edge
+
+        def upsert_edges(self, edges: tuple[MemoryEdge, ...]) -> None:
+            del edges
+
+        def get_memory(self, memory_id: str) -> MemoryAtom | None:
+            del memory_id
+            return None
+
+        def neighbors(self, memory_id: str) -> tuple[MemoryEdge, ...]:
+            del memory_id
+            return ()
+
+        def list_edges(self) -> tuple[MemoryEdge, ...]:
+            return ()
+
+        def shares_memory_store(self, memory_store: _CountingMemoryStore) -> bool:
+            del memory_store
+            return self._shared
+
+    shared_memory_store = _CountingMemoryStore()
+    shared_graph_store = _CountingGraphStore(shared=True)
+    separate_memory_store = _CountingMemoryStore()
+    separate_graph_store = _CountingGraphStore(shared=False)
+    shared_ingestor = CanonicalIngestor.with_built_in_adapters(
+        graph_store=shared_graph_store,
+        memory_store=shared_memory_store,
+        vector_store=InMemoryVectorIndex(),
+    )
+    separate_ingestor = CanonicalIngestor.with_built_in_adapters(
+        graph_store=separate_graph_store,
+        memory_store=separate_memory_store,
+        vector_store=InMemoryVectorIndex(),
+    )
+    artifacts = (
+        _artifact("atlas-1", observed_at=now, topic="atlas"),
+        _artifact("atlas-2", observed_at=now, topic="atlas"),
+    )
+
+    shared_memories = shared_ingestor.ingest(artifacts)
+    separate_memories = separate_ingestor.ingest(artifacts)
+
+    assert len(shared_memories) == 2
+    assert len(separate_memories) == 2
+    assert shared_memory_store.put_many_calls == 1
+    assert separate_memory_store.put_many_calls == 1
+    assert shared_graph_store.memory_upsert_calls == 0
+    assert separate_graph_store.memory_upsert_calls == 2

--- a/tests/integration/stores/test_graph_backends.py
+++ b/tests/integration/stores/test_graph_backends.py
@@ -273,6 +273,86 @@ def test_graph_native_backends_filter_archived_edges_and_share_state(
     assert graph_store.list_edges() == (active,)
 
 
+@pytest.mark.parametrize(
+    "graph_cls,connection_string,install_backend,clear_backends",
+    [
+        (
+            Neo4jGraphStore,
+            "bolt://neo4j:test@localhost:7687",
+            _install_fake_neo4j,
+            graph_backends._NEO4J_BACKENDS.clear,
+        ),
+        (
+            MemgraphGraphStore,
+            "bolt://memgraph:test@localhost:7687",
+            _install_fake_neo4j,
+            graph_backends._MEMGRAPH_BACKENDS.clear,
+        ),
+        (
+            ArangoDBGraphStore,
+            "arangodb://root:test@localhost:8529/cellin",
+            _install_fake_arango,
+            graph_backends._ARANGO_BACKENDS.clear,
+        ),
+    ],
+)
+def test_graph_native_backends_detect_shared_memory_store_identity(
+    graph_cls: type,
+    connection_string: str,
+    install_backend: Callable[[pytest.MonkeyPatch], None],
+    clear_backends: Callable[[], None],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clear_backends()
+    install_backend(monkeypatch)
+
+    graph_store = graph_cls(connection_string)
+    backend = graph_store._backend
+
+    if isinstance(graph_store, ArangoDBGraphStore):
+        shared_memory_store = type(
+            "_SharedArangoMemoryStore",
+            (),
+            {
+                "_database": backend._database,
+                "_connection_info": backend._connection_info,
+            },
+        )()
+        separate_memory_store = type(
+            "_SeparateArangoMemoryStore",
+            (),
+            {
+                "_database": object(),
+                "_connection_info": graph_backends._ArangoConnectionInfo(
+                    "https://other:8529",
+                    "other",
+                    "root",
+                    "test",
+                ),
+            },
+        )()
+    else:
+        shared_memory_store = type(
+            "_SharedCypherMemoryStore",
+            (),
+            {
+                "_driver": backend._driver,
+                "_backend_url": backend._backend_url,
+            },
+        )()
+        separate_memory_store = type(
+            "_SeparateCypherMemoryStore",
+            (),
+            {
+                "_driver": object(),
+                "_backend_url": "bolt://other:7687",
+            },
+        )()
+
+    assert graph_store.shares_memory_store(shared_memory_store)
+    assert not graph_store.shares_memory_store(separate_memory_store)
+
+
 def test_arangodb_backend_encodes_memory_ids_in_document_handles(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_graph_backends_unit.py
+++ b/tests/unit/test_graph_backends_unit.py
@@ -136,6 +136,85 @@ def test_neo4j_and_memgraph_are_cypher_wrapper_instances() -> None:
     assert issubclass(MemgraphGraphStore, _CypherGraphStoreWrapper)
 
 
+def test_backend_share_targets_include_wrapped_backend() -> None:
+    backend = object()
+    memory_store = type("WrappedMemoryStore", (), {"_backend": backend})()
+    plain_memory_store = object()
+
+    assert graph_backends._backend_share_targets(memory_store) == (memory_store, backend)
+    assert graph_backends._backend_share_targets(plain_memory_store) == (
+        plain_memory_store,
+        None,
+    )
+
+
+def test_optional_payload_rejects_non_string_payloads() -> None:
+    assert graph_backends._load_optional_payload(None) is None
+    with pytest.raises(TypeError, match="payloads must be strings"):
+        graph_backends._load_optional_payload({"memory": "bad"})
+
+
+def test_cypher_backend_detects_shared_memory_store_identity() -> None:
+    backend = object.__new__(graph_backends._CypherGraphBackend)
+    backend._driver = object()
+    backend._connection_identity = ("bolt://localhost:7687", None)
+    backend._backend_url = "bolt://localhost:7687"
+
+    same_backend_store = backend
+    same_driver = type("MemoryStore", (), {"_backend": type("Backend", (), {})()})()
+    same_driver._backend._driver = backend._driver
+    same_identity = type(
+        "MemoryStore",
+        (),
+        {"_connection_identity": backend._connection_identity},
+    )()
+    same_url = type("MemoryStore", (), {"_backend_url": backend._backend_url})()
+
+    assert backend.shares_memory_store(same_backend_store) is True
+    assert backend.shares_memory_store(same_driver) is True
+    assert backend.shares_memory_store(same_identity) is True
+    assert backend.shares_memory_store(same_url) is True
+    assert backend.shares_memory_store(object()) is False
+
+
+def test_arango_backend_detects_shared_memory_store_identity() -> None:
+    backend = object.__new__(graph_backends._ArangoGraphBackend)
+    backend._database = object()
+    backend._connection_identity = ("http://localhost:8529", "cellin", "root")
+    backend._connection_info = graph_backends._ArangoConnectionInfo(
+        "http://localhost:8529",
+        "cellin",
+        "root",
+        "placeholder",
+    )
+
+    same_backend_store = backend
+    same_database = type("MemoryStore", (), {"_backend": type("Backend", (), {})()})()
+    same_database._backend._database = backend._database
+    same_identity = type(
+        "MemoryStore",
+        (),
+        {"_connection_identity": backend._connection_identity},
+    )()
+    same_info = type("MemoryStore", (), {"_connection_info": backend._connection_info})()
+
+    assert backend.shares_memory_store(same_backend_store) is True
+    assert backend.shares_memory_store(same_database) is True
+    assert backend.shares_memory_store(same_identity) is True
+    assert backend.shares_memory_store(same_info) is True
+    assert backend.shares_memory_store(object()) is False
+
+
+def test_backend_graph_store_falls_back_to_backend_identity() -> None:
+    backend = object()
+    store = object.__new__(graph_backends._BackendGraphStore)
+    store._backend = backend
+    matching_memory_store = type("MemoryStore", (), {"_backend": backend})()
+
+    assert store.shares_memory_store(matching_memory_store) is True
+    assert store.shares_memory_store(object()) is False
+
+
 def test_load_edge_rejects_invalid_provenance_metadata_shape() -> None:
     edge = MemoryEdge(
         edge_id="edge-1",


### PR DESCRIPTION
Closes #149.
Closes #152.
Closes #155.
Closes #156.

Adds the missing regression coverage and implementation refinements for trust-score decay, deduplication pair indexing, graph-native memory sharing, and centralized tokenization.