### PR TITLE
docs(features): document flags and graduation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,33 @@ Generated artifacts such as `eval-results/`, `dist/`, `site/`, and `coverage.jso
 7. Run `make release-smoke` before pushing.
 8. Open a draft PR until the stream is ready for review.
 
+## Feature Gating
+
+New work must be feature-gated when it changes user-visible behavior, introduces
+risky strategy behavior, exposes an incomplete workflow, changes storage or
+release semantics, or adds a preview capability that needs validation before it
+is stable.
+
+Allocate new feature codes with:
+
+```bash
+make feature-flag NAME=<feature-name>
+```
+
+Codes use the immutable `CELN-FEAT-NNNN` format. Users activate features by
+name with `--enable-feature`, `--disable-feature`, or the `cellin.json`
+`features.enable` and `features.disable` keys. Maintainers use codes in
+`features.release.lock.json`.
+
+Feature PR merge is not graduation. Graduation requires a separate reviewed PR
+with tests, docs, compatibility notes, rollback notes, and release-lock review.
+Stable artifacts ship preview code with preview flags off by default unless a
+reviewed release lock enables them for that release. Rolling builds enable all
+registered flags.
+
+See `docs/maintainer/feature-flags.md` for registry rules, release-lock review,
+and graduation criteria.
+
 ## Quality Gates
 
 Canonical commands:

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,85 @@
+# Feature Flags
+
+Cellin uses feature flags when a capability is useful to test but not ready to
+be treated as stable behavior in every artifact.
+
+## Lifecycle States
+
+Feature defaults depend on both the feature lifecycle and the release channel.
+
+| Lifecycle | Meaning | Stable release default | Rolling build default |
+| --- | --- | --- | --- |
+| `preview` | Available for opt-in validation, still allowed to change | Disabled unless a reviewed release lock enables it | Enabled |
+| `stable` | Supported behavior and compatibility expectations apply | Enabled | Enabled |
+| `done` | Completed rollout kept in the registry for history | Enabled | Enabled |
+
+Stable artifacts ship preview feature code so users can opt in without a
+separate package. The code is left off by default unless the source-controlled
+release lock enables that feature for a specific release.
+
+Rolling builds set `CELLIN_RELEASE_CHANNEL=rolling`, so all registered flags are
+enabled by default. Use rolling builds to validate preview behavior before it is
+graduated.
+
+## Listing Flags
+
+Use the CLI to inspect registered features and their current default state:
+
+```bash
+cellin features list
+cellin features list --format json
+```
+
+The `CODE` column is the immutable maintainer-facing identifier. The `NAME`
+column is the activation name used by CLI flags and workspace config.
+
+## Opting In
+
+Enable preview features with the global CLI flag before the subcommand:
+
+```bash
+cellin --enable-feature preview-search retrieve \
+  --config ./cellin.json \
+  --query "memory graph retrieval"
+```
+
+Disable a feature for troubleshooting the same way:
+
+```bash
+cellin --disable-feature preview-search ingest \
+  --config ./cellin.json \
+  --input ./seed_envelopes.json
+```
+
+For repeatable workspace behavior, use the `features` key in `cellin.json`:
+
+```json
+{
+  "features": {
+    "enable": ["preview-search"],
+    "disable": ["experimental-ranker"]
+  }
+}
+```
+
+Command-line settings override workspace settings for that invocation. A feature
+name cannot appear in both `enable` and `disable`.
+
+## Release Locks
+
+Stable release PRs include a reviewed `features.release.lock.json` file. It can
+temporarily enable preview features by immutable code:
+
+```json
+{ "release": "v0.5.0", "defaultOn": ["CELN-FEAT-0001"], "notes": { "CELN-FEAT-0001": "Required for the release smoke path." } }
+```
+
+Release locks are source-controlled and reviewed. CI validates that locked codes
+exist and still point to preview features. The lock is ignored by rolling builds.
+
+## Graduation
+
+Merging a feature PR is not graduation. A preview feature graduates only through
+a separate reviewed source change that updates the registry lifecycle after the
+feature has tests, docs, compatibility notes, and rollback notes.
+

--- a/docs/maintainer/feature-flags.md
+++ b/docs/maintainer/feature-flags.md
@@ -1,0 +1,112 @@
+# Feature Flag Maintenance
+
+Feature flags protect users from incomplete or risky behavior while still
+allowing maintainers to ship preview code for real validation.
+
+## When to Gate Work
+
+Gate new work when it changes user-visible behavior, introduces a risky dream or
+retrieval strategy, exposes an incomplete workflow, changes storage or release
+semantics, or adds a preview capability that needs feedback before becoming
+stable.
+
+Small internal refactors and regression fixes usually do not need a new flag
+unless they intentionally alter behavior.
+
+## Allocating Codes
+
+Every feature has an immutable `CELN-FEAT-NNNN` code and a human-readable
+activation name. Allocate the next code with:
+
+```bash
+make feature-flag NAME=preview-search
+```
+
+The target calls:
+
+```bash
+uv run python scripts/add_feature_flag.py --name preview-search
+```
+
+The helper appends a preview entry to `src/cellin/features/registry.py`, using
+the next sequential code such as `CELN-FEAT-0001`. Edit the generated
+description before review if the default text is not clear enough.
+
+Run the registry validator after editing:
+
+```bash
+make feature-registry-check
+```
+
+Registry rules:
+
+- Codes are never reused or renamed.
+- Active `preview` and `stable` feature names must be unique.
+- `done` entries stay in the registry for history and release reporting.
+- Lifecycle values are `preview`, `stable`, and `done`.
+
+## Activation Surfaces
+
+Users activate by feature name:
+
+```bash
+cellin --enable-feature preview-search retrieve --config ./cellin.json --query "atlas"
+```
+
+Workspace config uses the same names:
+
+```json
+{
+  "features": {
+    "enable": ["preview-search"],
+    "disable": []
+  }
+}
+```
+
+Release locks use immutable codes:
+
+```json
+{
+  "release": "v0.5.0",
+  "defaultOn": ["CELN-FEAT-0001"],
+  "notes": {
+    "CELN-FEAT-0001": "Default-on for the stable release smoke path."
+  }
+}
+```
+
+## Release Lock Review
+
+`features.release.lock.json` is reviewed source, not generated state. CI
+validates it on every PR and rejects unknown codes, duplicate codes, unknown
+top-level keys, and attempts to default-on non-preview features.
+
+Release PR automation appends a feature flag report that separates:
+
+- Stable by default
+- Preview available by opt-in
+- Preview locked default-on for this release
+- Newly added preview flags since the previous release
+
+Maintainers decide whether any preview feature should be locked on for a stable
+release. Rolling builds ignore the release lock and enable all registered flags.
+
+## Graduation Criteria
+
+Feature PR merge is not graduation. Keep new flags in `preview` until a separate
+reviewed graduation PR proves the behavior is ready.
+
+Before changing a feature to `stable` or `done`, the graduation PR must include:
+
+- Tests that cover the stable behavior and failure modes
+- User-facing docs or examples for the behavior
+- Compatibility notes for existing configs, data, CLI output, and APIs
+- Rollback notes that explain how to disable or revert the behavior
+- Confirmation that no release lock is carrying the feature as a temporary
+  default-on exception
+
+Use `stable` when the flag still describes supported runtime behavior. Use
+`done` when the rollout is complete and the flag no longer needs user-facing
+activation, but the code should remain available for history and reports.
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,5 +7,8 @@ theme:
 
 nav:
   - Home: index.md
+  - Feature Flags: features.md
   - Architecture: architecture/README.md
   - Evals: evals/README.md
+  - Maintainers:
+      - Feature Flags: maintainer/feature-flags.md


### PR DESCRIPTION
## Summary
- add feature flag user-facing and maintainer docs
- document lifecycle, activation, release reporting, and graduation workflow
- wire the new pages into MkDocs and contribution guidance

## Validation
- `uv run --python 3.12 mkdocs build --strict`
- `uv run --python 3.12 python scripts/check_feature_registry.py`
- `uv run --python 3.12 python scripts/generate_feature_report.py --channel release --lock features.release.lock.json`

Closes #187