### PR TITLE
fix: clear Sonar quality issues

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Run release-please
         if: ${{ env.RELEASE_PLEASE_TOKEN != '' && steps.validate_release_token.outcome == 'success' }}
         id: release
-        uses: googleapis/release-please-action@v5
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7
         with:
           token: ${{ env.RELEASE_PLEASE_TOKEN }}
           target-branch: main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,4 +107,4 @@ jobs:
           path: dist
 
       - name: Publish distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -138,4 +138,4 @@ jobs:
           path: dist
 
       - name: Publish prerelease distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b

--- a/Makefile
+++ b/Makefile
@@ -66,15 +66,16 @@ package:
 
 package-smoke: package
 	$(UV) run twine check --strict dist/*
-	tmpdir=$$(mktemp -d); \
-		python3 -m venv "$$tmpdir/venv"; \
-		"$$tmpdir/venv/bin/pip" install --upgrade pip >/dev/null; \
-		"$$tmpdir/venv/bin/pip" install dist/*.whl >/dev/null; \
-		expected_version=$$(python3 scripts/release/verify_version.py --print-version); \
+	set -e; \
+		tmpdir=$$(mktemp -d); \
+		trap 'rm -rf "$$tmpdir"' EXIT; \
+		$(UV) run python -m venv "$$tmpdir/venv"; \
+		"$$tmpdir/venv/bin/python" -m pip install --upgrade pip >/dev/null; \
+		"$$tmpdir/venv/bin/python" -m pip install dist/*.whl >/dev/null; \
+		expected_version=$$($(UV) run python scripts/release/verify_version.py --print-version); \
 		"$$tmpdir/venv/bin/cellin" --version | grep -q "$$expected_version"; \
 		"$$tmpdir/venv/bin/cellin" plugin list | grep -q "in-memory-trace-sink"; \
-		"$$tmpdir/venv/bin/cellin" storage list --role memory | grep -q "role=memory backend=in_memory"; \
-		rm -rf "$$tmpdir"
+		"$$tmpdir/venv/bin/cellin" storage list --role memory | grep -q "role=memory backend=in_memory"
 
 version-check:
 	$(UV) run python scripts/release/verify_version.py $(if $(TAG),--tag $(TAG),) $(if $(EXPECT_VERSION),--expect-version $(EXPECT_VERSION),) --release-kind $(RELEASE_KIND)

--- a/scripts/add_feature_flag.py
+++ b/scripts/add_feature_flag.py
@@ -8,13 +8,14 @@ import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SRC_ROOT = REPO_ROOT / "src"
 if str(SRC_ROOT) not in sys.path:
     sys.path.insert(0, str(SRC_ROOT))
 
-from cellin.features.registry import FeatureFlag, validate_registry  # noqa: E402
+from cellin.features.registry import FeatureFlag, Lifecycle, validate_registry  # noqa: E402
 
 FEATURE_CODE_PATTERN = re.compile(r"^CELN-FEAT-(\d{4})$")
 DEFAULT_REGISTRY_PATH = REPO_ROOT / "src/cellin/features/registry.py"
@@ -58,8 +59,31 @@ def _parse_feature_flag(node: ast.expr) -> FeatureFlag:
         code=_feature_keyword_value(node, "code"),
         name=_feature_keyword_value(node, "name"),
         description=_feature_keyword_value(node, "description"),
-        lifecycle=_feature_keyword_value(node, "lifecycle"),
+        lifecycle=cast(Lifecycle, _feature_keyword_value(node, "lifecycle")),
     )
+
+
+def _assigned_name_value(node: ast.Assign, name: str) -> ast.expr | None:
+    for target in node.targets:
+        if isinstance(target, ast.Name) and target.id == name:
+            return node.value
+    return None
+
+
+def _registry_assignment_value(module: ast.Module) -> ast.expr:
+    for node in module.body:
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "REGISTRY"
+            and node.value is not None
+        ):
+            return node.value
+
+        if isinstance(node, ast.Assign) and (value := _assigned_name_value(node, "REGISTRY")):
+            return value
+
+    raise ValueError("REGISTRY assignment not found.")
 
 
 def load_registry_definition(path: Path = DEFAULT_REGISTRY_PATH) -> RegistryDefinition:
@@ -68,26 +92,7 @@ def load_registry_definition(path: Path = DEFAULT_REGISTRY_PATH) -> RegistryDefi
     source = path.read_text(encoding="utf-8")
     module = ast.parse(source)
 
-    registry_value: ast.expr | None = None
-    for node in module.body:
-        if (
-            isinstance(node, ast.AnnAssign)
-            and isinstance(node.target, ast.Name)
-            and node.target.id == "REGISTRY"
-            and node.value is not None
-        ):
-            registry_value = node.value
-            break
-        if isinstance(node, ast.Assign):
-            for target in node.targets:
-                if isinstance(target, ast.Name) and target.id == "REGISTRY":
-                    registry_value = node.value
-                    break
-            if registry_value is not None:
-                break
-
-    if registry_value is None:
-        raise ValueError("REGISTRY assignment not found.")
+    registry_value = _registry_assignment_value(module)
     if not isinstance(registry_value, ast.Tuple):
         raise ValueError("REGISTRY must be defined as a tuple literal.")
     if registry_value.end_lineno is None or registry_value.end_col_offset is None:

--- a/scripts/generate_feature_report.py
+++ b/scripts/generate_feature_report.py
@@ -117,21 +117,28 @@ def list_stable_tags(repo_root: Path) -> list[str]:
     return [tag for tag in tags if _STABLE_TAG_PATTERN.match(tag)]
 
 
+def _assigned_name_value(node: ast.Assign, name: str) -> ast.expr | None:
+    for target in node.targets:
+        if isinstance(target, ast.Name) and target.id == name:
+            return node.value
+    return None
+
+
+def _registry_assignment_value(node: ast.stmt) -> ast.expr | None:
+    if (
+        isinstance(node, ast.AnnAssign)
+        and isinstance(node.target, ast.Name)
+        and node.target.id == "REGISTRY"
+    ):
+        return node.value
+    if isinstance(node, ast.Assign):
+        return _assigned_name_value(node, "REGISTRY")
+    return None
+
+
 def _find_registry_tuple(module: ast.Module) -> ast.Tuple:
     for node in module.body:
-        value: ast.expr | None = None
-        if (
-            isinstance(node, ast.AnnAssign)
-            and isinstance(node.target, ast.Name)
-            and node.target.id == "REGISTRY"
-        ):
-            value = node.value
-        elif isinstance(node, ast.Assign):
-            for target in node.targets:
-                if isinstance(target, ast.Name) and target.id == "REGISTRY":
-                    value = node.value
-                    break
-
+        value = _registry_assignment_value(node)
         if value is None:
             continue
         if not isinstance(value, ast.Tuple):

--- a/src/cellin/cli/app.py
+++ b/src/cellin/cli/app.py
@@ -435,12 +435,7 @@ def cmd_trace_inspect(args: argparse.Namespace, _feature_context: FeatureContext
     return TRACE_INSPECT_SUCCESS_EXIT_CODE
 
 
-def cmd_features_list(args: argparse.Namespace, feature_context: FeatureContext) -> int:
-    rows = _feature_manifest_defaults(feature_context.channel)
-    if args.format == "json":
-        print(json.dumps(rows, indent=2, sort_keys=True))
-        return 0
-
+def _print_feature_table(rows: list[dict[str, object]]) -> None:
     code_width = max((len(str(row["code"])) for row in rows), default=4)
     name_width = max((len(str(row["name"])) for row in rows), default=4)
     lifecycle_width = max((len(str(row["lifecycle"])) for row in rows), default=9)
@@ -467,7 +462,14 @@ def cmd_features_list(args: argparse.Namespace, feature_context: FeatureContext)
             f"{row['lifecycle']:<{lifecycle_width}} "
             f"{default_value:<{default_width}}"
         )
-    return 0
+
+
+def cmd_features_list(args: argparse.Namespace, feature_context: FeatureContext) -> None:
+    rows = _feature_manifest_defaults(feature_context.channel)
+    if args.format == "json":
+        print(json.dumps(rows, indent=2, sort_keys=True))
+    else:
+        _print_feature_table(rows)
 
 
 def _mcp_subject_registry(args: argparse.Namespace) -> SubjectRegistry:

--- a/src/cellin/core/contracts.py
+++ b/src/cellin/core/contracts.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
-from typing import Protocol
+from typing import ClassVar, Protocol
 
 from cellin.core.models import (
     Artifact,
@@ -80,7 +80,7 @@ class PluginContext:
 class Plugin(Protocol):
     """Lifecycle hooks required for every Cellin plugin."""
 
-    manifest: PluginManifest
+    manifest: ClassVar[PluginManifest]
 
     def configure(self, context: PluginContext) -> None:
         """Configure the plugin with runtime state."""

--- a/src/cellin/dreaming/service.py
+++ b/src/cellin/dreaming/service.py
@@ -7,8 +7,8 @@ from dataclasses import replace
 from datetime import UTC, datetime
 from typing import Protocol
 
-from cellin.core import GraphStore, MemoryStore, VectorStore
-from cellin.dreaming.models import DreamDiff, DreamRunResult
+from cellin.core import GraphStore, MemoryAtom, MemoryEdge, MemoryStore, VectorStore
+from cellin.dreaming.models import DreamDiff, DreamEdgeChange, DreamMemoryChange, DreamRunResult
 from cellin.dreaming.scheduler import DeterministicDreamScheduler
 from cellin.dreaming.strategies import (
     AbstractionDreamStrategy,
@@ -81,40 +81,46 @@ class DreamRunner:
                 results.append(result)
         return tuple(results)
 
+    def _archive_edge(self, edge: MemoryEdge) -> None:
+        self.graph_store.upsert_edge(
+            replace(
+                edge,
+                metadata={**edge.metadata, "archived": True},
+            )
+        )
+
+    def _rollback_edge_change(self, edge_change: DreamEdgeChange) -> None:
+        if edge_change.before is None and edge_change.after is not None:
+            self._archive_edge(edge_change.after)
+        elif edge_change.before is not None:
+            self.graph_store.upsert_edge(edge_change.before)
+
+    def _archive_memory(self, memory: MemoryAtom) -> None:
+        archived = replace(
+            memory,
+            decay=replace(memory.decay, archived=True),
+        )
+        self.memory_store.put(archived)
+        self.graph_store.upsert_memory(archived)
+
+    def _restore_vector_if_needed(self, restored: MemoryAtom, after: MemoryAtom | None) -> None:
+        if self.vector_store is None or not hasattr(self.vector_store, "delete"):
+            return
+        if after is not None and after.decay.archived and not restored.decay.archived:
+            self.vector_store.upsert(restored.memory_id, restored.text)
+
+    def _rollback_memory_change(self, memory_change: DreamMemoryChange) -> None:
+        if memory_change.before is None and memory_change.after is not None:
+            self._archive_memory(memory_change.after)
+        elif memory_change.before is not None:
+            restored = memory_change.before
+            self.memory_store.put(restored)
+            self.graph_store.upsert_memory(restored)
+            self._restore_vector_if_needed(restored, memory_change.after)
+
     def rollback(self, diff: DreamDiff) -> None:
         for edge_change in reversed(diff.edge_changes):
-            if edge_change.before is None and edge_change.after is not None:
-                self.graph_store.upsert_edge(
-                    replace(
-                        edge_change.after,
-                        metadata={**edge_change.after.metadata, "archived": True},
-                    )
-                )
-                continue
-
-            if edge_change.before is not None:
-                self.graph_store.upsert_edge(edge_change.before)
+            self._rollback_edge_change(edge_change)
 
         for memory_change in reversed(diff.memory_changes):
-            if memory_change.before is None and memory_change.after is not None:
-                archived = replace(
-                    memory_change.after,
-                    decay=replace(memory_change.after.decay, archived=True),
-                )
-                self.memory_store.put(archived)
-                self.graph_store.upsert_memory(archived)
-                continue
-
-            if memory_change.before is not None:
-                restored = memory_change.before
-                self.memory_store.put(restored)
-                self.graph_store.upsert_memory(restored)
-                after = memory_change.after
-                if (
-                    self.vector_store is not None
-                    and hasattr(self.vector_store, "delete")
-                    and after is not None
-                    and after.decay.archived
-                    and not restored.decay.archived
-                ):
-                    self.vector_store.upsert(restored.memory_id, restored.text)
+            self._rollback_memory_change(memory_change)

--- a/src/cellin/evals/runner.py
+++ b/src/cellin/evals/runner.py
@@ -336,36 +336,35 @@ def _run_performance_case() -> EvaluationCaseResult:
 def _suite_cases(
     suite: str, *, storage_config: StorageConfig | None = None
 ) -> tuple[EvaluationCaseResult, ...]:
-    if suite == "smoke":
-        return (
-            _run_ingest_case(storage_config),
-            _run_retrieval_case(
-                benchmark_index=0,
-                corpus_name="project_memory",
-                case_id="retrieval-project",
-            ),
-            _run_dream_case(),
-        )
+    cases = [
+        _run_ingest_case(storage_config),
+        _run_retrieval_case(
+            benchmark_index=0,
+            corpus_name="project_memory",
+            case_id="retrieval-project",
+        ),
+        _run_dream_case(),
+    ]
 
     if suite == "full":
-        return (
-            _run_ingest_case(storage_config),
-            _run_retrieval_case(
-                benchmark_index=0,
-                corpus_name="project_memory",
-                case_id="retrieval-project",
-            ),
+        cases.insert(
+            2,
             _run_retrieval_case(
                 benchmark_index=1,
                 corpus_name="recency_trap",
                 case_id="retrieval-recency",
             ),
-            _run_dream_case(),
-            _run_contradiction_case(),
-            _run_performance_case(),
         )
+        cases.extend(
+            [
+                _run_contradiction_case(),
+                _run_performance_case(),
+            ]
+        )
+    elif suite != "smoke":
+        raise ValueError(f"Unknown eval suite: {suite}")
 
-    raise ValueError(f"Unknown eval suite: {suite}")
+    return tuple(cases)
 
 
 def write_report(report: EvaluationReport, output_path: Path) -> None:

--- a/src/cellin/features/resolver.py
+++ b/src/cellin/features/resolver.py
@@ -23,26 +23,20 @@ class ReleaseLockDocument(TypedDict):
     notes: dict[str, str]
 
 
-def resolve_features(
-    registry: tuple[FeatureFlag, ...],
-    channel: ReleaseChannel,
-    lock: Mapping[str, bool] | None,
-    enable: Iterable[str],
-    disable: Iterable[str],
-) -> dict[str, bool]:
-    """Resolve feature states for a release channel."""
-
-    validate_registry(registry)
-
-    features_by_code = {feature.code: feature for feature in registry}
+def _feature_name_index(registry: tuple[FeatureFlag, ...]) -> dict[str, list[str]]:
     names_to_codes: dict[str, list[str]] = {}
     for feature in registry:
         names_to_codes.setdefault(feature.name, []).append(feature.code)
+    return names_to_codes
 
-    enabled_names = set(enable)
-    disabled_names = set(disable)
-    known_names = set(names_to_codes)
-    unknown_names = sorted((enabled_names | disabled_names) - known_names)
+
+def _validate_feature_name_overrides(
+    names_to_codes: Mapping[str, list[str]],
+    enabled_names: set[str],
+    disabled_names: set[str],
+) -> None:
+    requested_names = enabled_names | disabled_names
+    unknown_names = sorted(requested_names - set(names_to_codes))
     if unknown_names:
         raise ValueError(f"Unknown feature names: {', '.join(unknown_names)}")
 
@@ -52,15 +46,17 @@ def resolve_features(
             f"Feature names cannot be both enabled and disabled: {', '.join(conflicts)}"
         )
 
-    ambiguous_names = sorted(
-        name for name in (enabled_names | disabled_names) if len(names_to_codes[name]) > 1
-    )
+    ambiguous_names = sorted(name for name in requested_names if len(names_to_codes[name]) > 1)
     if ambiguous_names:
         raise ValueError(f"Feature names are ambiguous: {', '.join(ambiguous_names)}")
 
+
+def _normalize_release_lock(
+    lock: Mapping[str, bool] | None,
+    features_by_code: Mapping[str, FeatureFlag],
+) -> dict[str, bool]:
     normalized_lock = dict(lock or {})
-    known_codes = set(features_by_code)
-    unknown_codes = sorted(set(normalized_lock) - known_codes)
+    unknown_codes = sorted(set(normalized_lock) - set(features_by_code))
     if unknown_codes:
         raise ValueError(f"Unknown feature lock codes: {', '.join(unknown_codes)}")
 
@@ -73,14 +69,39 @@ def resolve_features(
         raise ValueError(
             f"Release lock can only enable preview features: {', '.join(non_preview_codes)}"
         )
+    return normalized_lock
 
+
+def _default_feature_states(
+    registry: tuple[FeatureFlag, ...],
+    channel: ReleaseChannel,
+) -> dict[str, bool]:
     if channel == "rolling":
-        resolved = {feature.code: True for feature in registry}
-    elif channel in {"release", "dev"}:
-        resolved = {feature.code: feature.lifecycle in _STABLE_LIFECYCLES for feature in registry}
-    else:
-        raise ValueError(f"Unknown release channel `{channel}`.")
+        return {feature.code: True for feature in registry}
+    if channel in {"release", "dev"}:
+        return {feature.code: feature.lifecycle in _STABLE_LIFECYCLES for feature in registry}
+    raise ValueError(f"Unknown release channel `{channel}`.")
 
+
+def resolve_features(
+    registry: tuple[FeatureFlag, ...],
+    channel: ReleaseChannel,
+    lock: Mapping[str, bool] | None,
+    enable: Iterable[str],
+    disable: Iterable[str],
+) -> dict[str, bool]:
+    """Resolve feature states for a release channel."""
+
+    validate_registry(registry)
+
+    features_by_code = {feature.code: feature for feature in registry}
+    names_to_codes = _feature_name_index(registry)
+    enabled_names = set(enable)
+    disabled_names = set(disable)
+    _validate_feature_name_overrides(names_to_codes, enabled_names, disabled_names)
+
+    normalized_lock = _normalize_release_lock(lock, features_by_code)
+    resolved = _default_feature_states(registry, channel)
     if channel != "rolling":
         for code, enabled in normalized_lock.items():
             if enabled:
@@ -95,15 +116,7 @@ def resolve_features(
     return resolved
 
 
-def parse_release_lock_document(
-    raw: object,
-    registry: tuple[FeatureFlag, ...] | None = None,
-) -> ReleaseLockDocument:
-    """Validate the raw release lock payload against the feature registry."""
-
-    active_registry = REGISTRY if registry is None else registry
-    validate_registry(active_registry)
-
+def _release_lock_object(raw: object) -> dict[str, object]:
     if not isinstance(raw, dict):
         raise ValueError("Release lock must be a JSON object.")
 
@@ -114,37 +127,43 @@ def parse_release_lock_document(
     missing_keys = sorted(_RELEASE_LOCK_KEYS - set(raw))
     if missing_keys:
         raise ValueError(f"Release lock is missing keys: {', '.join(missing_keys)}")
+    return raw
 
-    release = raw["release"]
-    if release is not None and not isinstance(release, str):
-        raise ValueError("Release lock `release` must be a string or null.")
 
-    default_on = raw["defaultOn"]
-    if not isinstance(default_on, list):
+def _release_lock_codes(raw: object) -> list[str]:
+    if not isinstance(raw, list):
         raise ValueError("Release lock must define a `defaultOn` list.")
 
     codes: list[str] = []
-    for entry in default_on:
+    for entry in raw:
         if not isinstance(entry, str) or not entry:
             raise ValueError("Release lock feature codes must be non-empty strings.")
         codes.append(entry)
 
     if len(codes) != len(set(codes)):
         raise ValueError("Release lock contains duplicate feature codes.")
+    return codes
 
-    notes_raw = raw["notes"]
-    if not isinstance(notes_raw, dict):
+
+def _release_lock_notes(raw: object) -> dict[str, str]:
+    if not isinstance(raw, dict):
         raise ValueError("Release lock `notes` must be a JSON object.")
 
     notes: dict[str, str] = {}
-    for code, note in notes_raw.items():
+    for code, note in raw.items():
         if not isinstance(code, str) or not code:
             raise ValueError("Release lock note keys must be non-empty strings.")
         if not isinstance(note, str):
             raise ValueError("Release lock note values must be strings.")
         notes[code] = note
+    return notes
 
-    features_by_code = {feature.code: feature for feature in active_registry}
+
+def _validate_release_lock_feature_codes(
+    codes: list[str],
+    notes: Mapping[str, str],
+    features_by_code: Mapping[str, FeatureFlag],
+) -> None:
     unknown_codes = sorted(set(codes) - set(features_by_code))
     unknown_note_codes = sorted(set(notes) - set(features_by_code))
     unknown_codes.extend(code for code in unknown_note_codes if code not in unknown_codes)
@@ -158,6 +177,26 @@ def parse_release_lock_document(
         raise ValueError(
             f"Release lock can only enable preview features: {', '.join(non_preview_codes)}"
         )
+
+
+def parse_release_lock_document(
+    raw: object,
+    registry: tuple[FeatureFlag, ...] | None = None,
+) -> ReleaseLockDocument:
+    """Validate the raw release lock payload against the feature registry."""
+
+    active_registry = REGISTRY if registry is None else registry
+    validate_registry(active_registry)
+    release_lock = _release_lock_object(raw)
+
+    release = release_lock["release"]
+    if release is not None and not isinstance(release, str):
+        raise ValueError("Release lock `release` must be a string or null.")
+
+    codes = _release_lock_codes(release_lock["defaultOn"])
+    notes = _release_lock_notes(release_lock["notes"])
+    features_by_code = {feature.code: feature for feature in active_registry}
+    _validate_release_lock_feature_codes(codes, notes, features_by_code)
 
     return {
         "release": release,
@@ -177,4 +216,4 @@ def load_release_lock(path: str | Path) -> dict[str, bool]:
     """Load the release lock as an effective code-to-enabled mapping."""
 
     document = read_release_lock_document(path)
-    return {code: True for code in document["defaultOn"]}
+    return dict.fromkeys(document["defaultOn"], True)

--- a/src/cellin/runtime/builtins.py
+++ b/src/cellin/runtime/builtins.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from typing import ClassVar
 
 from cellin.__about__ import __version__
 from cellin.core.contracts import Capability, PluginContext, PluginManifest
@@ -14,17 +15,17 @@ from cellin.core.models import JSONValue, TraceEvent
 class InMemoryTraceSinkPlugin:
     """A minimal built-in plugin used to exercise runtime registration."""
 
-    events: list[TraceEvent] = field(default_factory=list)
-    context: PluginContext | None = None
-    started: bool = False
-
-    manifest = PluginManifest(
+    manifest: ClassVar[PluginManifest] = PluginManifest(
         plugin_id="in-memory-trace-sink",
         version=__version__,
         capabilities=(Capability.TRACE_SINK,),
         display_name="In-memory trace sink",
         description="Stores trace events in memory for tests and local development.",
     )
+
+    events: list[TraceEvent] = field(default_factory=list)
+    context: PluginContext | None = None
+    started: bool = False
 
     def configure(self, context: PluginContext) -> None:
         self.context = context
@@ -48,16 +49,16 @@ class InMemoryTraceSinkPlugin:
 class WeightedRankerPlugin:
     """Built-in plugin that exposes WeightedRanker as a RANKER capability."""
 
-    _settings: Mapping[str, JSONValue] = field(default_factory=dict)
-    _ranker: object = field(default=None, init=False, repr=False)
-
-    manifest = PluginManifest(
+    manifest: ClassVar[PluginManifest] = PluginManifest(
         plugin_id="weighted-ranker",
         version=__version__,
         capabilities=(Capability.RANKER,),
         display_name="Weighted ranker",
         description="Deterministic explainable weighted ranking over memory atoms.",
     )
+
+    _settings: Mapping[str, JSONValue] = field(default_factory=dict)
+    _ranker: object = field(default=None, init=False, repr=False)
 
     def configure(self, context: PluginContext) -> None:
         self._settings = context.plugin_settings
@@ -70,7 +71,7 @@ class WeightedRankerPlugin:
         self._ranker = WeightedRanker(profile=get_weight_profile(str(profile_name)))
 
     def stop(self) -> None:
-        pass
+        self._ranker = None
 
     @property
     def ranker(self) -> object:
@@ -82,16 +83,16 @@ class WeightedRankerPlugin:
 class WeightedRetrieverPlugin:
     """Built-in plugin that exposes WeightedRetriever as a RETRIEVER capability."""
 
-    _settings: Mapping[str, JSONValue] = field(default_factory=dict)
-    _retriever: object = field(default=None, init=False, repr=False)
-
-    manifest = PluginManifest(
+    manifest: ClassVar[PluginManifest] = PluginManifest(
         plugin_id="weighted-retriever",
         version=__version__,
         capabilities=(Capability.RETRIEVER,),
         display_name="Weighted retriever",
         description="Assembles explainable memory bundles from candidate memory atoms.",
     )
+
+    _settings: Mapping[str, JSONValue] = field(default_factory=dict)
+    _retriever: object = field(default=None, init=False, repr=False)
 
     def configure(self, context: PluginContext) -> None:
         self._settings = context.plugin_settings
@@ -115,7 +116,7 @@ class WeightedRetrieverPlugin:
         )
 
     def stop(self) -> None:
-        pass
+        self._retriever = None
 
     @property
     def retriever(self) -> object:

--- a/src/cellin/runtime/registry.py
+++ b/src/cellin/runtime/registry.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterator
 from importlib import metadata
 from typing import cast
 
@@ -117,7 +117,7 @@ class PluginRegistry:
 
         return tuple(self._plugins.keys())
 
-    def __iter__(self) -> Iterable[Plugin]:
+    def __iter__(self) -> Iterator[Plugin]:
         """Iterate registered plugins in registration order."""
 
         return iter(self._plugins.values())

--- a/src/cellin/stores/graph_backends.py
+++ b/src/cellin/stores/graph_backends.py
@@ -260,42 +260,54 @@ class _ArangoGraphBackend:
         if not self._database.has_collection("cellin_edges"):
             self._database.create_collection("cellin_edges", edge=True)
 
+    def _find_edge_documents_with_finder(
+        self,
+        finder: object,
+        filters: dict[str, object] | None,
+    ) -> list[dict[str, object]] | None:
+        if not callable(finder):
+            return None
+
+        try:
+            return list(finder()) if filters is None else list(finder(filters))
+        except TypeError:
+            return self._find_edge_documents_with_keyword_filters(finder, filters)
+        except Exception:
+            return None
+
+    def _find_edge_documents_with_keyword_filters(
+        self,
+        finder: object,
+        filters: dict[str, object] | None,
+    ) -> list[dict[str, object]] | None:
+        if filters is None or not callable(finder):
+            return None
+        try:
+            return list(finder(filters=filters))
+        except Exception:
+            return None
+
+    @staticmethod
+    def _document_matches(
+        document: dict[str, object],
+        filters: dict[str, object],
+    ) -> bool:
+        return all(document.get(name) == value for name, value in filters.items())
+
     def _find_edge_documents(
         self, filters: dict[str, object] | None = None
     ) -> list[dict[str, object]]:
-        finder = getattr(self._edge_collection, "find", None)
-        if callable(finder):
-
-            def _find_documents() -> list[dict[str, object]] | None:
-                try:
-                    if filters is None:
-                        return list(finder())
-                    return list(finder(filters))
-                except TypeError:
-                    if filters is None:
-                        return None
-                    try:
-                        return list(finder(filters=filters))
-                    except Exception:
-                        return None
-                except Exception:
-                    return None
-
-            documents = _find_documents()
-            if documents is not None:
-                return documents
+        documents = self._find_edge_documents_with_finder(
+            getattr(self._edge_collection, "find", None),
+            filters,
+        )
+        if documents is not None:
+            return documents
 
         edges = self._edge_collection.all()
         if not filters:
             return [dict(document) for document in edges]
-
-        def matches(document: dict[str, object], filters: dict[str, object]) -> bool:
-            for name, value in filters.items():
-                if document.get(name) != value:
-                    return False
-            return True
-
-        return [dict(document) for document in edges if matches(document, filters)]
+        return [dict(document) for document in edges if self._document_matches(document, filters)]
 
     def _ensure_memory_placeholder(self, memory_id: str) -> None:
         key = _arangodb_key(memory_id)

--- a/tests/contracts/test_runtime_additional.py
+++ b/tests/contracts/test_runtime_additional.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from typing import ClassVar
 
 import pytest
 
@@ -47,7 +48,7 @@ class MissingManifestPlugin:
 
 @dataclass
 class MissingStopPlugin:
-    manifest = PluginManifest(
+    manifest: ClassVar[PluginManifest] = PluginManifest(
         plugin_id="missing-stop",
         version="1.0.0",
         capabilities=(Capability.TRACE_SINK,),

--- a/tests/unit/test_redis_backend_unit.py
+++ b/tests/unit/test_redis_backend_unit.py
@@ -105,7 +105,7 @@ def test_neighbors_returns_correct_edges_without_scan() -> None:
 
     result = backend.neighbors("memory-x")
 
-    assert set(e.edge_id for e in result) == {"edge-src", "edge-tgt"}
+    assert {e.edge_id for e in result} == {"edge-src", "edge-tgt"}
 
     # SCAN must NOT have been called during neighbors()
     scan_calls = [c for c in fake.calls if c[0] == "scan_iter"]


### PR DESCRIPTION
## Summary
- split Sonar-reported complex functions into focused helpers across feature resolution, evals, dreaming rollback, graph backends, and registry scripts
- annotate plugin manifests as class variables and keep plugin stop hooks state-clean
- pin GitHub Actions used by release workflows and tighten package-smoke so release-smoke fails on real package smoke errors

## Validation
- `uv run --python 3.14 ruff format --check .`
- `uv run --python 3.14 ruff check .`
- `uv run --python 3.14 mypy src scripts`
- `uv run --python 3.14 pytest --cov=src/cellin --cov-report=term-missing --cov-report=json tests`
- `uv run --python 3.14 python scripts/check_coverage.py --coverage-json coverage.json --source-root src/cellin --overall 98 --package 98`
- `CELLIN_RELEASE_CHANNEL=rolling make UV=uv release-smoke`