### PR TITLE
fix: skip stable release for dev tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   build-release:
+    if: ${{ !contains(github.ref_name, '.dev') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- skip the stable release workflow jobs for rolling `.dev` tags
- prevent rolling prerelease tags like `v0.5.0.dev...` from failing stable release validation

## Validation
- `uv run --python 3.14 python` YAML parse check for `.github/workflows/release.yml`
- `git diff --check`