### PR TITLE
fix: guard GitHub release token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,9 +78,23 @@ jobs:
           name: release-bundle-${{ github.ref_name }}
           path: dist
 
-      - name: Publish GitHub release
+      - name: Validate GitHub release token
+        id: validate_github_release_token
+        continue-on-error: true
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+        run: gh api "repos/${REPO}/releases?per_page=1" >/dev/null
+
+      - name: Report unavailable GitHub release token
+        if: ${{ steps.validate_github_release_token.outcome != 'success' }}
+        run: |
+          echo "::warning::GitHub rejected the release token. Skipping GitHub release publication until the token is refreshed."
+
+      - name: Publish GitHub release
+        if: ${{ steps.validate_github_release_token.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
         shell: bash

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -108,9 +108,23 @@ jobs:
           name: rolling-release-v${{ needs.build-prerelease.outputs.package_version }}
           path: dist
 
-      - name: Publish rolling prerelease
+      - name: Validate GitHub release token
+        id: validate_github_release_token
+        continue-on-error: true
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
+          REPO: ${{ github.repository }}
+        run: gh api "repos/${REPO}/releases?per_page=1" >/dev/null
+
+      - name: Report unavailable GitHub release token
+        if: ${{ steps.validate_github_release_token.outcome != 'success' }}
+        run: |
+          echo "::warning::GitHub rejected the release token. Skipping rolling GitHub prerelease publication until the token is refreshed."
+
+      - name: Publish rolling prerelease
+        if: ${{ steps.validate_github_release_token.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           REPO: ${{ github.repository }}
           TAG: v${{ needs.build-prerelease.outputs.package_version }}
           TARGET_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.target_ref || github.sha }}


### PR DESCRIPTION
## Summary
- validate the token used by GitHub release publication jobs before calling `gh release`
- prefer the configured release token when present, falling back to `github.token`
- skip GitHub release publication with a workflow warning when the token is rejected instead of failing `main`

## Validation
- `uv run --python 3.14 python` YAML parse check for `.github/workflows/release.yml` and `.github/workflows/rolling-release.yml`
- `git diff --check`