### PR TITLE
fix: tolerate GitHub release auth rejection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,10 +100,28 @@ jobs:
           TAG: ${{ github.ref_name }}
         shell: bash
         run: |
+          release_error="$(mktemp)"
+          run_release_command() {
+            if "$@" 2>"${release_error}"; then
+              return 0
+            else
+              status=$?
+            fi
+
+            if grep -q "HTTP 401: Requires authentication" "${release_error}"; then
+              cat "${release_error}" >&2
+              echo "::warning::GitHub rejected the release token while publishing ${TAG}. Skipping GitHub release publication until the token is refreshed."
+              return 0
+            fi
+
+            cat "${release_error}" >&2
+            return "${status}"
+          }
+
           if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
-            gh release upload "$TAG" dist/* --repo "$REPO" --clobber
+            run_release_command gh release upload "$TAG" dist/* --repo "$REPO" --clobber
           else
-            gh release create "$TAG" dist/* --repo "$REPO" --title "$TAG" --generate-notes
+            run_release_command gh release create "$TAG" dist/* --repo "$REPO" --title "$TAG" --generate-notes
           fi
 
   publish-pypi:

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -130,10 +130,28 @@ jobs:
           TARGET_REF: ${{ github.event_name == 'workflow_dispatch' && inputs.target_ref || github.sha }}
         shell: bash
         run: |
+          release_error="$(mktemp)"
+          run_release_command() {
+            if "$@" 2>"${release_error}"; then
+              return 0
+            else
+              status=$?
+            fi
+
+            if grep -q "HTTP 401: Requires authentication" "${release_error}"; then
+              cat "${release_error}" >&2
+              echo "::warning::GitHub rejected the release token while publishing ${TAG}. Skipping rolling GitHub prerelease publication until the token is refreshed."
+              return 0
+            fi
+
+            cat "${release_error}" >&2
+            return "${status}"
+          }
+
           if gh release view "$TAG" --repo "$REPO" >/dev/null 2>&1; then
-            gh release upload "$TAG" dist/* --repo "$REPO" --clobber
+            run_release_command gh release upload "$TAG" dist/* --repo "$REPO" --clobber
           else
-            gh release create "$TAG" dist/* --repo "$REPO" --title "$TAG" --generate-notes --target "$TARGET_REF" --prerelease
+            run_release_command gh release create "$TAG" dist/* --repo "$REPO" --title "$TAG" --generate-notes --target "$TARGET_REF" --prerelease
           fi
 
   publish-pypi-prerelease:


### PR DESCRIPTION
## Summary
- keep GitHub release publication failing for real release errors
- downgrade only `HTTP 401: Requires authentication` from `gh release create/upload` to a workflow warning
- apply the behavior to both stable and rolling GitHub release publication jobs

## Validation
- `uv run --python 3.14 python` YAML parse check for release workflows
- `git diff --check`
- local bash simulation for 401 and non-401 helper paths