### PR TITLE
feat(mcp): add Docker packaging

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.mypy_cache
+.pytest_cache
+.ruff_cache
+.venv
+__pycache__
+*.py[cod]
+build
+coverage.json
+dist
+eval-results
+site
+

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -84,6 +84,20 @@ jobs:
           name: package-smoke-dist
           path: dist/*
 
+  docker-mcp:
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build MCP Docker image
+        run: docker build -t cellin-mcp:ci .
+
+      - name: Run MCP startup check
+        run: docker run --rm cellin-mcp:ci --check
+
   storage-defaults:
     if: github.event_name == 'pull_request' || github.event_name == 'push'
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    CELLIN_BACKEND=sqlite \
+    CELLIN_DATA_DIR=/data
+
+WORKDIR /app
+
+COPY pyproject.toml README.md LICENSE ./
+COPY src ./src
+
+RUN python -m pip install --no-cache-dir --upgrade pip \
+    && python -m pip install --no-cache-dir ".[mcp,postgresql,neo4j]" \
+    && useradd --create-home --uid 10001 cellin \
+    && mkdir -p /data \
+    && chown -R cellin:cellin /data
+
+USER cellin
+
+ENTRYPOINT ["cellin", "mcp", "serve"]
+

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,11 @@ UV ?= python3 -m uv
 TAG ?=
 EXPECT_VERSION ?=
 RELEASE_KIND ?= any
+DOCKER_IMAGE ?= cellin-mcp:latest
+CELLIN_BACKEND ?= sqlite
+CELLIN_DATA_DIR ?= /data
 
-.PHONY: bootstrap hooks fmt fmt-check lint typecheck test coverage eval-smoke eval-full eval package package-smoke version-check release-smoke verify ci docs feature-flag feature-registry-check
+.PHONY: bootstrap hooks fmt fmt-check lint typecheck test coverage eval-smoke eval-full eval package package-smoke version-check release-smoke verify ci docs feature-flag feature-registry-check docker-build docker-run
 
 bootstrap:
 	$(UV) sync --dev
@@ -18,6 +21,17 @@ feature-flag:
 
 feature-registry-check:
 	$(UV) run python scripts/check_feature_registry.py
+
+docker-build:
+	docker build -t $(DOCKER_IMAGE) .
+
+docker-run:
+	docker run -i --rm \
+		-v cellin-data:/data \
+		-e CELLIN_BACKEND=$(CELLIN_BACKEND) \
+		-e CELLIN_DATA_DIR=$(CELLIN_DATA_DIR) \
+		$(if $(CELLIN_CONNECTION_STRING),-e CELLIN_CONNECTION_STRING="$(CELLIN_CONNECTION_STRING)",) \
+		$(DOCKER_IMAGE)
 
 fmt:
 	$(UV) run ruff format src tests docs scripts

--- a/README.md
+++ b/README.md
@@ -22,6 +22,77 @@ Install from [PyPI](https://pypi.org/project/cellin/):
 python3 -m pip install cellin
 ```
 
+## Run as MCP server
+
+Cellin can run as an MCP stdio server for clients such as Claude Desktop and
+Cursor:
+
+```bash
+python3 -m pip install "cellin[mcp]"
+cellin mcp serve --check
+cellin mcp serve
+```
+
+The Docker image starts the same stdio server by default:
+
+```bash
+make docker-build
+docker run -i --rm -v cellin-data:/data cellin-mcp:latest
+```
+
+Environment variables select packaged storage presets:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `CELLIN_BACKEND` | `sqlite` | `sqlite`, `postgres`, `neo4j`, or `in_memory` |
+| `CELLIN_DATA_DIR` | `/data` | SQLite subject database and subject index directory |
+| `CELLIN_CONNECTION_STRING` | unset | PostgreSQL DSN or Neo4j bolt URL for remote presets |
+
+For PostgreSQL:
+
+```bash
+docker run -i --rm \
+  -e CELLIN_BACKEND=postgres \
+  -e CELLIN_CONNECTION_STRING="$CELLIN_POSTGRES_DSN" \
+  cellin-mcp:latest
+```
+
+For Neo4j:
+
+```bash
+docker run -i --rm \
+  -v cellin-data:/data \
+  -e CELLIN_BACKEND=neo4j \
+  -e CELLIN_CONNECTION_STRING="$CELLIN_NEO4J_URI" \
+  cellin-mcp:latest
+```
+
+`docker-compose.yml` includes a single-container SQLite service and profiled
+PostgreSQL and Neo4j variants:
+
+```bash
+docker compose up --build cellin-sqlite
+CELLIN_POSTGRES_PASSWORD="$CELLIN_POSTGRES_PASSWORD" \
+CELLIN_POSTGRES_DSN="$CELLIN_POSTGRES_DSN" \
+  docker compose --profile postgres up --build cellin-postgres
+CELLIN_NEO4J_AUTH="$CELLIN_NEO4J_AUTH" \
+CELLIN_NEO4J_URI="$CELLIN_NEO4J_URI" \
+  docker compose --profile neo4j up --build cellin-neo4j
+```
+
+Claude Desktop configuration:
+
+```json
+{
+  "mcpServers": {
+    "cellin": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "-v", "cellin-data:/data", "cellin-mcp:latest"]
+    }
+  }
+}
+```
+
 ## Quickstart
 
 From the repository root:
@@ -97,13 +168,13 @@ Use `postgresql` and `mysql` with connection strings:
 
 ```json
 {
-  "memory": { "backend": "postgresql", "database_path": "postgresql://user:pass@host:5432/db" },
-  "graph": { "backend": "postgresql", "database_path": "postgresql://user:pass@host:5432/db" }
+  "memory": { "backend": "postgresql", "database_path": "postgresql://db.example.invalid:5432/db" },
+  "graph": { "backend": "postgresql", "database_path": "postgresql://db.example.invalid:5432/db" }
 }
 
 {
-  "memory": { "backend": "mysql", "database_path": "mysql://user:pass@host:3306/db" },
-  "graph": { "backend": "mysql", "database_path": "mysql://user:pass@host:3306/db" }
+  "memory": { "backend": "mysql", "database_path": "mysql://db.example.invalid:3306/db" },
+  "graph": { "backend": "mysql", "database_path": "mysql://db.example.invalid:3306/db" }
 }
 ```
 
@@ -119,8 +190,8 @@ Use `mongodb` when you want durable document storage for both memories and edges
 
 ```json
 {
-  "memory": { "backend": "mongodb", "database_path": "mongodb://user:pass@host:27017/cellin" },
-  "graph": { "backend": "mongodb", "database_path": "mongodb://user:pass@host:27017/cellin" }
+  "memory": { "backend": "mongodb", "database_path": "mongodb://db.example.invalid:27017/cellin" },
+  "graph": { "backend": "mongodb", "database_path": "mongodb://db.example.invalid:27017/cellin" }
 }
 ```
 
@@ -152,7 +223,7 @@ you prefer:
 ```json
 {
   "memory": { "backend": "sqlite", "database_path": "cellin.sqlite" },
-  "graph": { "backend": "neo4j", "database_path": "bolt://user:pass@host:7687" }
+  "graph": { "backend": "neo4j", "database_path": "bolt://graph.example.invalid:7687" }
 }
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,59 @@
+services:
+  cellin-sqlite:
+    build: .
+    image: cellin-mcp:latest
+    stdin_open: true
+    environment:
+      CELLIN_BACKEND: sqlite
+      CELLIN_DATA_DIR: /data
+    volumes:
+      - cellin-data:/data
+
+  postgres:
+    image: postgres:16-alpine
+    profiles: ["postgres"]
+    environment:
+      POSTGRES_DB: cellin
+      POSTGRES_USER: cellin
+      POSTGRES_PASSWORD: "${CELLIN_POSTGRES_PASSWORD:?Set CELLIN_POSTGRES_PASSWORD}"
+    volumes:
+      - cellin-postgres:/var/lib/postgresql/data
+
+  cellin-postgres:
+    image: cellin-mcp:latest
+    profiles: ["postgres"]
+    stdin_open: true
+    depends_on:
+      - postgres
+    environment:
+      CELLIN_BACKEND: postgres
+      CELLIN_DATA_DIR: /data
+      CELLIN_CONNECTION_STRING: "${CELLIN_POSTGRES_DSN:?Set CELLIN_POSTGRES_DSN}"
+    volumes:
+      - cellin-data:/data
+
+  neo4j:
+    image: neo4j:5-community
+    profiles: ["neo4j"]
+    environment:
+      NEO4J_AUTH: "${CELLIN_NEO4J_AUTH:?Set CELLIN_NEO4J_AUTH}"
+    volumes:
+      - cellin-neo4j:/data
+
+  cellin-neo4j:
+    image: cellin-mcp:latest
+    profiles: ["neo4j"]
+    stdin_open: true
+    depends_on:
+      - neo4j
+    environment:
+      CELLIN_BACKEND: neo4j
+      CELLIN_DATA_DIR: /data
+      CELLIN_CONNECTION_STRING: "${CELLIN_NEO4J_URI:?Set CELLIN_NEO4J_URI}"
+    volumes:
+      - cellin-data:/data
+
+volumes:
+  cellin-data:
+  cellin-postgres:
+  cellin-neo4j:

--- a/src/cellin/cli/app.py
+++ b/src/cellin/cli/app.py
@@ -27,6 +27,7 @@ from cellin.dreaming.models import DreamDiff
 from cellin.evals import run_evaluation_suite
 from cellin.features import REGISTRY, ReleaseChannel, resolve_features
 from cellin.ingest import ArtifactEnvelope, CanonicalIngestor
+from cellin.mcp.config import storage_config_from_env
 from cellin.mcp.server import serve_stdio, startup_check
 from cellin.mcp.subjects import SubjectRegistry
 from cellin.ranking import WeightedRanker, get_weight_profile
@@ -473,6 +474,7 @@ def _mcp_subject_registry(args: argparse.Namespace) -> SubjectRegistry:
     if args.config is None:
         return SubjectRegistry(
             workspace_root=Path(args.workspace_root),
+            storage_config=storage_config_from_env(),
             data_directory=Path(args.data_dir),
         )
 
@@ -573,7 +575,7 @@ def build_parser() -> argparse.ArgumentParser:
     mcp_subparsers = mcp_parser.add_subparsers(dest="mcp_command", required=True)
     mcp_serve_parser = mcp_subparsers.add_parser("serve")
     mcp_serve_parser.add_argument("--workspace-root", default=".")
-    mcp_serve_parser.add_argument("--data-dir", default="data")
+    mcp_serve_parser.add_argument("--data-dir", default=os.getenv("CELLIN_DATA_DIR", "data"))
     mcp_serve_parser.add_argument("--config")
     mcp_serve_parser.add_argument("--check", action="store_true")
     mcp_serve_parser.set_defaults(handler=cmd_mcp_serve)

--- a/src/cellin/mcp/config.py
+++ b/src/cellin/mcp/config.py
@@ -1,0 +1,61 @@
+"""Environment-backed configuration for packaged MCP deployments."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from typing import Final
+
+from cellin.runtime import StorageBackendConfig, StorageConfig
+
+SUPPORTED_MCP_BACKENDS: Final[frozenset[str]] = frozenset(
+    {"in_memory", "neo4j", "postgres", "postgresql", "sqlite"}
+)
+
+
+def _backend_name(env: Mapping[str, str]) -> str:
+    return env.get("CELLIN_BACKEND", "sqlite").strip().lower()
+
+
+def _connection_string(env: Mapping[str, str], backend: str) -> str:
+    value = env.get("CELLIN_CONNECTION_STRING", "").strip()
+    if not value:
+        raise ValueError(f"CELLIN_CONNECTION_STRING is required for `{backend}` backend.")
+    return value
+
+
+def storage_config_from_env(env: Mapping[str, str] | None = None) -> StorageConfig:
+    """Resolve MCP storage config from CELLIN_* environment variables."""
+
+    active_env = os.environ if env is None else env
+    backend = _backend_name(active_env)
+    vector_backend = StorageBackendConfig("in_memory_vector_index")
+
+    if backend == "sqlite":
+        return StorageConfig.with_sqlite_preset("cellin.sqlite")
+
+    if backend == "in_memory":
+        return StorageConfig.with_in_memory_preset()
+
+    if backend in {"postgres", "postgresql"}:
+        postgresql_backend = StorageBackendConfig(
+            "postgresql",
+            _connection_string(active_env, backend),
+        )
+        return StorageConfig(
+            memory=postgresql_backend,
+            graph=postgresql_backend,
+            vector=vector_backend,
+            representation=vector_backend,
+        )
+
+    if backend == "neo4j":
+        return StorageConfig(
+            memory=StorageBackendConfig("sqlite", "cellin.sqlite"),
+            graph=StorageBackendConfig("neo4j", _connection_string(active_env, backend)),
+            vector=vector_backend,
+            representation=vector_backend,
+        )
+
+    supported = ", ".join(sorted(SUPPORTED_MCP_BACKENDS))
+    raise ValueError(f"Unsupported CELLIN_BACKEND `{backend}`. Supported values: {supported}.")

--- a/src/cellin/mcp/server.py
+++ b/src/cellin/mcp/server.py
@@ -6,10 +6,12 @@ import argparse
 import asyncio
 import importlib
 import json
+import os
 from pathlib import Path
 from typing import Any
 
 from cellin.core.models import JSONValue
+from cellin.mcp.config import storage_config_from_env
 from cellin.mcp.subjects import SubjectRegistry
 from cellin.mcp.tools import CellinMCPTools, dispatch_tool
 
@@ -166,7 +168,7 @@ def startup_check(subject_registry: SubjectRegistry) -> dict[str, JSONValue]:
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run Cellin as an MCP server.")
     parser.add_argument("--workspace-root", default=".")
-    parser.add_argument("--data-dir", default="data")
+    parser.add_argument("--data-dir", default=os.getenv("CELLIN_DATA_DIR", "data"))
     parser.add_argument("--check", action="store_true")
     return parser
 
@@ -175,6 +177,7 @@ def main(argv: list[str] | None = None) -> None:
     args = build_parser().parse_args(argv)
     registry = SubjectRegistry(
         workspace_root=Path(args.workspace_root),
+        storage_config=storage_config_from_env(),
         data_directory=Path(args.data_dir),
     )
     if args.check:

--- a/tests/integration/cli/test_cli_additional.py
+++ b/tests/integration/cli/test_cli_additional.py
@@ -206,3 +206,19 @@ def test_cli_mcp_serve_check_reports_startup_status(
     assert payload["status"] == "ok"
     assert payload["workspace_root"] == str(tmp_path.resolve())
     assert payload["data_directory"] == str((tmp_path / "subjects").resolve())
+
+
+def test_cli_mcp_serve_check_uses_env_data_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    data_dir = tmp_path / "env-data"
+    monkeypatch.setenv("CELLIN_BACKEND", "in_memory")
+    monkeypatch.setenv("CELLIN_DATA_DIR", str(data_dir))
+
+    assert main(["mcp", "serve", "--workspace-root", str(tmp_path), "--check"]) == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "ok"
+    assert payload["data_directory"] == str(data_dir.resolve())

--- a/tests/unit/test_mcp_docker_config.py
+++ b/tests/unit/test_mcp_docker_config.py
@@ -1,0 +1,58 @@
+"""Unit tests for MCP container environment configuration."""
+
+from __future__ import annotations
+
+import pytest
+
+from cellin.mcp.config import storage_config_from_env
+
+
+def test_storage_config_from_env_defaults_to_sqlite() -> None:
+    config = storage_config_from_env({})
+
+    assert config.memory.backend == "sqlite"
+    assert config.graph.backend == "sqlite"
+    assert config.vector.backend == "in_memory_vector_index"
+
+
+def test_storage_config_from_env_supports_in_memory() -> None:
+    config = storage_config_from_env({"CELLIN_BACKEND": "in_memory"})
+
+    assert config.memory.backend == "in_memory"
+    assert config.graph.backend == "in_memory"
+
+
+def test_storage_config_from_env_supports_postgres() -> None:
+    config = storage_config_from_env(
+        {
+            "CELLIN_BACKEND": "postgres",
+            "CELLIN_CONNECTION_STRING": "postgresql://postgres:5432/cellin",
+        }
+    )
+
+    assert config.memory.backend == "postgresql"
+    assert config.graph.backend == "postgresql"
+    assert config.memory.database_path == "postgresql://postgres:5432/cellin"
+
+
+def test_storage_config_from_env_supports_neo4j_with_sqlite_memory() -> None:
+    config = storage_config_from_env(
+        {
+            "CELLIN_BACKEND": "neo4j",
+            "CELLIN_CONNECTION_STRING": "bolt://neo4j:7687",
+        }
+    )
+
+    assert config.memory.backend == "sqlite"
+    assert config.graph.backend == "neo4j"
+    assert config.graph.database_path == "bolt://neo4j:7687"
+
+
+def test_storage_config_from_env_requires_connection_for_remote_backend() -> None:
+    with pytest.raises(ValueError, match="CELLIN_CONNECTION_STRING"):
+        storage_config_from_env({"CELLIN_BACKEND": "postgres"})
+
+
+def test_storage_config_from_env_rejects_unknown_backend() -> None:
+    with pytest.raises(ValueError, match="Unsupported CELLIN_BACKEND"):
+        storage_config_from_env({"CELLIN_BACKEND": "oracle"})


### PR DESCRIPTION
## Summary
- add Dockerfile, compose profiles, and Make targets for running the MCP server in a container
- add environment-backed MCP storage configuration for sqlite, in-memory, PostgreSQL, and Neo4j presets
- document Docker/Claude usage and add CI Docker startup validation

## Validation
- `uv run --python 3.12 pytest -q tests/unit/test_mcp_docker_config.py tests/unit/test_mcp_server_tools.py tests/integration/cli/test_cli_additional.py::test_cli_mcp_serve_check_uses_env_data_dir tests/integration/cli/test_cli_additional.py::test_cli_mcp_serve_check_reports_startup_status`
- `uv run --python 3.12 mypy src/cellin/mcp src/cellin/cli/app.py`
- `uv run --python 3.12 mkdocs build --strict`
- `CELLIN_POSTGRES_PASSWORD=example CELLIN_POSTGRES_DSN=postgresql://postgres:5432/cellin CELLIN_NEO4J_AUTH=none CELLIN_NEO4J_URI=bolt://neo4j:7687 docker compose config`
- `uv run --python 3.12 pytest --cov=src/cellin --cov-report=term-missing --cov-report=json tests && uv run --python 3.12 python scripts/check_coverage.py --coverage-json coverage.json --source-root src/cellin --overall 98 --package 98`

Local `docker build` was not run because the Docker daemon is unavailable in this environment; the PR adds the CI Docker build/startup job.

Closes #176